### PR TITLE
Scrum 1455 - fixed bug with multiple mod-corpus associations

### DIFF
--- a/src/xml_processing/query_pubmed_mod_updates.py
+++ b/src/xml_processing/query_pubmed_mod_updates.py
@@ -162,8 +162,10 @@ def get_pmid_association_to_mod_via_reference(pmids: List[str], mod_abbreviation
         ModCorpusAssociationModel.mod
     )
     results = query.all()
-    pmid_curie_mod_dict = {result[0]: (result[1], result[2] if result[2] == mod_abbreviation else None)
-                           for result in results}
+    pmid_curie_mod_dict = {}
+    for result in results:
+        if result[0] not in pmid_curie_mod_dict or pmid_curie_mod_dict[result[0]][1] is None:
+            pmid_curie_mod_dict[result[0]] = (result[1], result[2] if result[2] == mod_abbreviation else None)
     for pmid in pmids:
         if pmid not in pmid_curie_mod_dict:
             pmid_curie_mod_dict[pmid] = (None, None)

--- a/src/xml_processing/query_pubmed_mod_updates.py
+++ b/src/xml_processing/query_pubmed_mod_updates.py
@@ -9,7 +9,7 @@ import urllib
 from datetime import datetime
 # import os
 from os import environ, makedirs, path
-from typing import List, Set
+from typing import List, Set, Dict, Tuple, Union
 
 import requests
 from dotenv import load_dotenv
@@ -162,7 +162,7 @@ def get_pmid_association_to_mod_via_reference(pmids: List[str], mod_abbreviation
         ModCorpusAssociationModel.mod
     )
     results = query.all()
-    pmid_curie_mod_dict = {}
+    pmid_curie_mod_dict: Dict[str, Tuple[Union[str, None], Union[str, None]]] = {}
     for result in results:
         if result[0] not in pmid_curie_mod_dict or pmid_curie_mod_dict[result[0]][1] is None:
             pmid_curie_mod_dict[result[0]] = (result[1], result[2] if result[2] == mod_abbreviation else None)


### PR DESCRIPTION
When multiple mod-corpus associations are present for a given PMID, the sqlalchemy query returns all the related rows as different tuples. The new code picks the row containing the association to the provided MOD if present and otherwise sets the MOD value to None. The old code was always setting the value of the last tuple in the list.