### PR TITLE
Allow ISBN to have no pages, as they should, to prevent a report ment…

### DIFF
--- a/src/xml_processing/parse_dqm_json_reference.py
+++ b/src/xml_processing/parse_dqm_json_reference.py
@@ -459,7 +459,7 @@ def aggregate_dqm_with_pubmed(input_path, input_mod):      # noqa: C901
     # does checks on dqm crossReferences.  if primaryId is not PMID, and a crossReference is PubMed,
     # assigns PMID to primaryId and to authors's referenceId.
     # if any reference's author doesn't have author Rank, assign authorRank based on array order.
-    cross_ref_no_pages_ok_fields = ['DOI', 'PMID', 'PMC', 'PMCID']
+    cross_ref_no_pages_ok_fields = ['DOI', 'PMID', 'PMC', 'PMCID', 'ISBN']
     pmid_fields = ['authors', 'volume', 'title', 'pages', 'issueName', 'issueDate', 'datePublished', 'dateArrivedInPubmed', 'dateLastModified', 'abstract', 'pubMedType', 'publisher', 'meshTerms', 'plainLanguageAbstract', 'pubmedAbstractLanguages', 'publicationStatus']
     # single_value_fields = ['volume', 'title', 'pages', 'issueName', 'issueDate', 'datePublished', 'dateArrivedInPubmed', 'dateLastModified', 'abstract', 'pubMedType', 'publisher']
     single_value_fields = ['volume', 'title', 'pages', 'issueName', 'issueDate', 'datePublished', 'dateArrivedInPubmed', 'dateLastModified', 'abstract', 'publisher', 'plainLanguageAbstract', 'pubmedAbstractLanguages', 'publicationStatus']


### PR DESCRIPTION
…ioning that

Sorry @gildossantos I didn't catch that having ISBNs was generating an entry in the report files because they don't have a "pages" attribute.  They shouldn't according to the https://github.com/alliance-genome/agr_schemas/blob/master/resourceDescriptors.yaml and this update should prevent the message in future FB_main reports.