### PR TITLE
Scrum 1864 - scripts to simplify alembic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ restart-api:
 	docker-compose --env-file ${ENV_FILE} up -d api
 
 alembic-create-migration:
-	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app alembic revision --autogenerate -m ${ALEMBIC_COMMENT}
-	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app bash -c "find alembic/versions/ -maxdepth 1 -type f | xargs -I {} chmod o+w {}"
+	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app alembic revision --autogenerate -m "${ALEMBIC_COMMENT}"
+	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app bash -c "chmod -R o+w alembic/versions"
 
 alembic-apply-latest-migration:
 	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app alembic upgrade head

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ else
 	ENV_FILE=.env
 endif
 
+ifndef ALEMBIC_COMMENT
+	ALEMBIC_COMMENT=""
+endif
+
+
 login-ecr:
 	docker run -v ~/.aws/credentials:/root/.aws/credentials --rm -it amazon/aws-cli ecr get-login-password | docker login --username AWS --password-stdin ${REG}
 
@@ -98,4 +103,11 @@ restart-api:
 	docker-compose --env-file ${ENV_FILE} build --no-cache api
 	docker-compose --env-file ${ENV_FILE} rm -s -f api
 	docker-compose --env-file ${ENV_FILE} up -d api
+
+alembic-create-migration:
+	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app alembic revision --autogenerate -m ${ALEMBIC_COMMENT}
+	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app bash -c "find alembic/versions/ -maxdepth 1 -type f | xargs -I {} chmod o+w {}"
+
+alembic-apply-latest-migration:
+	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app alembic upgrade head
 


### PR DESCRIPTION
Added two make commands to simplify alembic.

These are the steps to create a new alembic migration script and apply it using the new commands:

1. modify your local alembic.ini file
2. run `make ENV_FILE=.env.test ALEMBIC_COMMENT="comment with whitespaces" alembic-create-migration`
3. check the new migration file generated by alembic under alembic/versions
4. run `make ENV_FILE=.env.test alembic-apply-latest-migration`