### PR TITLE
fix(api): removed lazy load option from mod and moved it to mod_curpu…

### DIFF
--- a/backend/app/literature/crud/reference_crud.py
+++ b/backend/app/literature/crud/reference_crud.py
@@ -295,8 +295,9 @@ def show(db: Session, curie: str, http_request=True):  # noqa
     if reference.mod_corpus_association:
         for i in range(len(reference_data["mod_corpus_association"])):
             del reference_data["mod_corpus_association"][i]["reference_id"]
-            reference_data["mod_corpus_association"][i]["mod_abbreviation"] = reference.mod_corpus_association[i].mod\
-                .abbreviation
+            reference_data["mod_corpus_association"][i]["mod_abbreviation"] = reference_data[
+                "mod_corpus_association"][i]["mod"]["abbreviation"]
+            del reference_data["mod_corpus_association"][i]["mod"]
             del reference_data["mod_corpus_association"][i]["mod_id"]
         reference_data["mod_corpus_associations"] = reference_data["mod_corpus_association"]
         del reference_data["mod_corpus_association"]

--- a/backend/app/literature/models/mod_corpus_association_model.py
+++ b/backend/app/literature/models/mod_corpus_association_model.py
@@ -46,7 +46,8 @@ class ModCorpusAssociationModel(Base):
 
     mod = relationship(
         "ModModel",
-        back_populates="mod_corpus_association"
+        back_populates="mod_corpus_association",
+        lazy="joined"
     )
 
     corpus = Column(

--- a/backend/app/literature/models/mod_model.py
+++ b/backend/app/literature/models/mod_model.py
@@ -26,7 +26,6 @@ class ModModel(Base):
 
     mod_corpus_association = relationship(
         "ModCorpusAssociationModel",
-        lazy="joined",
         primaryjoin="ModModel.mod_id==ModCorpusAssociationModel.mod_id",
         back_populates="mod",
         cascade="all, delete, delete-orphan"


### PR DESCRIPTION
…s_association model

- using lazy="joined" to always load the related table into an object using a join
- modified reference_crud.py to reflect changes in the models