### PR TITLE
Changed relationship type for mod_corpus_association - mod

### DIFF
--- a/backend/app/literature/models/mod_corpus_association_model.py
+++ b/backend/app/literature/models/mod_corpus_association_model.py
@@ -46,8 +46,8 @@ class ModCorpusAssociationModel(Base):
 
     mod = relationship(
         "ModModel",
-        back_populates="mod_corpus_association",
-        lazy="joined"
+        lazy="joined",
+        cascade="all, delete"
     )
 
     corpus = Column(

--- a/backend/app/literature/models/mod_model.py
+++ b/backend/app/literature/models/mod_model.py
@@ -9,7 +9,6 @@ from typing import Dict
 
 import pytz
 from sqlalchemy import Column, DateTime, Integer, String
-from sqlalchemy.orm import relationship
 
 from literature.database.base import Base
 

--- a/backend/app/literature/models/mod_model.py
+++ b/backend/app/literature/models/mod_model.py
@@ -24,13 +24,6 @@ class ModModel(Base):
         autoincrement=True
     )
 
-    mod_corpus_association = relationship(
-        "ModCorpusAssociationModel",
-        primaryjoin="ModModel.mod_id==ModCorpusAssociationModel.mod_id",
-        back_populates="mod",
-        cascade="all, delete, delete-orphan"
-    )
-
     abbreviation = Column(
         String(10),
         unique=True,


### PR DESCRIPTION
The SQLAlchemy relationship type between mod_corpus_association and mod is now many-to-one instead of many-to-many. This avoids adding a list of all mod_corpus_association objects in each mod object, which was slowing down the queries.