### PR TITLE
adding github action to run flake8

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,0 +1,21 @@
+name: flake8
+on: [push]
+jobs:
+  run-make:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-python@v2
+        name: setup python
+        with:
+          python-version: 3.9
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/app/requirements.txt
+          pip install -r backend/app/requirements.dev.txt
+      - name: run flake8
+        run: make run-local-flake8
+        continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ build-app:
 run-flake8:
 	docker run --rm -v ${PWD}:/workdir -i ${REG}/agr_literature_dev:${TAG} /bin/bash -c "python3 -m flake8 ."
 
+run-local-flake8:
+	python3 -m flake8 .
+
 run-mypy:
 	docker run --rm -v ${PWD}:/workdir -i ${REG}/agr_literature_dev:${TAG} /bin/bash -c "mypy --config-file mypy.config ."
 


### PR DESCRIPTION
This adds a "local" non docker flake8 target to makefile. This should be okay since we're just looking at the source/static analysis and not connecting it to any actual outside world. This will make it easier to put into a GH action.

This action is marked `continue-on-error`, so that failing flake8 doesn't stop a merge, ie it's optional. I think that's something we discussed?

