### PR TITLE
fix(continuum): tracking inserts with operation type 0 instead of 1

### DIFF
--- a/agr_literature_service/api/database/versioning.py
+++ b/agr_literature_service/api/database/versioning.py
@@ -2,7 +2,12 @@ from sqlalchemy_continuum import make_versioned
 from sqlalchemy_continuum.plugins import PropertyModTrackerPlugin
 from agr_literature_service.api.continuum_plugins import UserPlugin
 
+already_called = False
+
 
 def enable_versioning():
-    user_plugin = UserPlugin()
-    make_versioned(user_cls='UserModel', plugins=[user_plugin, PropertyModTrackerPlugin()])
+    global already_called
+    if not already_called:
+        user_plugin = UserPlugin()
+        make_versioned(user_cls='UserModel', plugins=[user_plugin, PropertyModTrackerPlugin()])
+        already_called = True

--- a/agr_literature_service/api/database/versioning.py
+++ b/agr_literature_service/api/database/versioning.py
@@ -1,13 +1,10 @@
 from sqlalchemy_continuum import make_versioned
 from sqlalchemy_continuum.plugins import PropertyModTrackerPlugin
 from agr_literature_service.api.continuum_plugins import UserPlugin
+from agr_literature_service.api.utils import execute_once
 
-already_called = False
 
-
+@execute_once
 def enable_versioning():
-    global already_called
-    if not already_called:
-        user_plugin = UserPlugin()
-        make_versioned(user_cls='UserModel', plugins=[user_plugin, PropertyModTrackerPlugin()])
-        already_called = True
+    user_plugin = UserPlugin()
+    make_versioned(user_cls='UserModel', plugins=[user_plugin, PropertyModTrackerPlugin()])

--- a/agr_literature_service/api/models/mod_corpus_association_model.py
+++ b/agr_literature_service/api/models/mod_corpus_association_model.py
@@ -11,8 +11,11 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql.sqltypes import Boolean
 
 from agr_literature_service.api.database.base import Base
+from agr_literature_service.api.database.versioning import enable_versioning
 from agr_literature_service.api.models.audited_model import AuditedModel
 from agr_literature_service.api.schemas import ModCorpusSortSourceType
+
+enable_versioning()
 
 
 class ModCorpusAssociationModel(AuditedModel, Base):

--- a/agr_literature_service/api/models/mod_model.py
+++ b/agr_literature_service/api/models/mod_model.py
@@ -9,7 +9,10 @@ from typing import Dict
 from sqlalchemy import Column, Integer, String
 
 from agr_literature_service.api.database.base import Base
+from agr_literature_service.api.database.versioning import enable_versioning
 from agr_literature_service.api.models.audited_model import AuditedModel
+
+enable_versioning()
 
 
 class ModModel(Base, AuditedModel):

--- a/agr_literature_service/api/models/mod_taxon_model.py
+++ b/agr_literature_service/api/models/mod_taxon_model.py
@@ -6,7 +6,10 @@ mod_taxon_model.py
 from typing import Dict
 from sqlalchemy import (Column, Integer, String, ForeignKey)
 from agr_literature_service.api.database.base import Base
+from agr_literature_service.api.database.versioning import enable_versioning
 from agr_literature_service.api.models.audited_model import AuditedModel
+
+enable_versioning()
 
 
 class ModTaxonModel(AuditedModel, Base):

--- a/agr_literature_service/api/models/obsolete_model.py
+++ b/agr_literature_service/api/models/obsolete_model.py
@@ -10,6 +10,9 @@ from typing import Dict
 from sqlalchemy import Column, ForeignKey, Integer, String
 
 from agr_literature_service.api.database.base import Base
+from agr_literature_service.api.database.versioning import enable_versioning
+
+enable_versioning()
 
 
 class ObsoleteReferenceModel(Base):

--- a/agr_literature_service/api/utils.py
+++ b/agr_literature_service/api/utils.py
@@ -1,0 +1,7 @@
+def execute_once(f):
+    def wrapper(*args, **kwargs):
+        if not wrapper.has_run:
+            wrapper.has_run = True
+            return f(*args, **kwargs)
+    wrapper.has_run = False
+    return wrapper


### PR DESCRIPTION
multiple calls to enable_versioning() now result in a single call to make_versioned

- avoids tracking changes multiple times. Calling make_versioned more than once was causing continuum operation types to be always 1 instead of 0 because continuum thought that if the same object is inserted twice in the same transaction there's probably a delete before the last insert and it was tracking the resulting operation as an update
- added call to enable_versioning to all models