### PR TITLE
fix(api): changed query strategy for xref objects from joined to sub-select to speed up ref queries

### DIFF
--- a/backend/app/literature/crud/reference_crud.py
+++ b/backend/app/literature/crud/reference_crud.py
@@ -282,8 +282,8 @@ def show(db: Session, curie: str, http_request=True):  # noqa
 
     if reference.cross_references:
         cross_references = []
-        for cross_reference in reference_data["cross_references"]:
-            cross_reference_show = jsonable_encoder(cross_reference_crud.show(db, cross_reference["curie"]))
+        for cross_reference in reference.cross_references:
+            cross_reference_show = jsonable_encoder(cross_reference_crud.show(db, cross_reference.curie))
             del cross_reference_show["reference_curie"]
             cross_references.append(cross_reference_show)
         reference_data["cross_references"] = cross_references

--- a/backend/app/literature/models/reference_model.py
+++ b/backend/app/literature/models/reference_model.py
@@ -36,7 +36,6 @@ class ReferenceModel(Base):
 
     cross_references = relationship(
         "CrossReferenceModel",
-        lazy="joined",
         back_populates="reference",
         cascade="all, delete, delete-orphan",
         passive_deletes=True


### PR DESCRIPTION
- joined query on ref and xref was taking too long. Inner joins might be faster, but I'm not sure whether we want to always create references with xrefs. Sub-select is safer and works faster
- now accessing xref list explicitly in the ref crud to trigger the sub-select