### PR TITLE
one-off script to remove the trailing timestamp for date_published_start and date_published_end

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/dqm_ingest/sort_dqm_json_reference_updates.py
+++ b/agr_literature_service/lit_processing/data_ingest/dqm_ingest/sort_dqm_json_reference_updates.py
@@ -784,8 +784,8 @@ def update_db_entries(mod_to_mod_id, dqm_entries, report_fh, processing_flag):  
                         date_range, error_message = parse_date(datePublished.strip(), False)
                         if date_range is not False:
                             (datePublishedStart, datePublishedEnd) = date_range
-                            dqm_entry['datePublishedStart'] = datePublishedStart
-                            dqm_entry['datePublishedEnd'] = datePublishedEnd
+                            dqm_entry['datePublishedStart'] = str(datePublishedStart)[0:10]
+                            dqm_entry['datePublishedEnd'] = str(datePublishedEnd)[0:10]
                     field_snake = field_camel
                     if field_camel in remap_keys:
                         field_snake = remap_keys[field_camel]

--- a/agr_literature_service/lit_processing/data_ingest/post_reference_to_db.py
+++ b/agr_literature_service/lit_processing/data_ingest/post_reference_to_db.py
@@ -307,6 +307,9 @@ def insert_reference(db_session, primaryId, journal_to_resource_id, entry):
             if date_range is not False:
                 (date_published_start, date_published_end) = date_range
 
+        date_published_start = str(date_published_start)[0:10]
+        date_published_end = str(date_published_end)[0:10]
+
         refData = {"curie": curie,
                    "resource_id": resource_id,
                    "title": entry.get('title', ''),

--- a/agr_literature_service/lit_processing/oneoff_scripts/fix_date_published_start_end.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/fix_date_published_start_end.py
@@ -1,0 +1,51 @@
+import logging
+
+from agr_literature_service.lit_processing.utils.sqlalchemy_utils import create_postgres_session
+# from agr_literature_service.api.models import ReferenceModel
+
+logging.basicConfig(format='%(message)s')
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def update_date_published_start_end():
+
+    db_session = create_postgres_session(False)
+
+    limit = 5000
+    loop_count = 200
+    row_count = 0
+    for index in range(loop_count):
+        offset = index * limit
+        rows = db_session.execute(f"SELECT reference_id, date_published_start, date_published_end "
+                                  f"FROM reference "
+                                  f"ORDER BY reference_id limit {limit} "
+                                  f"offset {offset}").fetchall()
+        if len(rows) == 0:
+            break
+        for x in rows:
+            reference_id = x[0]
+            date_published_start = x[1]
+            date_published_end = x[2]
+            if not date_published_start or len(date_published_start) <= 10:
+                continue
+
+            row_count += 1
+            try:
+                db_session.execute(f"UPDATE reference "
+                                   f"set date_published_start = '{date_published_start[0:10]}', "
+                                   f"date_published_end = '{date_published_end[0:10]}' "
+                                   f"WHERE reference_id = {reference_id}")
+                if row_count % 300 == 0:
+                    db_session.commit()
+                logger.info("UPDATE date_published_start and date_published_end for reference_id = " + str(reference_id))
+            except Exception as e:
+                logger.info("An error occurred when updatng date_published_start and date_published_end for reference_id = " + str(reference_id) + ". error " + str(e))
+
+    db_session.commit()
+    db_session.close()
+
+
+if __name__ == "__main__":
+
+    update_date_published_start_end()


### PR DESCRIPTION
also fixed the dqm loading and reference loading module to handle these two dates properly.