### PR TITLE
Scrum 2274 - new referencefile APIs to upload/delete file + metadata

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -37,6 +37,7 @@ from agr_literature_service.api.crud.topic_entity_tag_crud import (
     create as create_topic_entity_tag
 )
 from agr_literature_service.global_utils import get_next_reference_curie
+from agr_literature_service.api.crud.referencefile_crud import destroy as destroy_referencefile
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +182,8 @@ def destroy(db: Session, curie_or_reference_id: str):
     if not reference:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail=f"Reference with curie or reference_id {curie_or_reference_id} not found")
+    for referencefile in reference.referencefiles:
+        destroy_referencefile(db, str(referencefile.referencefile_id))
     db.delete(reference)
     db.commit()
 

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -73,15 +73,15 @@ def destroy(db: Session, md5sum_or_referencefile_id: str):
 
 
 def file_upload(db: Session, metadata: dict, file: UploadFile):
-    md5sum = hashlib.md5()
+    md5sum_hash = hashlib.md5()
     for byte_block in iter(lambda: file.file.read(4096), b""):
-        md5sum.update(byte_block)
-    md5sum = md5sum.hexdigest()
+        md5sum_hash.update(byte_block)
+    md5sum = md5sum_hash.hexdigest()
     folder = get_s3_folder_from_md5sum(md5sum)
     referencefile = db.query(ReferencefileModel).filter(ReferencefileModel.md5sum == md5sum).one_or_none()
     if referencefile is not None:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT,
-                            detail=f"The provided file and/or its metadata are already present in the system")
+                            detail="The provided file and/or its metadata are already present in the system")
     create_request = ReferencefileSchemaPost(md5sum=md5sum, **metadata)
     create_metadata(db, create_request)
     file.file.seek(0)

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -60,21 +60,21 @@ def remove_file_from_s3(md5sum: str):
                             detail=f"File with md5sum {md5sum} is not available")
 
 
-def destroy(db: Session, md5sum_or_referencefile_id: str, delete_file: bool = False):
+def destroy(db: Session, md5sum_or_referencefile_id: str):
     referencefile = read_referencefile_db_obj_from_md5sum_or_id(db, md5sum_or_referencefile_id)
-    if delete_file:
-        remove_file_from_s3(referencefile.md5sum)
+    remove_file_from_s3(referencefile.md5sum)
     db.delete(referencefile)
     db.commit()
 
 
 def file_upload(db: Session, metadata: dict, file: UploadFile):
-    # TODO: calculate md5sum and gzip file
+    # TODO: calculate md5sum and then gzip file
+    # TODO: create webtest
     md5sum = "random"
     folder = get_s3_folder_from_md5sum(md5sum)
     create_request = ReferencefileSchemaPost(md5sum=md5sum, **metadata)
     create_metadata(db, create_request)
     client = boto3.client('s3')
     upload_file_to_bucket(s3_client=client, file_obj=file.file, bucket="agr-literature", folder=folder,
-                          object_name=md5sum)
+                          object_name=md5sum + ".gz")
     return md5sum

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -91,6 +91,6 @@ def file_upload(db: Session, metadata: dict, file: UploadFile):
     client = boto3.client('s3')
     with open(temp_file_name, 'rb') as gzipped_file:
         upload_file_to_bucket(s3_client=client, file_obj=gzipped_file, bucket="agr-literature", folder=folder,
-                              object_name=md5sum + ".gz")
+                              object_name=md5sum + ".gz", ExtraArgs={'StorageClass': 'GLACIER_IR'})
     os.remove(temp_file_name)
     return md5sum

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -81,7 +81,7 @@ def file_upload(db: Session, metadata: dict, file: UploadFile):
     referencefile = db.query(ReferencefileModel).filter(ReferencefileModel.md5sum == md5sum).one_or_none()
     if referencefile is not None:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT,
-                            detail="The provided file and/or its metadata are already present in the system")
+                            detail="The provided file md5sum is already present in the system")
     create_request = ReferencefileSchemaPost(md5sum=md5sum, **metadata)
     create_metadata(db, create_request)
     file.file.seek(0)

