### PR TITLE
Pgsync schema with child nodes and wildcard field for cross ref curie

### DIFF
--- a/pgsync_schema.json
+++ b/pgsync_schema.json
@@ -5,8 +5,40 @@
         "nodes": {
             "table": "references",
             "columns": [
-                "title"
-            ]
+                "curie", "title", "resource_id", "volume", "date_published", "pages", "abstract", "citation", "keywords", "publisher"
+                , "pubmed_type", "issue_name", "issue_date"
+            ],
+            "children":[
+                {
+                    "table": "authors",
+                    "columns": [
+                        "orcid", "first_author", "corresponding_author", "affiliation", "first_name", "middle_names", "last_name"
+                    ],
+                    "relationship": {
+                        "variant": "object",
+                        "type": "one_to_many",
+                        "foreign_key": {
+                            "child": ["reference_id"],
+                            "parent": ["reference_id"]
+                        }
+                    }
+                },
+                {
+                    "table": "resources",
+                    "columns":[
+                       "title", "title_synonyms", "iso_abbreviation", "medline_abbreviation", "publisher", "volumes"
+                       ,"abstract", "summary"
+                    ],
+                    "relationship":{
+                        "variant": "object",
+                        "type": "one_to_many",
+                        "foreign_key":{
+                            "child": ["resource_id"],
+                            "parent": ["resource_id"]
+                        }
+                    }
+                }
+            ] 
         }
     }
 ]

--- a/pgsync_schema.json
+++ b/pgsync_schema.json
@@ -37,6 +37,20 @@
                             "parent": ["resource_id"]
                         }
                     }
+                },
+                {
+                    "table": "cross_references",
+                    "columns":[
+                       "curie", "is_obsolete"
+                    ],
+                    "relationship":{
+                        "variant": "object",
+                        "type": "one_to_many",
+                        "foreign_key":{
+                            "child": ["reference_id"],
+                            "parent": ["reference_id"]
+                        }
+                    }
                 }
             ] 
         }

--- a/pgsync_schema.json
+++ b/pgsync_schema.json
@@ -50,6 +50,13 @@
                             "child": ["reference_id"],
                             "parent": ["reference_id"]
                         }
+                    },
+                    "transform": {
+                        "mapping": {
+                            "curie": {
+                                "type": "wildcard"
+                            }
+                        }
                     }
                 }
             ] 


### PR DESCRIPTION
This PR adds authors, resources and cross_references to the index by defining relationships in the pgsync schema. In addition, the field cross_references.curie is set as an elasticsearch wildcard field (https://www.elastic.co/guide/en/elasticsearch/reference/7.16/keyword.html) through the 'mapping' field in the schema.

This is a sample query that can be run on the resulting index:
curl -H 'Content-Type: application/json' -XPOST "http://localhost:9200/references_index/_search" -d '{"query": {"bool": {"must": {"wildcard": {"cross_references.curie": "PMID\\:12345*"}}, "filter": {"match": {"cross_references.is_obsolete": "false"}}}}}' | python -m json.tool