### PR TITLE
Scrum 1462 - Added more facets

### DIFF
--- a/backend/app/literature/crud/search_crud.py
+++ b/backend/app/literature/crud/search_crud.py
@@ -38,6 +38,18 @@ def search_references(query: str = None, facets_values: Dict[str, List[str]] = N
                     "field": "pubmed_types.keyword",
                     "size": facets_limits["pubmed_types.keyword"] if "pubmed_types.keyword" in facets_limits else 10
                 }
+            },
+            "category.keyword": {
+                "terms": {
+                    "field": "category.keyword",
+                    "size": facets_limits["category.keyword"] if "category.keyword" in facets_limits else 10
+                }
+            },
+            "pubmed_publication_status.keyword": {
+                "terms": {
+                    "field": "pubmed_publication_status.keyword",
+                    "size": facets_limits["pubmed_publication_status.keyword"] if "pubmed_publication_status.keyword" in facets_limits else 10
+                }
             }
         },
         "size": size_result_count,
@@ -52,7 +64,8 @@ def search_references(query: str = None, facets_values: Dict[str, List[str]] = N
         es_body["query"]["bool"]["must"].append({"match": {"title": query}})
     if facets_values:
         for facet_field, facet_list_values in facets_values.items():
-            es_body["query"]["bool"]["filter"]["bool"]["must"] = []
+            if "must" not in es_body["query"]["bool"]["filter"]["bool"]:
+                es_body["query"]["bool"]["filter"]["bool"]["must"] = []
             es_body["query"]["bool"]["filter"]["bool"]["must"].append({"bool": {"should": []}})
             for facet_value in facet_list_values:
                 es_body["query"]["bool"]["filter"]["bool"]["must"][-1]["bool"]["should"].append({"term": {}})

--- a/pgsync_schema.json
+++ b/pgsync_schema.json
@@ -75,7 +75,7 @@
             "table": "reference",
             "columns": [
                 "curie", "title", "resource_id", "volume", "date_published", "page_range", "abstract", "keywords", "publisher"
-                , "pubmed_types", "issue_name"
+                , "pubmed_types", "issue_name", "category", "pubmed_publication_status"
             ],
             "transform": {
                 "mapping": {
@@ -168,12 +168,32 @@
                                 "ignore_above": 256
                             }
                         }
+                    },
+                    "category": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
+                            }
+                        }
+                    },
+                    "pubmed_publication_status": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "normalizer": "sortNormalizer",
+                                "ignore_above": 256
+                            }
+                        }
                     }
                 }
             },
             "children":[
                 {
-                    "table": "authors",
+                    "table": "author",
                     "columns": [
                         "orcid", "first_author", "corresponding_author", "affiliations", "first_name", "last_name"
                     ],
@@ -231,7 +251,7 @@
                     }
                 },
                 {
-                    "table": "resources",
+                    "table": "resource",
                     "columns":[
                        "title", "title_synonyms", "iso_abbreviation", "medline_abbreviation", "publisher", "volumes"
                        ,"abstract", "summary"


### PR DESCRIPTION
- Updated pgsync with singular table names
- Added missing facet fields to pgsync
- Added fields as aggregations in search crud es query
- Fixed bug in es query - was overwriting array of "must" clause for each facet, now initializing it to an empty list only fir the first facet and then append to it