### PR TITLE
fix(pgsync): pgsync schema file moved outside docker image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -83,6 +83,8 @@ services:
       dockerfile: docker/Dockerfile.pgsync.env
     networks:
       - agr-literature
+    volumes:
+      - "./pgsync_schema.json:/src/app/pgsync_schema.json"
     depends_on:
       - initdb
       - elasticsearch

--- a/docker/Dockerfile.pgsync.env
+++ b/docker/Dockerfile.pgsync.env
@@ -2,7 +2,6 @@ FROM python:3.9-slim
 WORKDIR /src/app
 RUN apt-get update
 RUN apt-get install -y libpq-dev gcc && pip install psycopg2-binary && pip install pgsync
-COPY pgsync_schema.json pgsync_schema.json
 COPY backend/app/initialize.py initialize.py
 COPY .env /usr/local/lib
 COPY pgsync_start.sh pgsync_start.sh


### PR DESCRIPTION
- keeping the schema file in a volume and not within the docker image makes it easier to modify the index and restart pgsync without rebuilding the pgsync image