### PR TITLE
fixed reference api to return data even with an invalid XREF ID

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -288,8 +288,10 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
         for x in cross_references:
             pieces = x['curie'].split(":")
             if len(pieces) > 2 and pieces[0] != 'DOI':
+                ## will pick up something like 'FB:FB:FBrf0221304'
                 bad_cross_ref_ids.append(x['curie'])
-            elif len(pieces) == 1:
+            elif pieces[1] == "":
+                ## will pick up something like 'FB:'
                 bad_cross_ref_ids.append(x['curie'])
     reference_data["bad_cross_reference_ids"] = bad_cross_ref_ids
 

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -293,7 +293,7 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
             elif pieces[1] == "":
                 ## will pick up something like 'FB:'
                 bad_cross_ref_ids.append(x['curie'])
-    reference_data["bad_cross_reference_ids"] = bad_cross_ref_ids
+    reference_data["invalid_cross_reference_ids"] = bad_cross_ref_ids
 
     if reference.mod_referencetypes:
         reference_data["mod_reference_types"] = []

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -277,6 +277,7 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
             reference_data["copyright_license_url"] = crl.url
             reference_data["copyright_license_description"] = crl.description
 
+    bad_cross_ref_ids = []
     if reference.cross_reference:
         cross_references = []
         for cross_reference in reference.cross_reference:
@@ -284,6 +285,13 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
             del cross_reference_show["reference_curie"]
             cross_references.append(cross_reference_show)
         reference_data["cross_references"] = cross_references
+        for x in cross_references:
+            pieces = x['curie'].split(":")
+            if len(pieces) > 2 and pieces[0] != 'DOI':
+                bad_cross_ref_ids.append(x['curie'])
+            elif len(pieces) == 1:
+                bad_cross_ref_ids.append(x['curie'])
+    reference_data["bad_cross_reference_ids"] = bad_cross_ref_ids
 
     if reference.mod_referencetypes:
         reference_data["mod_reference_types"] = []

--- a/agr_literature_service/api/schemas/cross_reference_schemas.py
+++ b/agr_literature_service/api/schemas/cross_reference_schemas.py
@@ -23,7 +23,8 @@ class CrossReferenceSchemaRelated(AuditedObjectModelSchema):
 
     @validator('curie')
     def name_must_contain_space(cls, v):
-        if v.count(":") != 1 and not v.startswith("DOI:"):
+        # if v.count(":") != 1 and not v.startswith("DOI:"):
+        if v.count(":") == 0:
             raise ValueError('must contain a single colon')
         return v
 

--- a/agr_literature_service/api/schemas/reference_schemas.py
+++ b/agr_literature_service/api/schemas/reference_schemas.py
@@ -144,7 +144,7 @@ class ReferenceSchemaShow(AuditedObjectModelSchema):
     copyright_license_name: Optional[str] = None
     copyright_license_url: Optional[str] = None
     copyright_license_description: Optional[str] = None
-    bad_cross_reference_ids: Optional[List[str]] = None
+    invalid_cross_reference_ids: Optional[List[str]] = None
     authors: Optional[List[AuthorSchemaShow]] = None
     comment_and_corrections: CommentAndCorrectionSchemaRelations
     open_access: Optional[bool] = None

--- a/agr_literature_service/api/schemas/reference_schemas.py
+++ b/agr_literature_service/api/schemas/reference_schemas.py
@@ -144,6 +144,7 @@ class ReferenceSchemaShow(AuditedObjectModelSchema):
     copyright_license_name: Optional[str] = None
     copyright_license_url: Optional[str] = None
     copyright_license_description: Optional[str] = None
+    bad_cross_reference_ids: Optional[List[str]] = None
     authors: Optional[List[AuthorSchemaShow]] = None
     comment_and_corrections: CommentAndCorrectionSchemaRelations
     open_access: Optional[bool] = None


### PR DESCRIPTION
and also return a new field 'invalid_cross_reference_ids' (a list of invalid id(s) or an empty list) 