### PR TITLE
added code to check DOI in the DB and in the new paper set to avoid pulling in duplicate entries

### DIFF
--- a/src/xml_processing/query_pubmed_mod_updates.py
+++ b/src/xml_processing/query_pubmed_mod_updates.py
@@ -6,7 +6,7 @@ import time
 import urllib
 from os import environ, makedirs, path
 from typing import List, Set, Dict, Tuple, Union
-
+import json
 
 import requests
 from dotenv import load_dotenv
@@ -23,7 +23,9 @@ from update_resource_pubmed_nlm import update_resource_pubmed_nlm
 
 from literature.database.main import get_db
 from literature.models import ReferenceModel, CrossReferenceModel, ModCorpusAssociationModel, ModModel
-
+from helper_sqlalchemy import sqlalchemy_load_ref_xref
+from literature.crud.cross_reference_crud import create
+from literature.schemas import CrossReferenceSchemaPost
 
 load_dotenv()
 
@@ -212,6 +214,9 @@ def query_mods(input_mod, reldate):
     }
     # source of WB FP file: https://tazendra.caltech.edu/~postgres/agr/lit/WB_false_positive_pmids
 
+    # retrieve all cross_reference info from database
+    xref_ref, ref_xref_valid, ref_xref_obsolete = sqlalchemy_load_ref_xref('reference')
+    
     mods_to_query = ['ZFIN', 'WB', 'FB', 'SGD']
     if input_mod in mods_to_query:
         mods_to_query = [input_mod]
@@ -253,7 +258,7 @@ def query_mods(input_mod, reldate):
             # print(json_data)
             # pmids_joined = (',').join(sorted(pmids_wanted))
             # logger.info(pmids_joined)
-            # logger.info(len(pmids_wanted))
+            # logger.info(len(pmids_wanted))            
             for pmid in pmids_wanted:
                 if pmid in pmid_curie_mod_dict:
                     agr_curie = pmid_curie_mod_dict[pmid][0]
@@ -266,7 +271,7 @@ def query_mods(input_mod, reldate):
                         # print(f"add {mod} mca to {pmid} is {agr_curie}")
                         agr_curies_to_corpus.append(agr_curie)
         logger.info(f"pmids_to_create: {len(pmids_to_create)}")
-        # print (f"pmids_to_create: {len(pmids_to_create)}")
+
         # pmids_joined = (',').join(sorted(pmids_to_create))
         # logger.info(pmids_joined)
         logger.info(f"agr_curies_to_corpus: {len(agr_curies_to_corpus)}")
@@ -284,6 +289,52 @@ def query_mods(input_mod, reldate):
         download_pubmed_xml(pmids_to_process)
         generate_json(pmids_to_process, [])
 
+        # check for papers with same doi in the database
+        
+        # print ("ref_xref_valid=", str(ref_xref_valid['AGR:AGR-Reference-0000167781']))
+        # ref_xref_valid= {'DOI': '10.1111/j.1440-1711.2005.01311.x', 'MGI': '3573820', 'PMID': '15748210'}
+        # print ("xref_ref['DOI'][doi]=", str(xref_ref['DOI']['10.1111/j.1440-1711.2005.01311.x']))
+        # xref_ref['DOI'][doi]= AGR:AGR-Reference-0000167781
+        
+        db_session = next(get_db())
+        json_path = base_path + "pubmed_json/"
+        log_file = base_path + "pubmed_searches/duplicate_rows.log"
+        fw = open(log_file, "w")
+        for pmid in pmids_to_process:
+            json_file = json_path + pmid + ".json"
+            f = open(json_file)
+            json_data = json.load(f)
+            f.close()
+            cross_references = json_data['crossReferences']
+            doi = None
+            for c in cross_references:
+                if c['id'].startswith('DOI:'):
+                    doi = c['id'].replace('DOI:', '')
+                    break                    
+            if doi and doi in xref_ref['DOI']:
+                ## the doi for the new paper is in the database
+                agr = xref_ref['DOI'][doi]
+                all_ref_xref = ref_xref_valid[agr] if agr in ref_xref_valid else {}
+                if agr in ref_xref_obsolete:
+                    all_ref_xref.update(ref_xref_obsolete[agr]) ## merge two dictionaries            
+                found_pmids_for_this_doi = []
+                for prefix in all_ref_xref:
+                    if prefix == 'PMID':
+                        found_pmids_for_this_doi.append(all_ref_xref[prefix])
+                if len(found_pmids_for_this_doi) == 0:
+                    fw.write("adding PMID:" + pmid + " to the row with doi = " + doi + " in the database\n")
+                    data = {"curie": "PMID:" + pmid, "reference_curie": agr, "pages": ["reference"]}
+                    try:
+                        xref_schema = CrossReferenceSchemaPost(**data)
+                        create(db_session, xref_schema)
+                    except Exception as e:
+                        fw.write("adding " + pmid + " to the row with " + doi + " is failed: " + str(e) + "\n")
+                else:
+                    fw.write(doi + " is associated with PMID(s) in the database: " + ",".join(found_pmids_for_this_doi) + "\n")
+                pmids_to_process.remove(pmid)
+        fw.close()
+        # done checking
+    
         inject_object = {}
         mod_corpus_associations = [{"modAbbreviation": mod, "modCorpusSortSource": "mod_pubmed_search", "corpus": None}]
         inject_object['modCorpusAssociations'] = mod_corpus_associations
