### PR TITLE
Scrum 1516

### DIFF
--- a/src/xml_processing/generate_pubmed_nlm_resource.py
+++ b/src/xml_processing/generate_pubmed_nlm_resource.py
@@ -28,10 +28,6 @@ logging.config.fileConfig(log_file_path)
 logger = logging.getLogger('literature logger')
 
 
-base_path = environ.get('XML_PATH', "")
-storage_path = base_path + 'pubmed_resource_json/'
-
-
 def populate_nlm_info(file_data):
     """
 
@@ -91,6 +87,9 @@ def generate_json(nlm_info, upload_to_s3):
     logger.info("Generating JSON from NLM data and saving to outfile")
     json_data = json.dumps(nlm_info, indent=4, sort_keys=True)
 
+    base_path = environ.get('XML_PATH', "")
+    storage_path = base_path + 'pubmed_resource_json/'
+
     if not path.exists(storage_path):
         makedirs(storage_path)
 
@@ -132,6 +131,7 @@ def populate_from_local_file():
     :return:
     """
 
+    base_path = environ.get('XML_PATH', "")
     filename = base_path + 'J_Medline.txt'
     with open(filename) as txt_file:
         if not path.exists(filename):

--- a/src/xml_processing/post_resource_to_api.py
+++ b/src/xml_processing/post_resource_to_api.py
@@ -3,7 +3,7 @@ import argparse
 import json
 import logging
 import logging.config
-from os import environ, path
+from os import environ, sys
 
 from dotenv import load_dotenv
 
@@ -19,9 +19,6 @@ from helper_post_to_api import (generate_headers, get_authentication_token,
 load_dotenv()
 
 # pipenv run python3 post_resource_to_api.py > log_post_resource_to_api
-
-# base_path = '/home/azurebrd/git/agr_literature_service_demo/src/xml_processing/'
-base_path = environ.get('XML_PATH', "")
 
 # resource_fields = ['primaryId', 'nlm', 'title', 'isoAbbreviation', 'medlineAbbreviation', 'printISSN', 'onlineISSN']
 # resource_fields_from_pubmed = ['title', 'isoAbbreviation', 'medlineAbbreviation', 'printISSN', 'onlineISSN']
@@ -43,21 +40,26 @@ resource_fields_not_in_pubmed = ['titleSynonyms', 'abbreviationSynonyms', 'isoAb
 # 2021-05-24 23:06:27,845 - literature logger - INFO - key printISSN
 
 
-log_file_path = path.join(path.dirname(path.abspath(__file__)), '../logging.conf')
-logging.config.fileConfig(log_file_path)
-logger = logging.getLogger('literature logger')
+logging.basicConfig(level=logging.INFO,
+                    stream=sys.stdout,
+                    format= '%(asctime)s - %(levelname)s - {%(module)s %(funcName)s:%(lineno)d} - %(message)s',    # noqa E251
+                    datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger(__name__)
 
 
-def post_resources(input_path):      # noqa: C901
+def post_resources(input_path, input_mod):      # noqa: C901
     """
 
     :param input_path:
     :return:
     """
 
+    base_path = environ.get('XML_PATH', "")
     api_port = environ.get('API_PORT')
     json_storage_path = base_path + input_path + '/'
     filesets = ['NLM', 'FB', 'ZFIN']
+    if input_mod in filesets:
+        filesets = [input_mod]
     keys_to_remove = {'nlm', 'primaryId'}
     remap_keys = dict()
     remap_keys['isoAbbreviation'] = 'iso_abbreviation'
@@ -224,7 +226,7 @@ if __name__ == "__main__":
     logger.info("starting post_resource_to_api.py")
 
     if args['file']:
-        post_resources(args['file'])
+        post_resources(args['file'], 'all')
 
     else:
         logger.info("No flag passed in.  Use -h for help.")

--- a/src/xml_processing/post_resource_to_api.py
+++ b/src/xml_processing/post_resource_to_api.py
@@ -3,7 +3,8 @@ import argparse
 import json
 import logging
 import logging.config
-from os import environ, sys
+import sys
+from os import environ
 
 from dotenv import load_dotenv
 

--- a/src/xml_processing/update_resource_pubmed_nlm.py
+++ b/src/xml_processing/update_resource_pubmed_nlm.py
@@ -1,7 +1,8 @@
 
 import logging
 import logging.config
-from os import environ, sys
+import sys
+from os import environ
 
 from generate_pubmed_nlm_resource import (populate_from_url, populate_nlm_info,
                                           generate_json)

--- a/src/xml_processing/update_resource_pubmed_nlm.py
+++ b/src/xml_processing/update_resource_pubmed_nlm.py
@@ -1,0 +1,57 @@
+
+import logging
+import logging.config
+from os import environ, sys
+
+from generate_pubmed_nlm_resource import (populate_from_url, populate_nlm_info,
+                                          generate_json)
+from helper_file_processing import load_pubmed_resource_basic
+from parse_dqm_json_resource import (save_resource_file, create_storage_path)
+from helper_sqlalchemy import sqlalchemy_load_ref_xref
+from post_resource_to_api import post_resources
+
+
+logging.basicConfig(level=logging.INFO,
+                    stream=sys.stdout,
+                    format= '%(asctime)s - %(levelname)s - {%(module)s %(funcName)s:%(lineno)d} - %(message)s',    # noqa E251
+                    datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger(__name__)
+
+
+def update_resource_pubmed_nlm():
+    """
+    download J_Medline file, convert to json, compare to existing resources, post new ones to api and database
+    """
+
+    upload_to_s3 = True
+    file_data = populate_from_url()
+    nlm_info = populate_nlm_info(file_data)
+    generate_json(nlm_info, upload_to_s3)
+    pubmed_by_nlm, nlm_by_issn = load_pubmed_resource_basic()
+
+    xref_ref, ref_xref_valid, ref_xref_obsolete = sqlalchemy_load_ref_xref('resource')
+
+    resources_to_create = dict()
+
+    for nlm in pubmed_by_nlm:
+        if 'NLM' in xref_ref and nlm in xref_ref['NLM'] and xref_ref['NLM'][nlm] is not None:
+            logger.info(f"{nlm} already {xref_ref['NLM'][nlm]}")
+        else:
+            logger.info(f"create {nlm}")
+            resources_to_create[nlm] = pubmed_by_nlm[nlm]
+
+    base_path = environ.get('XML_PATH', "")
+    json_storage_path = base_path + 'sanitized_resource_json/'
+    create_storage_path(json_storage_path)
+    save_resource_file(json_storage_path, resources_to_create, 'NLM')
+    post_resources('sanitized_resource_json', 'NLM')
+
+
+if __name__ == "__main__":
+    """
+    process nlm updates from medline to database
+    """
+
+    logger.info("start update_resource_pubmed_nlm")
+    update_resource_pubmed_nlm()
+    logger.info("end update_resource_pubmed_nlm")


### PR DESCRIPTION
Modularized update of pubmed nlm resources to only create new resources, but not update existing ones.  This should be run before doing any new paper creation, from pubmed searches, dqm updates, pubmed paper updates, but probably not before creating one-of papers via PMID through the UI, because it would take too long.