### PR TITLE
Scrum 1971 - bulk file uploader

### DIFF
--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -147,11 +147,14 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
     if not metadata["reference_curie"].startswith("AGRKB:101"):
         ref_curie_res = db.query(ReferenceModel.curie).filter(
             ReferenceModel.cross_reference.any(CrossReferenceModel.curie == metadata["reference_curie"])).one_or_none()
+        if ref_curie_res is not None:
+            metadata["reference_curie"] = ref_curie_res.curie
+        else:
+            metadata["reference_curie"] = None
         if metadata["reference_curie"] is None:
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                                 detail="The specified curie is not in the standard Alliance format and no cross "
                                        "references match the specified value.")
-        metadata["reference_curie"] = ref_curie_res.curie
     md5sum_hash = hashlib.md5()
     for byte_block in iter(lambda: file.file.read(4096), b""):
         md5sum_hash.update(byte_block)

--- a/file_uploader/upload_files.sh
+++ b/file_uploader/upload_files.sh
@@ -80,7 +80,7 @@ process_file() {
   if [[ ${file_class} == "main" ]]; then
     parse_main_filename
   else
-    reference_id=$(basename $(dirname ${file_path}))
+    reference_id=$(basename $(dirname "${file_path}"))
   fi
   if [[ ${reference_id} =~ ^[0-9]{15}$ ]]; then
     reference_id="AGRKB:${reference_id}"
@@ -100,13 +100,13 @@ for reffileordir in /usr/files_to_upload/*; do
   if [[ -d ${reffileordir} ]]; then
     echo "Processing supplemental files from ${reffileordir}"
     for reffile in ${reffileordir}/*; do
-      if [[ ! -d ${reffile} && $(basename ${reffile}) != "*" ]]; then
+      if [[ ! -d "${reffile}" && $(basename "${reffile}") != "*" ]]; then
         process_file "${reffile}" "supplement"
       else
         echo "Found empty dir or subdir for reference ${reffileordir}"
       fi
     done
   else
-    process_file ${reffileordir} "main"
+    process_file "${reffileordir}" "main"
   fi
 done

--- a/file_uploader/upload_files.sh
+++ b/file_uploader/upload_files.sh
@@ -38,7 +38,7 @@ upload_file () {
   else
     upload_status="error"
   fi
-  if [[ "${response}" == "Expired token" ]]; then
+  if [[ "${response}" == "{\"detail\":\"Expired token\"}" ]]; then
     echo "INFO: Access token expired, requesting a new one"
     generate_access_token
     upload_file

--- a/file_uploader/upload_files.sh
+++ b/file_uploader/upload_files.sh
@@ -104,6 +104,8 @@ process_file() {
   upload_file
 }
 
+generate_access_token
+
 for reffileordir in /usr/files_to_upload/*; do
   if [[ -d ${reffileordir} ]]; then
     echo "Processing supplemental files from ${reffileordir}"

--- a/file_uploader/upload_files.sh
+++ b/file_uploader/upload_files.sh
@@ -39,6 +39,7 @@ upload_file () {
     upload_status="error"
   fi
   if [[ "${response}" == "Expired token" ]]; then
+    echo "INFO: Access token expired, requesting a new one"
     generate_access_token
     upload_file
   else


### PR DESCRIPTION
Tested the bulk uploader on the whole WB corpus. 

Changes to the API:

- Fixed bug in code to read reference from cross reference when curie provided in upload metadata does not start with "AGRKB:101"
-  Overwrite "file_publication_status" and set it to "temp" when a temp file is uploaded and the same file (same md5sum) is already in the system but it's "final". Keep all the other metadata fields as they are in the db
- If the uploaded file has the same display name as a file already in the system associated to the specified reference but the existing file has different content (different md5sum), append an underscore followed by an incremental number to the display name of the uploaded file before storing it in the db, until there are no other files with the same name.

Changes to the file uploader:

- Added quotes to cope with whitespaces in file names
- Added function to generate a new okta token when the one in use expires