### PR TITLE
fix(api): removed wrong delete cascade on mod from mod_corpus_association

### DIFF
--- a/backend/app/literature/models/mod_corpus_association_model.py
+++ b/backend/app/literature/models/mod_corpus_association_model.py
@@ -46,8 +46,7 @@ class ModCorpusAssociationModel(Base):
 
     mod = relationship(
         "ModModel",
-        lazy="joined",
-        cascade="all, delete"
+        lazy="joined"
     )
 
     corpus = Column(


### PR DESCRIPTION
mods were deleted when mod_corpus_associations were deleted. This was happening at the ORM level and not as a result of the constraint cascades in the DB, but the mods were deleted when changes were then committed to the DB by the api. Removing the additional ORM cascade fixed the issue