### PR TITLE
Scrum 2716 fixed loading strategies for reference query in script to subset db

### DIFF
--- a/agr_literature_service/lit_processing/oneoff_scripts/make_subset_db/make_subset.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/make_subset_db/make_subset.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, joinedload
 from os import environ
 
 from agr_literature_service.api.models import (
@@ -92,7 +92,7 @@ def start():
     db_subset_session.commit()
     db_subset_session.close()
 
-    refs = db_orig_session.query(ReferenceModel).filter(ReferenceModel.reference_id <= num_of_ref)
+    refs = db_orig_session.query(ReferenceModel).options(joinedload("*")).filter(ReferenceModel.reference_id <= num_of_ref)
     for ref in refs:
         print(f"Adding {ref}")
         db_subset_session.merge(ref)

--- a/agr_literature_service/lit_processing/oneoff_scripts/make_subset_db/make_subset.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/make_subset_db/make_subset.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, joinedload
+from sqlalchemy.orm import sessionmaker, subqueryload
 from os import environ
 
 from agr_literature_service.api.models import (
@@ -7,7 +7,8 @@ from agr_literature_service.api.models import (
     UserModel,
     ReferenceModel,
     ResourceModel,
-    CopyrightLicenseModel
+    CopyrightLicenseModel, ModReferencetypeAssociationModel,
+    ReferencetypeModel
 )
 
 num_of_ref = 2000
@@ -92,7 +93,31 @@ def start():
     db_subset_session.commit()
     db_subset_session.close()
 
-    refs = db_orig_session.query(ReferenceModel).options(joinedload("*")).filter(ReferenceModel.reference_id <= num_of_ref)
+    referencetypes = db_orig_session.query(ReferencetypeModel).all()
+    for referencetype in referencetypes:
+        print(f"Adding {referencetype}")
+        db_subset_session.merge(referencetype)
+    db_subset_session.commit()
+    db_subset_session.close()
+
+    mod_referencetypes = db_orig_session.query(ModReferencetypeAssociationModel).all()
+    for mod_referencetype in mod_referencetypes:
+        print(f"Adding {mod_referencetype}")
+        db_subset_session.merge(mod_referencetype)
+    db_subset_session.commit()
+    db_subset_session.close()
+
+    refs = db_orig_session.query(ReferenceModel).options(
+        subqueryload(ReferenceModel.cross_reference),
+        subqueryload(ReferenceModel.obsolete_reference),
+        subqueryload(ReferenceModel.mod_referencetypes),
+        subqueryload(ReferenceModel.mod_corpus_association),
+        subqueryload(ReferenceModel.mesh_term),
+        subqueryload(ReferenceModel.author),
+        subqueryload(ReferenceModel.referencefiles),
+        subqueryload(ReferenceModel.topic_entity_tags),
+        subqueryload(ReferenceModel.workflow_tag)
+    ).filter(ReferenceModel.reference_id <= num_of_ref)
     for ref in refs:
         print(f"Adding {ref}")
         db_subset_session.merge(ref)


### PR DESCRIPTION
- Added individual loading strategies for each related table that needs to be loaded in the subset
- Using subqueryload makes the query much faster than joins
- Added separate queries for additional data that needs preloading