### PR TITLE
feat(docker-compose): removed dependencies from services that don't need them in all envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,14 @@ run-functest:
 	docker-compose --env-file .env.test run test_runner python3 src/xml_processing/tests/functional_tests.py
 	docker-compose --env-file .env.test down
 
+start-pgsync-aws:
+	# postgres and elasticsearch are not needed in this case as they are on RDS and OpenSearch respectively
+	docker-compose up -d pgsync
+
+start-pgsync-local:
+	docker-compose up -d postgres
+	sleep 5
+	docker-compose up -d elasticsearch
+	sleep 5
+	docker-compose up -d pgsync
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -101,8 +101,6 @@ services:
       REDIS_DB: "${REDIS_DB}"
       REDIS_AUTH: "${REDIS_AUTH}"
     depends_on:
-      - initdb
-      - elasticsearch
       - redis
     restart: on-failure
 


### PR DESCRIPTION
- some services depend on other services only for local deployment (e.g., pgsync needs postgres and elasticsearch when the whole stack is started locally but not in production, where pg and es are hosted on RDS)
- the current version of docker-compose on the dev server (which is also the default one in ubuntu 21.10) does not manage different dependencies in multiple profiles
- we decided to remove the dependencies from docker-compose.yaml and add entries in the Makefile to manage the dependencies for different profiles there