@@ -296,8 +347,9 @@ def query_mods(input_mod, reldate):
         # post generated json to api
         json_filepath = base_path + 'sanitized_reference_json/REFERENCE_PUBMED_PMID.json'
         process_results = post_references(json_filepath, 'no_file_check')
-        logger.info(process_results)
 
+        logger.info(process_results)
+        
         # upload each processed json file to s3
         for pmid in pmids_to_process:
             # logger.info(f"upload {pmid} to s3")

--- a/src/xml_processing/query_pubmed_mod_updates.py
+++ b/src/xml_processing/query_pubmed_mod_updates.py
@@ -328,10 +328,11 @@ def check_handle_duplicate(db_session, pmids, xref_ref, ref_xref_valid, ref_xref
     # print ("xref_ref['DOI'][doi]=", str(xref_ref['DOI']['10.1111/j.1440-1711.2005.01311.x']))
     # xref_ref['DOI'][doi]= AGR:AGR-Reference-0000167781
 
+    from datetime import datetime
     json_path = base_path + "pubmed_json/"
-    log_file = base_path + "pubmed_searches/duplicate_rows.log"
+    log_file = base_path + "report_files/duplicate_rows.log"
 
-    fw = open(log_file, "w")
+    fw = open(log_file, "a")
     for pmid in pmids:
         json_file = json_path + pmid + ".json"
         f = open(json_file)
@@ -354,16 +355,15 @@ def check_handle_duplicate(db_session, pmids, xref_ref, ref_xref_valid, ref_xref
                 if prefix == 'PMID':
                     found_pmids_for_this_doi.append(all_ref_xref[prefix])
             if len(found_pmids_for_this_doi) == 0:
-                fw.write("adding PMID:" + pmid + " to the row with doi = " + doi + " in the database\n")
-                # data = {"curie": "PMID:" + pmid, "reference_curie": agr, "pages": ["reference"]}
+                fw.write(str(datetime.now()) + ": adding PMID:" + pmid + " to the row with doi = " + doi + " in the database\n")
                 data = {"curie": "PMID:" + pmid, "reference_curie": agr}
                 try:
                     xref_schema = CrossReferenceSchemaPost(**data)
                     create(db_session, xref_schema)
                 except Exception as e:
-                    fw.write("adding " + pmid + " to the row with " + doi + " is failed: " + str(e) + "\n")
+                    logger.info(str(datetime.now()) + ": adding " + pmid + " to the row with " + doi + " is failed: " + str(e) + "\n")
             else:
-                fw.write(doi + " is associated with PMID(s) in the database: " + ",".join(found_pmids_for_this_doi) + "\n")
+                fw.write(str(datetime.now()) + ": " + doi + " is associated with PMID(s) in the database: " + ",".join(found_pmids_for_this_doi) + "\n")
             pmids.remove(pmid)
     fw.close()
 

--- a/src/xml_processing/query_pubmed_mod_updates.py
+++ b/src/xml_processing/query_pubmed_mod_updates.py
@@ -216,7 +216,6 @@ def query_mods(input_mod, reldate):
 
     # retrieve all cross_reference info from database
     xref_ref, ref_xref_valid, ref_xref_obsolete = sqlalchemy_load_ref_xref('reference')
-    
     mods_to_query = ['ZFIN', 'WB', 'FB', 'SGD']
     if input_mod in mods_to_query:
         mods_to_query = [input_mod]
@@ -258,7 +257,7 @@ def query_mods(input_mod, reldate):
             # print(json_data)
             # pmids_joined = (',').join(sorted(pmids_wanted))
             # logger.info(pmids_joined)
-            # logger.info(len(pmids_wanted))            
+            # logger.info(len(pmids_wanted))
             for pmid in pmids_wanted:
                 if pmid in pmid_curie_mod_dict:
                     agr_curie = pmid_curie_mod_dict[pmid][0]
@@ -290,12 +289,10 @@ def query_mods(input_mod, reldate):
         generate_json(pmids_to_process, [])
 
         # check for papers with same doi in the database
-        
         # print ("ref_xref_valid=", str(ref_xref_valid['AGR:AGR-Reference-0000167781']))
         # ref_xref_valid= {'DOI': '10.1111/j.1440-1711.2005.01311.x', 'MGI': '3573820', 'PMID': '15748210'}
         # print ("xref_ref['DOI'][doi]=", str(xref_ref['DOI']['10.1111/j.1440-1711.2005.01311.x']))
         # xref_ref['DOI'][doi]= AGR:AGR-Reference-0000167781
-        
         db_session = next(get_db())
         json_path = base_path + "pubmed_json/"
         log_file = base_path + "pubmed_searches/duplicate_rows.log"
@@ -310,13 +307,13 @@ def query_mods(input_mod, reldate):
             for c in cross_references:
                 if c['id'].startswith('DOI:'):
                     doi = c['id'].replace('DOI:', '')
-                    break                    
             if doi and doi in xref_ref['DOI']:
                 ## the doi for the new paper is in the database
                 agr = xref_ref['DOI'][doi]
                 all_ref_xref = ref_xref_valid[agr] if agr in ref_xref_valid else {}
                 if agr in ref_xref_obsolete:
-                    all_ref_xref.update(ref_xref_obsolete[agr]) ## merge two dictionaries            
+                    # merge two dictionaries
+                    all_ref_xref.update(ref_xref_obsolete[agr])
                 found_pmids_for_this_doi = []
                 for prefix in all_ref_xref:
                     if prefix == 'PMID':
@@ -334,7 +331,6 @@ def query_mods(input_mod, reldate):
                 pmids_to_process.remove(pmid)
         fw.close()
         # done checking
-    
         inject_object = {}
         mod_corpus_associations = [{"modAbbreviation": mod, "modCorpusSortSource": "mod_pubmed_search", "corpus": None}]
         inject_object['modCorpusAssociations'] = mod_corpus_associations
@@ -347,9 +343,7 @@ def query_mods(input_mod, reldate):
         # post generated json to api
         json_filepath = base_path + 'sanitized_reference_json/REFERENCE_PUBMED_PMID.json'
         process_results = post_references(json_filepath, 'no_file_check')
-
         logger.info(process_results)
-        
         # upload each processed json file to s3
         for pmid in pmids_to_process:
             # logger.info(f"upload {pmid} to s3")

--- a/src/xml_processing/query_pubmed_mod_updates.py
+++ b/src/xml_processing/query_pubmed_mod_updates.py
@@ -355,7 +355,8 @@ def check_handle_duplicate(db_session, pmids, xref_ref, ref_xref_valid, ref_xref
                     found_pmids_for_this_doi.append(all_ref_xref[prefix])
             if len(found_pmids_for_this_doi) == 0:
                 fw.write("adding PMID:" + pmid + " to the row with doi = " + doi + " in the database\n")
-                data = {"curie": "PMID:" + pmid, "reference_curie": agr, "pages": ["reference"]}
+                # data = {"curie": "PMID:" + pmid, "reference_curie": agr, "pages": ["reference"]}
+                data = {"curie": "PMID:" + pmid, "reference_curie": agr}
                 try:
                     xref_schema = CrossReferenceSchemaPost(**data)
                     create(db_session, xref_schema)

--- a/src/xml_processing/query_pubmed_mod_updates.py
+++ b/src/xml_processing/query_pubmed_mod_updates.py
@@ -283,14 +283,15 @@ def query_mods(input_mod, reldate):
 
         pmids_to_process = sorted(pmids_to_create)
         # pmids_to_process = sorted(pmids_to_create)[0:2]   # smaller set to test
-        for pmid in pmids_to_process:
-            pmids_posted.add(pmid)
         logger.info(pmids_to_process)
         download_pubmed_xml(pmids_to_process)
         generate_json(pmids_to_process, [])
 
         check_handle_duplicate(db_session, pmids_to_process, xref_ref,
                                ref_xref_valid, ref_xref_obsolete)
+
+        for pmid in pmids_to_process:
+            pmids_posted.add(pmid)
 
         inject_object = {}
         mod_corpus_associations = [{"modAbbreviation": mod, "modCorpusSortSource": "mod_pubmed_search", "corpus": None}]

--- a/src/xml_processing/sort_dqm_json_reference_updates.py
+++ b/src/xml_processing/sort_dqm_json_reference_updates.py
@@ -197,7 +197,9 @@ def sort_dqm_references(input_path, input_mod):      # noqa: C901
     url_ref_curie_prefix = make_url_ref_curie_prefix()
 
     # download the dqm file(s) from mod(s)
-    download_dqm_json()
+    env_state = environ.get('ENV_STATE', 'build')
+    if env_state != 'test':
+        download_dqm_json()
     # to pull in new journal info from pubmed
     update_resource_pubmed_nlm()
     token = get_authentication_token()
@@ -541,7 +543,7 @@ def sort_dqm_references(input_path, input_mod):      # noqa: C901
         # env_state = environ.get('ENV_STATE', 'prod')
         # if env_state == 'build':
         env_state = environ.get('ENV_STATE', 'build')
-        if env_state != 'test':
+        if env_state == 'prod'':
             merge_md5dict = {}
             merge_md5dict[mod] = {**old_md5dict[mod], **new_md5dict[mod]}
             save_s3_md5data(merge_md5dict, [mod])

--- a/src/xml_processing/sort_dqm_json_reference_updates.py
+++ b/src/xml_processing/sort_dqm_json_reference_updates.py
@@ -543,7 +543,7 @@ def sort_dqm_references(input_path, input_mod):      # noqa: C901
         # env_state = environ.get('ENV_STATE', 'prod')
         # if env_state == 'build':
         env_state = environ.get('ENV_STATE', 'build')
-        if env_state == 'prod'':
+        if env_state == 'prod':
             merge_md5dict = {}
             merge_md5dict[mod] = {**old_md5dict[mod], **new_md5dict[mod]}
             save_s3_md5data(merge_md5dict, [mod])

--- a/src/xml_processing/sort_dqm_json_reference_updates.py
+++ b/src/xml_processing/sort_dqm_json_reference_updates.py
@@ -541,7 +541,7 @@ def sort_dqm_references(input_path, input_mod):      # noqa: C901
         # env_state = environ.get('ENV_STATE', 'prod')
         # if env_state == 'build':
         env_state = environ.get('ENV_STATE', 'build')
-        if env_state == 'prod':
+        if env_state != 'test':
             merge_md5dict = {}
             merge_md5dict[mod] = {**old_md5dict[mod], **new_md5dict[mod]}
             save_s3_md5data(merge_md5dict, [mod])

--- a/src/xml_processing/sort_dqm_json_reference_updates.py
+++ b/src/xml_processing/sort_dqm_json_reference_updates.py
@@ -199,9 +199,10 @@ def sort_dqm_references(input_path, input_mod):      # noqa: C901
     # download the dqm file(s) from mod(s)
     env_state = environ.get('ENV_STATE', 'build')
     if env_state != 'test':
+        # download the dqm file(s) from mod(s)
         download_dqm_json()
-    # to pull in new journal info from pubmed
-    update_resource_pubmed_nlm()
+        # to pull in new journal info from pubmed
+        update_resource_pubmed_nlm()
     token = get_authentication_token()
     headers = generate_headers(token)
 


### PR DESCRIPTION
1. if a new paper's DOI is already in the database and no PMID is associated with this existing one, add the PMID  to the existing paper and add the info to the log 
2. if a new paper's DOI is already in the database and is associated with a PMID, simply add the details to the log.

The log file is available at src/xml_processing/pubmed_searches/duplicate_rows.log

