### PR TITLE
changed date_published field from 'date' to 'text'

### DIFF
--- a/pgsync_schema.json
+++ b/pgsync_schema.json
@@ -12,6 +12,9 @@
                 "mapping": {
                     "curie": {
                         "type": "keyword"
+                    },
+                    "date_published": {
+                        "type": "text"
                     }
                 }
             },


### PR DESCRIPTION
Some values in the DB for the field references.date_published cannot be converted to date, but elasticsearch was automatically setting the field type to date and was failing on these entries. Setting the field type to text in pgsync_schema to solve the issue