### PR TITLE
Scrum 2634 - removed default joined loads from reference model

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -260,7 +260,8 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
     :param http_request:
     :return:
     """
-    reference = get_reference(db, curie_or_reference_id, load_authors=True, load_mod_corpus_associations=True)
+    reference = get_reference(db, curie_or_reference_id, load_authors=True, load_mod_corpus_associations=True,
+                              load_mesh_terms=True, load_obsolete_references=True)
     reference_data = jsonable_encoder(reference)
     if reference.resource_id:
         reference_data["resource_curie"] = \

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -260,7 +260,7 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
     :param http_request:
     :return:
     """
-    reference = get_reference(db, curie_or_reference_id)
+    reference = get_reference(db, curie_or_reference_id, load_authors=True, load_mod_corpus_associations=True)
     reference_data = jsonable_encoder(reference)
     if reference.resource_id:
         reference_data["resource_curie"] = \

--- a/agr_literature_service/api/crud/reference_utils.py
+++ b/agr_literature_service/api/crud/reference_utils.py
@@ -1,7 +1,7 @@
 import logging
 
 from sqlalchemy import or_
-from sqlalchemy.orm import Session, subqueryload, joinedload, Load
+from sqlalchemy.orm import Session, Load
 from fastapi import HTTPException, status
 
 from agr_literature_service.api.models import ReferenceModel, ObsoleteReferenceModel, ReferencefileModel

--- a/agr_literature_service/api/crud/reference_utils.py
+++ b/agr_literature_service/api/crud/reference_utils.py
@@ -1,7 +1,7 @@
 import logging
 
 from sqlalchemy import or_
-from sqlalchemy.orm import Session, subqueryload, joinedload
+from sqlalchemy.orm import Session, subqueryload, joinedload, Load
 from fastapi import HTTPException, status
 
 from agr_literature_service.api.models import ReferenceModel, ObsoleteReferenceModel, ReferencefileModel
@@ -32,18 +32,27 @@ def get_merged(db: Session, curie):
 
 
 def get_reference(db: Session, curie_or_reference_id: str, load_referencefiles: bool = False,
-                  load_authors: bool = False, load_mod_corpus_associations: bool = False):
+                  load_authors: bool = False, load_mod_corpus_associations: bool = False,
+                  load_mesh_terms: bool = False, load_obsolete_references: bool = False):
     reference_id = int(curie_or_reference_id) if curie_or_reference_id.isdigit() else None
     reference = None
     try:
         query = db.query(ReferenceModel)
-        if load_referencefiles:
-            query = query.options(subqueryload(ReferenceModel.referencefiles).subqueryload(
-                ReferencefileModel.referencefile_mods))
-        if load_authors:
-            query = query.options(joinedload(ReferenceModel.author))
-        if load_mod_corpus_associations:
-            query = query.options(joinedload(ReferenceModel.mod_corpus_association))
+        if load_referencefiles or load_authors or load_mod_corpus_associations or load_mesh_terms or \
+                load_obsolete_references:
+            options = Load(ReferenceModel)
+            if load_referencefiles:
+                options.subqueryload(ReferenceModel.referencefiles).subqueryload(
+                    ReferencefileModel.referencefile_mods)
+            if load_authors:
+                options.joinedload(ReferenceModel.author)
+            if load_mod_corpus_associations:
+                options.joinedload(ReferenceModel.mod_corpus_association)
+            if load_mesh_terms:
+                options.joinedload(ReferenceModel.mesh_term)
+            if load_obsolete_references:
+                options.joinedload(ReferenceModel.obsolete_reference)
+            query = query.options(options)
         reference = query.filter(or_(ReferenceModel.curie == curie_or_reference_id,
                                      ReferenceModel.reference_id == reference_id)).one()
     except Exception:

--- a/agr_literature_service/api/models/reference_model.py
+++ b/agr_literature_service/api/models/reference_model.py
@@ -58,8 +58,7 @@ class ReferenceModel(Base, AuditedModel):
 
     obsolete_reference = relationship(
         "ObsoleteReferenceModel",
-        foreign_keys="ObsoleteReferenceModel.new_id",
-        lazy="joined"
+        foreign_keys="ObsoleteReferenceModel.new_id"
     )
 
     resource_id = Column(
@@ -199,7 +198,6 @@ class ReferenceModel(Base, AuditedModel):
 
     mesh_term = relationship(
         "MeshDetailModel",
-        lazy="joined",
         back_populates="reference",
         cascade="all, delete, delete-orphan"
     )

--- a/agr_literature_service/api/models/reference_model.py
+++ b/agr_literature_service/api/models/reference_model.py
@@ -91,14 +91,12 @@ class ReferenceModel(Base, AuditedModel):
 
     mod_corpus_association = relationship(
         "ModCorpusAssociationModel",
-        lazy="joined",
         back_populates="reference",
         cascade="all, delete, delete-orphan"
     )
 
     author = relationship(
         "AuthorModel",
-        lazy="joined",
         back_populates="reference",
         cascade="all, delete, delete-orphan"
     )


### PR DESCRIPTION
this allows us to use a generic get_reference function that is now much faster and easier to use in other places than the main reference api endpoint to get a reference object by curie or id without necessarily loading all the related data (authors etc) by default