### PR TITLE
Scrum 1568

### DIFF
--- a/agr_literature_service/lit_processing/get_dqm_data.py
+++ b/agr_literature_service/lit_processing/get_dqm_data.py
@@ -1,4 +1,5 @@
 
+import sys
 import gzip
 import hashlib
 import io
@@ -17,9 +18,11 @@ load_dotenv()
 # pipenv run python get_dqm_data.py
 
 
-log_file_path = path.join(path.dirname(path.abspath(__file__)), '../../logging.conf')
-logging.config.fileConfig(log_file_path)
-logger = logging.getLogger('literature logger')
+logging.basicConfig(level=logging.INFO,
+                    stream=sys.stdout,
+                    format= '%(asctime)s - %(levelname)s - {%(module)s %(funcName)s:%(lineno)d} - %(message)s',    # noqa E251
+                    datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger(__name__)
 
 base_path = environ.get('XML_PATH', "")
 storage_path = base_path + 'dqm_data/'

--- a/agr_literature_service/lit_processing/get_dqm_data.py
+++ b/agr_literature_service/lit_processing/get_dqm_data.py
@@ -61,13 +61,13 @@ def download_dqm_json():
     if not path.exists(storage_path):
         makedirs(storage_path)
 
-    mods = ['SGD', 'RGD', 'FB', 'WB', 'MGI', 'ZFIN']
+    mods = ['SGD', 'RGD', 'FB', 'XB', 'WB', 'MGI', 'ZFIN']
     datatypes = ['REFERENCE', 'REF-EXCHANGE', 'RESOURCE']
-#     mods = ['WB']
+#     mods = ['XB']
 #     datatypes = ['RESOURCE']
 #     mods = ['WB', 'FB']
 #     datatypes = ['REFERENCE']
-    release = '5.2.0'
+    release = '5.2.1'
     for datatype in datatypes:
         for mod in mods:
             url = 'https://fms.alliancegenome.org/api/datafile/by/' + release + '/' + datatype + '/' + mod + '?latest=true'

--- a/agr_literature_service/lit_processing/parse_dqm_json_reference.py
+++ b/agr_literature_service/lit_processing/parse_dqm_json_reference.py
@@ -61,8 +61,8 @@ def generate_pmid_data(input_path, output_directory, input_mod):      # noqa: C9
     logger.info("generating pmid sets from dqm data")
 
     # RGD should be first in mods list.  if conflicting allianceCategories the later mod gets priority
-    mods = ['RGD', 'MGI', 'SGD', 'FB', 'ZFIN', 'WB']
-    # mods = ['SGD']
+    mods = ['RGD', 'MGI', 'XB', 'SGD', 'FB', 'ZFIN', 'WB']
+    # mods = ['XB']
 
     if input_mod in mods:
         mods = [input_mod]
@@ -260,6 +260,7 @@ def populate_expected_cross_reference_type():
     expected_cross_reference_type.add('ISBN:'.lower())
     expected_cross_reference_type.add('FB:FBrf'.lower())
     expected_cross_reference_type.add('ZFIN:ZDB-PUB-'.lower())
+    expected_cross_reference_type.add('Xenbase:XB-ART-'.lower())
 
     # when getting pubmed data and merging mod cross references, was excluding these types, but
     # now merging so long as the type does not already exist from pubmed (mods have DOIs not in PubMed)
@@ -274,6 +275,7 @@ def populate_expected_cross_reference_type():
     exclude_cross_reference_type.add('WB:WBTransgene'.lower())
     exclude_cross_reference_type.add('WB:WBGene'.lower())
     exclude_cross_reference_type.add('WB:WBVar'.lower())
+    exclude_cross_reference_type.add('Xenbase:XB-GENEPAGE-'.lower())
 
     return expected_cross_reference_type, exclude_cross_reference_type, pubmed_not_dqm_cross_reference_type
 
@@ -439,7 +441,7 @@ def aggregate_dqm_with_pubmed(input_path, input_mod, output_directory):      # n
     # mods = ['SGD', 'RGD', 'FB', 'WB', 'MGI', 'ZFIN']
     # RGD should be first in mods list.  if conflicting allianceCategories the later mod gets priority
     # mods = ['RGD', 'SGD', 'FB', 'MGI', 'ZFIN', 'WB']
-    mods = ['RGD', 'MGI', 'SGD', 'FB', 'ZFIN', 'WB']
+    mods = ['RGD', 'MGI', 'SGD', 'FB', 'ZFIN', 'WB', 'XB']
     if input_mod in mods:
         mods = [input_mod]
 
@@ -561,10 +563,8 @@ def aggregate_dqm_with_pubmed(input_path, input_mod, output_directory):      # n
                 expected_cross_references = []
                 dqm_xrefs = dict()
                 for cross_reference in entry['crossReferences']:
+
                     prefix, identifier, separator = split_identifier(cross_reference["id"])
-                    if prefix not in dqm_xrefs:
-                        dqm_xrefs[prefix] = set()
-                    dqm_xrefs[prefix].add(identifier)
                     if 'pages' in cross_reference:
                         if len(cross_reference["pages"]) > 1:
                             fh_mod_report[mod].write("mod %s primaryId %s has cross reference identifier %s with multiple web pages %s\n" % (mod, primary_id, cross_reference["id"], cross_reference["pages"]))
@@ -583,6 +583,7 @@ def aggregate_dqm_with_pubmed(input_path, input_mod, output_directory):      # n
                             # logger.debug("mod %s primaryId %s has cross reference %s without pages", mod, primary_id, cross_reference["id"])
 
                     id = cross_reference['id']
+
                     cross_ref_type_group = re.search(r"^([^0-9]+)[0-9]", id)
                     if cross_ref_type_group is not None:
                         if cross_ref_type_group[1].lower() not in expected_cross_reference_type:
@@ -592,8 +593,13 @@ def aggregate_dqm_with_pubmed(input_path, input_mod, output_directory):      # n
                                 cross_reference_types[mod][cross_ref_type_group[1]] = [primary_id + ' ' + id]
                             # cross_reference_types[mod].add(cross_ref_type_group[1])
                         if cross_ref_type_group[1].lower() not in exclude_cross_reference_type:
+                            if prefix not in dqm_xrefs:
+                                dqm_xrefs[prefix] = set()
+                            dqm_xrefs[prefix].add(identifier)
+#                             logger.info(f"xref id {id} not in exclude_cross_reference_type")
                             expected_cross_references.append(cross_reference)
                 entry['crossReferences'] = expected_cross_references
+#                 logger.info(f"expected {expected_cross_references}")
                 for prefix in dqm_xrefs:
                     if len(dqm_xrefs[prefix]) > 1:
                         too_many_xref_per_type_failure = True

--- a/agr_literature_service/lit_processing/post_reference_to_api.py
+++ b/agr_literature_service/lit_processing/post_reference_to_api.py
@@ -90,6 +90,7 @@ def post_references(input_file, check_file_flag):      # noqa: C901
     remap_keys = dict()
     remap_keys['datePublished'] = 'date_published'
     remap_keys['dateArrivedInPubmed'] = 'date_arrived_in_pubmed'
+    remap_keys['dateArrivedInPubMed'] = 'date_arrived_in_pubmed'
     remap_keys['dateLastModified'] = 'date_last_modified_in_pubmed'
     remap_keys['crossReferences'] = 'cross_references'
     remap_keys['issueName'] = 'issue_name'
@@ -109,7 +110,7 @@ def post_references(input_file, check_file_flag):      # noqa: C901
 
     subkeys_to_remove['mesh_terms'] = {'referenceId'}
     subkeys_to_remove['tags'] = {'referenceId'}
-    subkeys_to_remove['authors'] = {'referenceId', 'firstinit', 'firstInit', 'crossReferences', 'collectivename'}
+    subkeys_to_remove['authors'] = {'referenceId', 'firstinit', 'firstInit', 'crossReferences', 'collectivename', 'middleNames'}
 
     remap_subkeys['mesh_terms'] = dict()
     remap_subkeys['mesh_terms']['meshHeadingTerm'] = 'heading_term'

--- a/agr_literature_service/lit_processing/sort_dqm_json_reference_updates.py
+++ b/agr_literature_service/lit_processing/sort_dqm_json_reference_updates.py
@@ -206,12 +206,12 @@ def sort_dqm_references(input_path, input_mod):      # noqa: C901
     token = get_authentication_token()
     headers = generate_headers(token)
 
-    mods = ['RGD', 'MGI', 'SGD', 'FB', 'ZFIN', 'WB']
+    mods = ['RGD', 'MGI', 'XB', 'SGD', 'FB', 'ZFIN', 'WB']
     if input_mod in mods:
         mods = [input_mod]
 
     # these tags are allowed from dqms, but we don't want them in the database
-    dqm_keys_to_remove = {'tags', 'issueDate', 'dateLastModified', 'keywords', 'citation'}
+    dqm_keys_to_remove = {'tags', 'issueDate', 'dateArrivedInPubmed', 'dateLastModified', 'keywords', 'citation'}
 
     # to debug, save 9 seconds per run by generating xref mappings only once and load from flatfile
     # generate_cross_references_file('reference')


### PR DESCRIPTION
Mostly adding xenbase and handling their crossReference types.  But also in parse_dqm_json_reference.py moving the logic for tracking dqm_xrefs prefixes and identifier for all xrefs to just valid xref prefixes.  Also account for dateArrivedInPubmed with different casing, and exclude that when coming from DQMs because it should only be populated from PubMed.