### PR TITLE
Modified pgsync schema with new es mappings and settings

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -88,7 +88,6 @@ services:
       - agr-literature
     volumes:
       - "./pgsync_schema.json:/src/app/pgsync_schema.json"
-      - "./.env:/usr/local/lib/.env"
     environment:
       PG_USER: "${PG_USER}"
       PG_PASSWORD: "${PG_PASSWORD}"
@@ -96,6 +95,7 @@ services:
       PG_PORT: "${PG_PORT}"
       ELASTICSEARCH_HOST: "${ELASTICSEARCH_HOST}"
       ELASTICSEARCH_PORT: "${ELASTICSEARCH_PORT}"
+      ELASTICSEARCH_TIMEOUT: 100
       REDIS_HOST: "${REDIS_HOST}"
       REDIS_PORT: "${REDIS_PORT}"
       REDIS_DB: "${REDIS_DB}"

--- a/pgsync_schema.json
+++ b/pgsync_schema.json
@@ -84,7 +84,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -93,7 +94,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -102,7 +104,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -111,7 +114,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -120,7 +124,18 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "abstract": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -129,7 +144,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -138,7 +154,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -147,7 +164,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -156,7 +174,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     },
@@ -165,7 +184,8 @@
                         "fields": {
                             "keyword": {
                                 "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
                             }
                         }
                     }
@@ -192,7 +212,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             },
@@ -201,7 +222,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             },
@@ -210,7 +232,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             },
@@ -219,7 +242,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             },
@@ -228,7 +252,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             }
@@ -260,7 +285,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             },
@@ -269,7 +295,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             },
@@ -287,7 +314,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             },
@@ -305,7 +333,18 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
+                                    }
+                                }
+                            },
+                            "abstract": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             },
@@ -314,7 +353,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             }
@@ -345,7 +385,8 @@
                                 "fields": {
                                     "keyword": {
                                         "type": "keyword",
-                                        "normalizer": "sortNormalizer"
+                                        "normalizer": "sortNormalizer",
+                                        "ignore_above": 256
                                     }
                                 }
                             }

--- a/pgsync_schema.json
+++ b/pgsync_schema.json
@@ -6,7 +6,7 @@
             "number_of_shards": "1",
             "number_of_replicas": "0",
             "max_ngram_diff": "20",
-            "max_result_window": 500000,
+            "max_result_window": 1000000,
             "analysis": {
                 "filter": {
                     "ngram_filter": {
@@ -40,6 +40,22 @@
                         ],
                         "type": "custom",
                         "tokenizer": "ngram_tokenizer"
+                    },
+                    "default": {
+                        "filter": [
+                            "asciifolding",
+                            "lowercase"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "ngram_tokenizer"
+                    },
+                    "default_search": {
+                        "filter": [
+                            "asciifolding",
+                            "lowercase"
+                        ],
+                        "type": "custom",
+                        "tokenizer": "ngram_tokenizer"
                     }
                 },
                 "tokenizer": {
@@ -65,16 +81,102 @@
                 "mapping": {
                     "curie": {
                         "type": "text",
-                        "analyzer": "autocompleteAnalyzer",
-                        "search_analyzer": "autocompleteSearchAnalyzer",
-                        "copy_to": "curie_keyword"
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
                     },
-                    "curie_keyword": {
-                        "type": "keyword",
-                        "normalizer": "sortNormalizer"
+                    "title": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
+                    },
+                    "volume": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
                     },
                     "date_published": {
-                        "type": "text"
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
+                    },
+                    "pages": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
+                    },
+                    "abstract": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
+                    },
+                    "citation": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
+                    },
+                    "publisher": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
+                    },
+                    "pubmed_type": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
+                    },
+                    "issue_name": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
+                    },
+                    "issue_date": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer"
+                            }
+                        }
                     }
                 }
             },
@@ -91,6 +193,55 @@
                             "child": ["reference_id"],
                             "parent": ["reference_id"]
                         }
+                    },
+                    "transform": {
+                        "mapping": {
+                            "orcid": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "affiliation": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "first_name": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "middle_names": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "last_name": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
                 {
@@ -99,12 +250,92 @@
                        "title", "title_synonyms", "iso_abbreviation", "medline_abbreviation", "publisher", "volumes"
                        ,"abstract", "summary"
                     ],
-                    "relationship":{
+                    "relationship": {
                         "variant": "object",
                         "type": "one_to_many",
-                        "foreign_key":{
-                            "child": ["resource_id"],
-                            "parent": ["resource_id"]
+                        "foreign_key": {
+                            "child": [
+                                "resource_id"
+                            ],
+                            "parent": [
+                                "resource_id"
+                            ]
+                        }
+                    },
+                    "transform": {
+                        "mapping": {
+                            "title": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "title_synonyms": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "iso_abbreviation": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "medline_abbreviation": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "publisher": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "volumes": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "abstract": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            },
+                            "summary": {
+                                "type": "text",
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
+                            }
                         }
                     }
                 },
@@ -113,25 +344,28 @@
                     "columns":[
                        "curie", "is_obsolete"
                     ],
-                    "relationship":{
+                    "relationship": {
                         "variant": "object",
                         "type": "one_to_many",
-                        "foreign_key":{
-                            "child": ["reference_id"],
-                            "parent": ["reference_id"]
+                        "foreign_key": {
+                            "child": [
+                                "reference_id"
+                            ],
+                            "parent": [
+                                "reference_id"
+                            ]
                         }
                     },
                     "transform": {
                         "mapping": {
                             "curie": {
                                 "type": "text",
-                                "analyzer": "autocompleteAnalyzer",
-                                "search_analyzer": "autocompleteSearchAnalyzer",
-                                "copy_to": "cross_references.curie_keyword"
-                            },
-                            "curie_keyword": {
-                                "type": "keyword",
-                                "normalizer": "sortNormalizer"
+                                "fields": {
+                                    "keyword": {
+                                        "type": "keyword",
+                                        "normalizer": "sortNormalizer"
+                                    }
+                                }
                             }
                         }
                     }

--- a/pgsync_schema.json
+++ b/pgsync_schema.json
@@ -124,15 +124,6 @@
                             }
                         }
                     },
-                    "abstract": {
-                        "type": "text",
-                        "fields": {
-                            "keyword": {
-                                "type": "keyword",
-                                "normalizer": "sortNormalizer"
-                            }
-                        }
-                    },
                     "citation": {
                         "type": "text",
                         "fields": {
@@ -310,15 +301,6 @@
                                 }
                             },
                             "volumes": {
-                                "type": "text",
-                                "fields": {
-                                    "keyword": {
-                                        "type": "keyword",
-                                        "normalizer": "sortNormalizer"
-                                    }
-                                }
-                            },
-                            "abstract": {
                                 "type": "text",
                                 "fields": {
                                     "keyword": {


### PR DESCRIPTION
This PR introduces changes to align our references_index settings and mappings to those used by the A-Team. These are the main changes:

- increased max_result_window to 1M
- set default analyzer and search_analyzer for text fields to the custom ones also used by the A-Team
- renamed _keyword fields to .keyword (the standard naming used by es)
- added custom normalizer to all .keyword fields