### PR TITLE
Dqm loading mrt hotfix - using new mrt table structure for dqm load

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/dqm_ingest/sort_dqm_json_reference_updates.py
+++ b/agr_literature_service/lit_processing/data_ingest/dqm_ingest/sort_dqm_json_reference_updates.py
@@ -766,7 +766,7 @@ def update_db_entries(mod_to_mod_id, dqm_entries, report_fh, processing_flag):  
                 dqm_entry_pubmed_types = []
 
             update_mod_reference_types(db_session, db_entry['reference_id'],
-                                       db_entry.get('mod_reference_type', []),
+                                       db_entry.get('mod_referencetypes', []),
                                        dqm_entry.get('MODReferenceTypes', []),
                                        set(db_entry_pubmed_types) | set(dqm_entry_pubmed_types),
                                        logger)

--- a/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
@@ -233,9 +233,9 @@ def update_mod_reference_types(db_session, reference_id, db_mod_ref_types, json_
     db_mrt_data = {}
     to_delete_duplicate_rows = []
     for mrt in db_mod_ref_types:
-        source = mrt['source']
-        ref_type = mrt['reference_type']
-        mrt_id = mrt['mod_reference_type_id']
+        source = mrt['mod_referencetype']['mod']['abbreviation']
+        ref_type = mrt['mod_referencetype']['referencetype']['label']
+        mrt_id = mrt['reference_mod_referencetype_id']
         if source not in db_mrt_data:
             db_mrt_data[source] = {}
         if ref_type not in db_mrt_data[source]:

--- a/agr_literature_service/lit_processing/utils/db_read_utils.py
+++ b/agr_literature_service/lit_processing/utils/db_read_utils.py
@@ -74,9 +74,9 @@ def get_references_by_curies(db_session, curie_list):
             joinedload(ReferenceModel.mod_referencetypes).subqueryload(
                 ReferenceModReferenceTypeAssociationModel.mod_referencetype).subqueryload(
                 ModReferenceTypeAssociationModel.mod)).options(
-                joinedload(ReferenceModel.mod_referencetypes).subqueryload(
-                    ReferenceModReferenceTypeAssociationModel.mod_referencetype).subqueryload(
-                    ModReferenceTypeAssociationModel.referencetype)).filter(ReferenceModel.curie.in_(curie_list)).all():
+        joinedload(ReferenceModel.mod_referencetypes).subqueryload(
+            ReferenceModReferenceTypeAssociationModel.mod_referencetype).subqueryload(
+            ModReferenceTypeAssociationModel.referencetype)).filter(ReferenceModel.curie.in_(curie_list)).all():
         ref_curie_to_reference[x.curie] = jsonable_encoder(x)
 
     return ref_curie_to_reference

--- a/tests/lit_processing/data_ingest/utils/test_db_write_utils.py
+++ b/tests/lit_processing/data_ingest/utils/test_db_write_utils.py
@@ -99,7 +99,7 @@ class TestDbReadUtils:
             }
         ]
         update_mod_reference_types(db, reference_id,
-                                   db_entry.get('mod_reference_type', []),
+                                   db_entry.get('mod_referencetypes', []),
                                    mod_reference_types, {'Journal'}, logger)
         db.commit()
         mrt_rows = db.query(ReferenceModReferenceTypeAssociationModel).filter_by(reference_id=reference_id).order_by(


### PR DESCRIPTION
- reading data from references using lazy=joined strategy to pre-load all the sub-tables for mod reference types
- pass new mod ref type data structures to dqm load functions