--- a/agr_literature_service/api/crud/referencefile_utils.py
+++ b/agr_literature_service/api/crud/referencefile_utils.py
@@ -1,10 +1,14 @@
 import logging
+from os import environ
 
 from fastapi import HTTPException, status
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
-from agr_literature_service.api.models import ReferencefileModel
+from agr_literature_service.api.models import ReferencefileModel, ReferenceModel
+from agr_literature_service.api.schemas.referencefile_mod_schemas import ReferencefileModSchemaPost
+from agr_literature_service.api.schemas.referencefile_schemas import ReferencefileSchemaPost
+from agr_literature_service.api.crud.referencefile_mod_utils import create as create_referencefile_mod
 
 
 logger = logging.getLogger(__name__)
@@ -22,3 +26,31 @@ def read_referencefile_db_obj_from_md5sum_or_id(db: Session, md5sum_or_reference
                             detail=f"Referencefile with the referencefile_id or md5sum {md5sum_or_referencefile_id} "
                                    f"is not available")
     return referencefile
+
+
+def create(db: Session, request: ReferencefileSchemaPost):
+    request_dict = request.dict()
+    ref_obj = db.query(ReferenceModel).filter(ReferenceModel.curie == request.reference_curie).one_or_none()
+    if ref_obj is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"Reference with curie {request.reference_curie} does not exist")
+    del request_dict["reference_curie"]
+    request_dict["reference_id"] = ref_obj.reference_id
+    mod_abbreviation = request_dict["mod_abbreviation"]
+    del request_dict["mod_abbreviation"]
+    new_ref_file_obj = ReferencefileModel(**request_dict)
+    db.add(new_ref_file_obj)
+    db.commit()
+    create_referencefile_mod(db, ReferencefileModSchemaPost(referencefile_id=new_ref_file_obj.referencefile_id,
+                                                            mod_abbreviation=mod_abbreviation))
+    return new_ref_file_obj.referencefile_id
+
+
+def get_s3_folder_from_md5sum(md5sum: str):
+    if environ.get("ENV_STATE", "test") == "test":
+        folder = "develop"
+    else:
+        folder = "prod"
+    folder += "/reference/documents/"
+    folder += "/".join([char for char in md5sum[0:4]])
+    return folder

--- a/agr_literature_service/api/crud/referencefile_utils.py
+++ b/agr_literature_service/api/crud/referencefile_utils.py
@@ -47,10 +47,13 @@ def create(db: Session, request: ReferencefileSchemaPost):
 
 
 def get_s3_folder_from_md5sum(md5sum: str):
-    if environ.get("ENV_STATE", "test") == "test":
-        folder = "develop"
-    else:
+    env_state = environ.get("ENV_STATE", "")
+    if env_state == "" or env_state == "test":
+        folder = "test"
+    elif env_state == "prod":
         folder = "prod"
+    else:
+        folder = "develop"
     folder += "/reference/documents/"
     folder += "/".join([char for char in md5sum[0:4]])
     return folder

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -46,40 +46,42 @@ def file_upload(reference_curie: str = None,
                 db: Session = db_session):
     """
 
-    Sample usage with curl:
+    Sample usage with curl
 
-    metadata provided as file:
+    - metadata provided as file
 
         metadata file json format:
 
-        {
-            "reference_curie": "AGRKB:101000000000001",
-            "display_name": "test",
-            "file_class": "main",
-            "file_publication_status": "final",
-            "file_extension": "txt",
-            "pdf_type": null,
-            "is_annotation": "false",
-            "mod_abbreviation": "WB"
-        }
+            {
+                "reference_curie": "AGRKB:101000000000001",
+                "display_name": "test",
+                "file_class": "main",
+                "file_publication_status": "final",
+                "file_extension": "txt",
+                "pdf_type": null,
+                "is_annotation": "false",
+                "mod_abbreviation": "WB"
+            }
 
         request:
 
-        curl -X 'POST' 'http://localhost:8080/reference/referencefile/file_upload/' \
-         -H 'accept: application/json' \
-         -H 'Authorization: Bearer <okta_token>' \
-         -H 'Content-Type: multipart/form-data' \
-         -F 'file=@test2.txt;type=text/plain' \
-         -F 'metadata_file=@metadata_file.txt;type=text/plain'
+            curl -X 'POST' 'http://localhost:8080/reference/referencefile/file_upload/' \\
+             -H 'accept: application/json' \\
+             -H 'Authorization: Bearer <okta_token>' \\
+             -H 'Content-Type: multipart/form-data' \\
+             -F 'file=@test2.txt;type=text/plain' \\
+             -F 'metadata_file=@metadata_file.txt;type=text/plain'
 
-    metadata as url parameters:
+    - metadata as url parameters
 
-        curl -X 'POST' 'http://localhost:8080/reference/referencefile/file_upload/?reference_curie=AGRKB:101000000000001&display_name=test&file_class=main&file_publication_status=final&file_extension=txt&pdf_type=null&is_annotation=false' \
-         -H 'accept: application/json' \
-         -H 'Authorization: Bearer <okta_token>' \
-         -H 'Content-Type: multipart/form-data' \
-         -F 'file=@test2.txt;type=text/plain' \
-         -F 'metadata_file='
+        request:
+
+            curl -X 'POST' 'http://localhost:8080/reference/referencefile/file_upload/?reference_curie=AGRKB:101000000000001&display_name=test&file_class=main&file_publication_status=final&file_extension=txt&pdf_type=null&is_annotation=false' \\
+             -H 'accept: application/json' \\
+             -H 'Authorization: Bearer <okta_token>' \\
+             -H 'Content-Type: multipart/form-data' \\
+             -F 'file=@test2.txt;type=text/plain' \\
+             -F 'metadata_file='
 
     """
     if is_annotation is None:

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -61,12 +61,12 @@ def file_upload(reference_curie: str = None,
     return referencefile_crud.file_upload(db, metadata, file)
 
 
-@router.post('/file_delete/{md5sum}')
+@router.delete('/file_delete/{md5sum}')
 def file_delete(md5sum: str,
                 user: OktaUser = db_user,
                 db: Session = db_session):
     set_global_user_from_okta(db, user)
-    return referencefile_crud.destroy(db, md5sum, delete_file=True)
+    return referencefile_crud.destroy(db, md5sum)
 
 
 @router.get('/{md5sum_or_referencefile_id}',
@@ -86,12 +86,3 @@ def patch(md5sum_or_referencefile_id: str,
           db: Session = db_session):
     set_global_user_from_okta(db, user)
     return referencefile_crud.patch(db, md5sum_or_referencefile_id, request.dict(exclude_unset=True))
-
-
-@router.delete('/{md5sum_or_referencefile_id}',
-               status_code=status.HTTP_204_NO_CONTENT)
-def destroy(md5sum_or_referencefile_id: str,
-            user: OktaUser = db_user,
-            db: Session = db_session):
-    set_global_user_from_okta(db, user)
-    referencefile_crud.destroy(db, md5sum_or_referencefile_id)

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -3,7 +3,7 @@ import logging
 from json import JSONDecodeError
 from typing import Union
 
-from fastapi import APIRouter, Depends, Security, status, File, UploadFile, HTTPException
+from fastapi import APIRouter, Depends, Security, status, File, UploadFile, HTTPException, Response
 from fastapi_okta import OktaUser
 from sqlalchemy.orm import Session
 
@@ -70,12 +70,14 @@ def file_upload(reference_curie: str = None,
     return referencefile_crud.file_upload(db, metadata, file)
 
 
-@router.delete('/file_delete/{md5sum}')
+@router.delete('/file_delete/{md5sum}',
+               status_code=status.HTTP_204_NO_CONTENT)
 def file_delete(md5sum: str,
                 user: OktaUser = db_user,
                 db: Session = db_session):
     set_global_user_from_okta(db, user)
-    return referencefile_crud.destroy(db, md5sum)
+    referencefile_crud.destroy(db, md5sum)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.get('/{md5sum_or_referencefile_id}',

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -38,12 +38,52 @@ def file_upload(reference_curie: str = None,
                 file_publication_status: str = None,
                 file_extension: str = None,
                 pdf_type: str = None,
-                is_annotation: bool = False,
+                is_annotation: bool = None,
                 mod_abbreviation: str = None,
                 file: UploadFile = File(...),  # noqa: B008
                 metadata_file: Union[UploadFile, None] = File(default=None),  # noqa: B008
                 user: OktaUser = db_user,
                 db: Session = db_session):
+    """
+
+    Sample usage with curl:
+
+    metadata provided as file:
+
+        metadata file json format:
+
+        {
+            "reference_curie": "AGRKB:101000000000001",
+            "display_name": "test",
+            "file_class": "main",
+            "file_publication_status": "final",
+            "file_extension": "txt",
+            "pdf_type": null,
+            "is_annotation": "false",
+            "mod_abbreviation": "WB"
+        }
+
+        request:
+
+        curl -X 'POST' 'http://localhost:8080/reference/referencefile/file_upload/' \
+         -H 'accept: application/json' \
+         -H 'Authorization: Bearer <okta_token>' \
+         -H 'Content-Type: multipart/form-data' \
+         -F 'file=@test2.txt;type=text/plain' \
+         -F 'metadata_file=@metadata_file.txt;type=text/plain'
+
+    metadata as url parameters:
+
+        curl -X 'POST' 'http://localhost:8080/reference/referencefile/file_upload/?reference_curie=test&display_name=test&file_class=test&file_publication_status=test&file_extension=test&pdf_type=test&is_annotation=false' \
+         -H 'accept: application/json' \
+         -H 'Authorization: Bearer <okta_token>' \
+         -H 'Content-Type: multipart/form-data' \
+         -F 'file=@test2.txt;type=text/plain' \
+         -F 'metadata_file='
+
+    """
+    if is_annotation in None:
+        is_annotation = False
     set_global_user_from_okta(db, user)
     metadata = None
     if reference_curie and display_name and file_class and file_publication_status and file_extension:

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -40,8 +40,8 @@ def file_upload(reference_curie: str = None,
                 pdf_type: str = None,
                 is_annotation: bool = False,
                 mod_abbreviation: str = None,
-                file: UploadFile = File(...),
-                metadata_file: Union[UploadFile, None] = File(default=None),
+                file: UploadFile = File(...),  # noqa: B008
+                metadata_file: Union[UploadFile, None] = File(default=None),  # noqa: B008
                 user: OktaUser = db_user,
                 db: Session = db_session):
     set_global_user_from_okta(db, user)
@@ -61,10 +61,10 @@ def file_upload(reference_curie: str = None,
             metadata = json.load(metadata_file.file)
         except JSONDecodeError:
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                                detail=f"The provided metadata file is not a valid json file")
+                                detail="The provided metadata file is not a valid json file")
     if not reference_curie or not display_name or not file_class or not file_publication_status or not file_extension:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                            detail=f"The provided metadata is not valid")
+                            detail="The provided metadata is not valid")
     return referencefile_crud.file_upload(db, metadata, file)
 
 

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -45,6 +45,7 @@ def file_upload(reference_curie: str = None,
                 user: OktaUser = db_user,
                 db: Session = db_session):
     set_global_user_from_okta(db, user)
+    metadata = None
     if reference_curie and display_name and file_class and file_publication_status and file_extension:
         metadata = {
             "reference_curie": reference_curie,
@@ -56,13 +57,14 @@ def file_upload(reference_curie: str = None,
             "is_annotation": is_annotation,
             "mod_abbreviation": mod_abbreviation
         }
-    else:
+    elif metadata_file is not None:
         try:
             metadata = json.load(metadata_file.file)
         except JSONDecodeError:
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                                 detail="The provided metadata file is not a valid json file")
-    if not reference_curie or not display_name or not file_class or not file_publication_status or not file_extension:
+    if not metadata or not metadata["reference_curie"] or not metadata["display_name"] or not \
+            metadata["file_class"] or not metadata["file_publication_status"] or not metadata["file_extension"]:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                             detail="The provided metadata is not valid")
     return referencefile_crud.file_upload(db, metadata, file)

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -74,7 +74,7 @@ def file_upload(reference_curie: str = None,
 
     metadata as url parameters:
 
-        curl -X 'POST' 'http://localhost:8080/reference/referencefile/file_upload/?reference_curie=test&display_name=test&file_class=test&file_publication_status=test&file_extension=test&pdf_type=test&is_annotation=false' \
+        curl -X 'POST' 'http://localhost:8080/reference/referencefile/file_upload/?reference_curie=AGRKB:101000000000001&display_name=test&file_class=main&file_publication_status=final&file_extension=txt&pdf_type=null&is_annotation=false' \
          -H 'accept: application/json' \
          -H 'Authorization: Bearer <okta_token>' \
          -H 'Content-Type: multipart/form-data' \
@@ -82,7 +82,7 @@ def file_upload(reference_curie: str = None,
          -F 'metadata_file='
 
     """
-    if is_annotation in None:
+    if is_annotation is None:
         is_annotation = False
     set_global_user_from_okta(db, user)
     metadata = None

--- a/agr_literature_service/api/s3/upload.py
+++ b/agr_literature_service/api/s3/upload.py
@@ -1,7 +1,7 @@
 from botocore.exceptions import ClientError
 
 
-def upload_file_to_bucket(s3_client, file_obj, bucket, folder, object_name=None):
+def upload_file_to_bucket(s3_client, file_obj, bucket, folder, object_name=None, **kwargs):
     """Upload a file to an S3 bucket
     :param file_obj: File to upload
     :param bucket: Bucket to upload to
@@ -15,7 +15,7 @@ def upload_file_to_bucket(s3_client, file_obj, bucket, folder, object_name=None)
 
     # Upload the file
     try:
-        s3_client.upload_fileobj(file_obj, bucket, f"{folder}/{object_name}")
+        s3_client.upload_fileobj(file_obj, bucket, f"{folder}/{object_name}", **kwargs)
     except ClientError as e:
         print(e)
         return False

--- a/tests/api/test_referencefile.py
+++ b/tests/api/test_referencefile.py
@@ -1,6 +1,3 @@
-from collections import namedtuple
-from tempfile import TemporaryFile
-
 import pytest
 from starlette.testclient import TestClient
 

--- a/tests/api/test_referencefile.py
+++ b/tests/api/test_referencefile.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from tempfile import TemporaryFile
 
 import pytest
 from starlette.testclient import TestClient
@@ -7,40 +8,34 @@ from agr_literature_service.api.main import app
 from fastapi import status
 
 from agr_literature_service.api.models import ReferencefileModel
+from agr_literature_service.api.schemas.referencefile_schemas import ReferencefileSchemaPost
 from agr_literature_service.lit_processing.tests.mod_populate_load import populate_test_mods
 from .test_reference import test_reference # noqa
 from ..fixtures import db # noqa
 from .fixtures import auth_headers # noqa
-
-
-TestReferencefileData = namedtuple('TestReferencefileData', ['response', 'new_referencefile_id'])
+from agr_literature_service.api.crud.referencefile_utils import create as create_metadata
 
 
 @pytest.fixture
 def test_referencefile(db, auth_headers, test_reference): # noqa
     print("***** Adding a test referencefile *****")
-    with TestClient(app) as client:
-        new_referencefile = {
-            "display_name": "Bob",
-            "reference_curie": test_reference.new_ref_curie,
-            "file_class": "main",
-            "file_publication_status": "final",
-            "file_extension": "pdf",
-            "pdf_type": "pdf",
-            "md5sum": "1234567890"
-        }
-        response = client.post(url="/reference/referencefile/", json=new_referencefile, headers=auth_headers)
-        yield TestReferencefileData(response, response.json())
+    new_referencefile = {
+        "display_name": "Bob",
+        "reference_curie": test_reference.new_ref_curie,
+        "file_class": "main",
+        "file_publication_status": "final",
+        "file_extension": "pdf",
+        "pdf_type": "pdf",
+        "md5sum": "1234567890"
+    }
+    yield create_metadata(db, ReferencefileSchemaPost(**new_referencefile))
 
 
-class TestReferencefile():
-
-    def test_create_referencefile(self, test_referencefile): # noqa
-        assert test_referencefile.response.status_code == status.HTTP_201_CREATED
+class TestReferencefile:
 
     def test_show_referencefile(self, test_referencefile):
         with TestClient(app) as client:
-            response = client.get(url=f"/reference/referencefile/{test_referencefile.new_referencefile_id}")
+            response = client.get(url=f"/reference/referencefile/{test_referencefile}")
             assert response.status_code == status.HTTP_200_OK
             response2 = client.get(url="/reference/referencefile/1234567890")
             assert response2.status_code == status.HTTP_200_OK
@@ -50,38 +45,31 @@ class TestReferencefile():
             "display_name": "Bob2"
         }
         with TestClient(app) as client:
-            response = client.patch(url=f"/reference/referencefile/{test_referencefile.new_referencefile_id}",
+            response = client.patch(url=f"/reference/referencefile/{test_referencefile}",
                                     json=patch_referencefile, headers=auth_headers)
             assert response.status_code == status.HTTP_202_ACCEPTED
-            response = client.get(url=f"/reference/referencefile/{test_referencefile.new_referencefile_id}")
+            response = client.get(url=f"/reference/referencefile/{test_referencefile}")
             assert response.json()["display_name"] == patch_referencefile["display_name"]
             ref_file_obj = db.query(ReferencefileModel).filter(
-                ReferencefileModel.referencefile_id == test_referencefile.new_referencefile_id).one_or_none()
+                ReferencefileModel.referencefile_id == test_referencefile).one_or_none()
             assert ref_file_obj.display_name == patch_referencefile["display_name"]
 
-    def test_destroy_referencefile(self, test_referencefile, auth_headers): # noqa
-        with TestClient(app) as client:
-            response = client.delete(url=f"/reference/referencefile/{test_referencefile.new_referencefile_id}",
-                                     headers=auth_headers)
-            assert response.status_code == status.HTTP_204_NO_CONTENT
-            response = client.get(url=f"/reference/referencefile/{test_referencefile.new_referencefile_id}")
-            assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_show_reference_referencefiles(self, db, test_referencefile): # noqa
         with TestClient(app) as client:
-            response_file = client.get(url=f"/reference/referencefile/{test_referencefile.new_referencefile_id}")
+            response_file = client.get(url=f"/reference/referencefile/{test_referencefile}")
             response_ref = client.get(url=f"/reference/{response_file.json()['reference_curie']}")
             assert "referencefiles" in response_ref.json()
             assert response_ref.json()["referencefiles"][0]["display_name"] == "Bob"
 
     def test_delete_reference_cascade(self, test_referencefile, auth_headers): # noqa
         with TestClient(app) as client:
-            response_file = client.get(url=f"/reference/referencefile/{test_referencefile.new_referencefile_id}")
+            response_file = client.get(url=f"/reference/referencefile/{test_referencefile}")
             client.delete(url=f"/reference/{response_file.json()['reference_curie']}", headers=auth_headers)
-            response_file = client.get(url=f"/reference/referencefile/{test_referencefile.new_referencefile_id}")
+            response_file = client.get(url=f"/reference/referencefile/{test_referencefile}")
             assert response_file.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_create_referencefile_with_mod(self, test_reference, auth_headers): # noqa
+    def test_create_referencefile_with_mod(self, db, test_reference, auth_headers): # noqa
         populate_test_mods()
         new_referencefile = {
             "display_name": "Bob",
@@ -93,14 +81,13 @@ class TestReferencefile():
             "md5sum": "1234567890",
             "mod_abbreviation": "WB"
         }
+        new_referencefile_id = create_metadata(db, ReferencefileSchemaPost(**new_referencefile))
         with TestClient(app) as client:
-            response = client.post(url="/reference/referencefile/", json=new_referencefile, headers=auth_headers)
-            assert response.status_code == status.HTTP_201_CREATED
-            response_file = client.get(url=f"/reference/referencefile/{response.json()}")
+            response_file = client.get(url=f"/reference/referencefile/{new_referencefile_id}")
             assert response_file.status_code == status.HTTP_200_OK
             assert response_file.json()["referencefile_mods"][0]["mod_abbreviation"] == "WB"
 
-    def test_create_referencefile_pmc(self, test_reference, auth_headers):  # noqa
+    def test_create_referencefile_pmc(self, db, test_reference, auth_headers):  # noqa
         populate_test_mods()
         new_referencefile = {
             "display_name": "Bob",
@@ -112,14 +99,13 @@ class TestReferencefile():
             "md5sum": "1234567890",
             "mod_abbreviation": None
         }
+        new_referencefile_id = create_metadata(db, ReferencefileSchemaPost(**new_referencefile))
         with TestClient(app) as client:
-            response = client.post(url="/reference/referencefile/", json=new_referencefile, headers=auth_headers)
-            assert response.status_code == status.HTTP_201_CREATED
-            response_file = client.get(url=f"/reference/referencefile/{response.json()}")
+            response_file = client.get(url=f"/reference/referencefile/{new_referencefile_id}")
             assert response_file.status_code == status.HTTP_200_OK
             assert response_file.json()["referencefile_mods"][0]["mod_abbreviation"] is None
 
-    def test_create_referencefile_annotation(self, test_reference, auth_headers):  # noqa
+    def test_create_referencefile_annotation(self, db, test_reference, auth_headers):  # noqa
         populate_test_mods()
         new_referencefile = {
             "display_name": "Bob",
@@ -132,14 +118,13 @@ class TestReferencefile():
             "mod_abbreviation": "WB",
             "is_annotation": True
         }
+        new_referencefile_id = create_metadata(db, ReferencefileSchemaPost(**new_referencefile))
         with TestClient(app) as client:
-            response = client.post(url="/reference/referencefile/", json=new_referencefile, headers=auth_headers)
-            assert response.status_code == status.HTTP_201_CREATED
-            response_file = client.get(url=f"/reference/referencefile/{response.json()}")
+            response_file = client.get(url=f"/reference/referencefile/{new_referencefile_id}")
             assert response_file.status_code == status.HTTP_200_OK
             assert response_file.json()["is_annotation"] is True
 
-    def test_create_referencefile_pdf_type(self, test_reference, auth_headers):  # noqa
+    def test_create_referencefile_pdf_type(self, db, test_reference, auth_headers):  # noqa
         populate_test_mods()
         new_referencefile = {
             "display_name": "Bob",
@@ -151,10 +136,9 @@ class TestReferencefile():
             "md5sum": "1234567890",
             "mod_abbreviation": "WB"
         }
+        new_referencefile_id = create_metadata(db, ReferencefileSchemaPost(**new_referencefile))
         with TestClient(app) as client:
-            response = client.post(url="/reference/referencefile/", json=new_referencefile, headers=auth_headers)
-            assert response.status_code == status.HTTP_201_CREATED
-            response_file = client.get(url=f"/reference/referencefile/{response.json()}")
+            response_file = client.get(url=f"/reference/referencefile/{new_referencefile_id}")
             assert response_file.status_code == status.HTTP_200_OK
             assert response_file.json()["pdf_type"] is None
             response_ref = client.get(url=f"/reference/{test_reference.new_ref_curie}")

--- a/tests/api/test_referencefile_mod.py
+++ b/tests/api/test_referencefile_mod.py
@@ -22,7 +22,7 @@ def test_referencefile_mod(db, auth_headers, test_referencefile): # noqa
     populate_test_mods()
     with TestClient(app) as client:
         new_referencefile_mod = {
-            "referencefile_id": int(test_referencefile.new_referencefile_id),
+            "referencefile_id": int(test_referencefile),
             "mod_abbreviation": "WB"
         }
         response = client.post(url="/reference/referencefile_mod/", json=new_referencefile_mod, headers=auth_headers)


### PR DESCRIPTION
- removed direct access to metadata create and destroy from API and updated tests
- added endpoints to create metadata and upload file at the same time (file_upload) and to destroy file and metadata (file_delete)
- file_upload calculates md5sum and gzip file before uploading to s3