### PR TITLE
Scrum 2869 - fix bugs with file upload and deletion

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -27,6 +27,7 @@ from agr_literature_service.api.models import (AuthorModel, CrossReferenceModel,
                                                ResourceModel,
                                                CopyrightLicenseModel,
                                                CitationModel)
+from agr_literature_service.api.routers.okta_utils import OktaAccess
 from agr_literature_service.api.schemas import ReferenceSchemaPost, ModReferenceTypeSchemaRelated
 from agr_literature_service.api.crud.mod_corpus_association_crud import create as create_mod_corpus_association
 from agr_literature_service.api.crud.workflow_tag_crud import (
@@ -185,7 +186,7 @@ def destroy(db: Session, curie_or_reference_id: str):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail=f"Reference with curie or reference_id {curie_or_reference_id} not found")
     for referencefile in reference.referencefiles:
-        destroy_referencefile(db, referencefile.referencefile_id)
+        destroy_referencefile(db, referencefile.referencefile_id, OktaAccess.ALL_ACCESS)
     db.delete(reference)
     db.commit()
 

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -208,9 +208,8 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
         # request may be incompatible with the one in the db. The metadata in the db will not be modified and a new
         # connection between the file and the mod will be created. If the uploaded file is "temp", the file publication
         # status will be updated and set to "temp" even if another MOD uploaded it as "final"
-        if metadata["file_publication_status"] in ["final", "temp"] and referencefile.file_publication_status != \
-                metadata["file_publication_status"]:
-            referencefile.file_publication_status = metadata["file_publication_status"]
+        if metadata["file_publication_status"] == "temp" and referencefile.file_publication_status == "final":
+            referencefile.file_publication_status = "temp"
             db.commit()
         else:
             mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -19,12 +19,12 @@ from starlette.responses import FileResponse
 
 from agr_literature_service.api.crud.reference_utils import get_reference
 from agr_literature_service.api.crud.referencefile_utils import read_referencefile_db_obj, \
-    create as create_metadata, get_s3_folder_from_md5sum
-from agr_literature_service.api.crud.referencefile_mod_utils import create as create_mod_connection
+    get_s3_folder_from_md5sum, remove_from_s3_and_db
+from agr_literature_service.api.crud.referencefile_mod_utils import create as create_mod_connection, \
+    destroy as destroy_mod_association
 from agr_literature_service.api.models import ReferenceModel, ReferencefileModel, ReferencefileModAssociationModel, \
     ModModel, CopyrightLicenseModel, CrossReferenceModel
 from agr_literature_service.api.routers.okta_utils import OktaAccess, OKTA_ACCESS_MOD_ABBR
-from agr_literature_service.api.s3.delete import delete_file_in_bucket
 from agr_literature_service.api.s3.upload import upload_file_to_bucket
 from agr_literature_service.api.schemas.referencefile_mod_schemas import ReferencefileModSchemaPost
 from agr_literature_service.api.schemas.referencefile_schemas import ReferencefileSchemaPost, ReferencefileSchemaRelated
@@ -86,21 +86,14 @@ def patch(db: Session, referencefile_id: int, request):
     return {"message": messageEnum.updated}
 
 
-def remove_file_from_s3(md5sum: str):  # pragma: no cover
-    folder = get_s3_folder_from_md5sum(md5sum)
-    client = boto3.client('s3')
-    if not delete_file_in_bucket(s3_client=client, bucket="agr-literature", folder=folder, object_name=md5sum + ".gz"):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
-                            detail=f"File with md5sum {md5sum} is not available")
-
-
-def destroy(db: Session, referencefile_id: int):
-    referencefile = read_referencefile_db_obj(db, referencefile_id)
-    if len(referencefile.reference.referencefiles) == 1:
-        if os.environ.get("ENV_STATE", "test") != "test":
-            remove_file_from_s3(referencefile.md5sum)
-    db.delete(referencefile)
-    db.commit()
+def destroy(db: Session, referencefile_id: int, mod_access: OktaAccess):
+    referencefile: ReferencefileModel = read_referencefile_db_obj(db, referencefile_id)
+    if mod_access == OktaAccess.ALL_ACCESS:
+        remove_from_s3_and_db(db, referencefile)
+    elif mod_access != OktaAccess.NO_ACCESS:
+        for referencefile_mod in referencefile.referencefile_mods:
+            if referencefile_mod.mod.abbreviation == OKTA_ACCESS_MOD_ABBR[mod_access]:
+                destroy_mod_association(db, referencefile_mod.referencefile_mod_id)
 
 
 def file_paths_in_dir(directory):
@@ -151,11 +144,11 @@ def file_upload(db: Session, metadata: dict, file: UploadFile):  # pragma: no co
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=error_message)
     else:
         file_upload_single(db, metadata, file)
+    mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None
+    cleanup_temp_file(db, metadata["reference_curie"], mod_abbreviation)
 
-    cleanup_temp_file(db, metadata["reference_curie"])
 
-
-def cleanup_temp_file(db: Session, ref_curie: str):  # pragma: no cover
+def cleanup_temp_file(db: Session, ref_curie: str, mod_abbreviation):  # pragma: no cover
     ref = db.query(ReferenceModel).filter_by(curie=ref_curie).one_or_none()
     if ref:
         reffiles = db.query(ReferencefileModel).filter_by(
@@ -169,7 +162,32 @@ def cleanup_temp_file(db: Session, ref_curie: str):  # pragma: no cover
                 if reffile.file_publication_status == 'temp':
                     if None in mod_ids_with_final or all([mod.mod_id in mod_ids_with_final for mod in
                                                           reffile.referencefile_mods]):
-                        destroy(db, reffile.referencefile_id)
+                        destroy(db, reffile.referencefile_id, [okta_access for okta_access, mod_abbr in
+                                                               OKTA_ACCESS_MOD_ABBR.items() if
+                                                               mod_abbr == mod_abbreviation][0])
+
+
+def create_metadata(db: Session, request: ReferencefileSchemaPost):
+    request_dict = request.dict()
+    ref_obj = db.query(ReferenceModel).filter(ReferenceModel.curie == request.reference_curie).one_or_none()
+    if ref_obj is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"Reference with curie {request.reference_curie} does not exist")
+    del request_dict["reference_curie"]
+    request_dict["reference_id"] = ref_obj.reference_id
+    mod_abbreviation = request_dict["mod_abbreviation"]
+    if mod_abbreviation is not None:
+        mod = db.query(ModModel).filter(ModModel.abbreviation == mod_abbreviation).one_or_none()
+        if mod is None:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                detail=f"Mod with abbreviation {request.mod_abbreviation} does not exist")
+    del request_dict["mod_abbreviation"]
+    new_ref_file_obj = ReferencefileModel(**request_dict)
+    db.add(new_ref_file_obj)
+    db.commit()
+    create_mod_connection(db, ReferencefileModSchemaPost(referencefile_id=new_ref_file_obj.referencefile_id,
+                                                         mod_abbreviation=mod_abbreviation))
+    return new_ref_file_obj.referencefile_id
 
 
 def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma: no cover
@@ -190,12 +208,13 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
         # request may be incompatible with the one in the db. The metadata in the db will not be modified and a new
         # connection between the file and the mod will be created. If the uploaded file is "temp", the file publication
         # status will be updated and set to "temp" even if another MOD uploaded it as "final"
-        if metadata["file_publication_status"] == "temp" and referencefile.file_publication_status != "temp":
-            referencefile.file_publication_status = "temp"
-        db.commit()
-        mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None
-        create_mod_connection(db, ReferencefileModSchemaPost(referencefile_id=referencefile.referencefile_id,
-                                                             mod_abbreviation=mod_abbreviation))
+        if metadata["file_publication_status"] == "final" and referencefile.file_publication_status == "temp":
+            referencefile.file_publication_status = "final"
+            db.commit()
+        else:
+            mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None
+            create_mod_connection(db, ReferencefileModSchemaPost(referencefile_id=referencefile.referencefile_id,
+                                                                 mod_abbreviation=mod_abbreviation))
     else:
         # 2 possible cases here: i) an entry with the same md5sum does not exist; ii) same md5sum exists, but it's
         # associated with a different curie (same file content for different files or same files). In both cases we need

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -211,9 +211,8 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
         if metadata["file_publication_status"] == "temp" and referencefile.file_publication_status == "final":
             referencefile.file_publication_status = "temp"
             db.commit()
-        else:
-            mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None
-            create_mod_connection(db, ReferencefileModSchemaPost(referencefile_id=referencefile.referencefile_id,
+        mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None
+        create_mod_connection(db, ReferencefileModSchemaPost(referencefile_id=referencefile.referencefile_id,
                                                                  mod_abbreviation=mod_abbreviation))
     else:
         # 2 possible cases here: i) an entry with the same md5sum does not exist; ii) same md5sum exists, but it's
@@ -236,6 +235,7 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
             metadata["display_name"] = f"{original_name}_{counter}"
         create_request = ReferencefileSchemaPost(md5sum=md5sum, **metadata)
         create_metadata(db, create_request)
+        # TODO: check if md5sum is already in s3 before uploading
         file.file.seek(0)
         temp_file_name = metadata["display_name"] + "." + metadata["file_extension"] + ".gz"
         with gzip.open(temp_file_name, 'wb') as f_out:

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -235,18 +235,20 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
             metadata["display_name"] = f"{original_name}_{counter}"
         create_request = ReferencefileSchemaPost(md5sum=md5sum, **metadata)
         create_metadata(db, create_request)
-        # TODO: check if md5sum is already in s3 before uploading
-        file.file.seek(0)
-        temp_file_name = metadata["display_name"] + "." + metadata["file_extension"] + ".gz"
-        with gzip.open(temp_file_name, 'wb') as f_out:
-            shutil.copyfileobj(file.file, f_out)
-        client = boto3.client('s3')
-        env_state = os.environ.get("ENV_STATE", "")
-        extra_args = {'StorageClass': 'GLACIER_IR'} if env_state == "prod" else {'StorageClass': 'STANDARD'}
-        with open(temp_file_name, 'rb') as gzipped_file:
-            upload_file_to_bucket(s3_client=client, file_obj=gzipped_file, bucket="agr-literature", folder=folder,
-                                  object_name=md5sum + ".gz", ExtraArgs=extra_args)
-        os.remove(temp_file_name)
+        # check if md5sum is the only one in the db before uploading to s3
+        ref_file_by_md5sum_count = db.query(ReferencefileModel).filter(ReferencefileModel.md5sum == md5sum).count()
+        if ref_file_by_md5sum_count == 1:
+            file.file.seek(0)
+            temp_file_name = metadata["display_name"] + "." + metadata["file_extension"] + ".gz"
+            with gzip.open(temp_file_name, 'wb') as f_out:
+                shutil.copyfileobj(file.file, f_out)
+            client = boto3.client('s3')
+            env_state = os.environ.get("ENV_STATE", "")
+            extra_args = {'StorageClass': 'GLACIER_IR'} if env_state == "prod" else {'StorageClass': 'STANDARD'}
+            with open(temp_file_name, 'rb') as gzipped_file:
+                upload_file_to_bucket(s3_client=client, file_obj=gzipped_file, bucket="agr-literature", folder=folder,
+                                      object_name=md5sum + ".gz", ExtraArgs=extra_args)
+            os.remove(temp_file_name)
     return md5sum
 
 

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -208,8 +208,9 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
         # request may be incompatible with the one in the db. The metadata in the db will not be modified and a new
         # connection between the file and the mod will be created. If the uploaded file is "temp", the file publication
         # status will be updated and set to "temp" even if another MOD uploaded it as "final"
-        if metadata["file_publication_status"] == "final" and referencefile.file_publication_status == "temp":
-            referencefile.file_publication_status = "final"
+        if metadata["file_publication_status"] in ["final", "temp"] and referencefile.file_publication_status != \
+                metadata["file_publication_status"]:
+            referencefile.file_publication_status = metadata["file_publication_status"]
             db.commit()
         else:
             mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None

--- a/agr_literature_service/api/crud/referencefile_mod_crud.py
+++ b/agr_literature_service/api/crud/referencefile_mod_crud.py
@@ -8,7 +8,6 @@ from agr_literature_service.api.crud.referencefile_mod_utils import read_referen
 from agr_literature_service.api.crud.referencefile_utils import read_referencefile_db_obj
 from agr_literature_service.api.models import ModModel
 from agr_literature_service.api.schemas.response_message_schemas import messageEnum
-from agr_literature_service.api.crud.referencefile_crud import destroy as destroy_referencefile
 from agr_literature_service.api.crud.referencefile_mod_utils import create
 
 logger = logging.getLogger(__name__)
@@ -41,12 +40,3 @@ def patch(db: Session, referencefile_mod_id: int, request):
             referencefile_mod.mod_id = None
     db.commit()
     return {"message": messageEnum.updated}
-
-
-def destroy(db: Session, referencefile_mod_id: int):
-    referencefile_mod = read_referencefile_mod_obj_from_db(db, referencefile_mod_id)
-    if len(referencefile_mod.referencefile.referencefile_mods) == 1:
-        destroy_referencefile(db, referencefile_mod.referencefile.referencefile_id)
-    else:
-        db.delete(referencefile_mod)
-    db.commit()

--- a/agr_literature_service/api/crud/referencefile_mod_utils.py
+++ b/agr_literature_service/api/crud/referencefile_mod_utils.py
@@ -1,6 +1,7 @@
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
+from agr_literature_service.api.crud.referencefile_utils import remove_from_s3_and_db
 from agr_literature_service.api.models import ReferencefileModAssociationModel, ReferencefileModel, ModModel
 from agr_literature_service.api.schemas.referencefile_mod_schemas import ReferencefileModSchemaPost
 
@@ -40,3 +41,12 @@ def read_referencefile_mod_obj_from_db(db: Session, referencefile_mod_id: int):
                             detail=f"ReferencefileMod with referencefile_mod_id {str(referencefile_mod_id)} "
                                    f"is not avaliable")
     return referencefile_mod
+
+
+def destroy(db: Session, referencefile_mod_id: int):
+    referencefile_mod = read_referencefile_mod_obj_from_db(db, referencefile_mod_id)
+    if len(referencefile_mod.referencefile.referencefile_mods) == 1:
+        remove_from_s3_and_db(db, referencefile_mod.referencefile)
+    else:
+        db.delete(referencefile_mod)
+    db.commit()

--- a/agr_literature_service/api/crud/referencefile_utils.py
+++ b/agr_literature_service/api/crud/referencefile_utils.py
@@ -45,6 +45,8 @@ def remove_file_from_s3(md5sum: str):  # pragma: no cover
 
 
 def remove_from_s3_and_db(db: Session, referencefile: ReferencefileModel):
-    remove_file_from_s3(referencefile.md5sum)
+    copies = db.query(ReferencefileModel).filter(ReferencefileModel.md5sum == referencefile.md5sum).all()
+    if len(copies) == 1:
+        remove_file_from_s3(referencefile.md5sum)
     db.delete(referencefile)
     db.commit()

--- a/agr_literature_service/api/crud/referencefile_utils.py
+++ b/agr_literature_service/api/crud/referencefile_utils.py
@@ -1,13 +1,12 @@
 import logging
 from os import environ
 
+import boto3
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from agr_literature_service.api.models import ReferencefileModel, ReferenceModel, ModModel
-from agr_literature_service.api.schemas.referencefile_mod_schemas import ReferencefileModSchemaPost
-from agr_literature_service.api.schemas.referencefile_schemas import ReferencefileSchemaPost
-from agr_literature_service.api.crud.referencefile_mod_utils import create as create_referencefile_mod
+from agr_literature_service.api.models import ReferencefileModel
+from agr_literature_service.api.s3.delete import delete_file_in_bucket
 
 
 logger = logging.getLogger(__name__)
@@ -24,29 +23,6 @@ def read_referencefile_db_obj(db: Session, referencefile_id: int):
     return referencefile
 
 
-def create(db: Session, request: ReferencefileSchemaPost):
-    request_dict = request.dict()
-    ref_obj = db.query(ReferenceModel).filter(ReferenceModel.curie == request.reference_curie).one_or_none()
-    if ref_obj is None:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                            detail=f"Reference with curie {request.reference_curie} does not exist")
-    del request_dict["reference_curie"]
-    request_dict["reference_id"] = ref_obj.reference_id
-    mod_abbreviation = request_dict["mod_abbreviation"]
-    if mod_abbreviation is not None:
-        mod = db.query(ModModel).filter(ModModel.abbreviation == mod_abbreviation).one_or_none()
-        if mod is None:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                                detail=f"Mod with abbreviation {request.mod_abbreviation} does not exist")
-    del request_dict["mod_abbreviation"]
-    new_ref_file_obj = ReferencefileModel(**request_dict)
-    db.add(new_ref_file_obj)
-    db.commit()
-    create_referencefile_mod(db, ReferencefileModSchemaPost(referencefile_id=new_ref_file_obj.referencefile_id,
-                                                            mod_abbreviation=mod_abbreviation))
-    return new_ref_file_obj.referencefile_id
-
-
 def get_s3_folder_from_md5sum(md5sum: str):
     env_state = environ.get("ENV_STATE", "")
     if env_state == "" or env_state == "test":
@@ -58,3 +34,17 @@ def get_s3_folder_from_md5sum(md5sum: str):
     folder += "/reference/documents/"
     folder += "/".join([char for char in md5sum[0:4]])
     return folder
+
+
+def remove_file_from_s3(md5sum: str):  # pragma: no cover
+    folder = get_s3_folder_from_md5sum(md5sum)
+    client = boto3.client('s3')
+    if not delete_file_in_bucket(s3_client=client, bucket="agr-literature", folder=folder, object_name=md5sum + ".gz"):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"File with md5sum {md5sum} is not available")
+
+
+def remove_from_s3_and_db(db: Session, referencefile: ReferencefileModel):
+    remove_file_from_s3(referencefile.md5sum)
+    db.delete(referencefile)
+    db.commit()

--- a/agr_literature_service/api/routers/referencefile_mod_router.py
+++ b/agr_literature_service/api/routers/referencefile_mod_router.py
@@ -11,7 +11,7 @@ from agr_literature_service.api.schemas import ResponseMessageSchema
 from agr_literature_service.api.schemas.referencefile_mod_schemas import ReferencefileModSchemaPost, \
     ReferencefileModSchemaShow, ReferencefileModSchemaUpdate
 from agr_literature_service.api.user import set_global_user_from_okta
-from agr_literature_service.api.crud import referencefile_mod_crud
+from agr_literature_service.api.crud import referencefile_mod_crud, referencefile_mod_utils
 
 logger = logging.getLogger(__name__)
 
@@ -61,4 +61,4 @@ def destroy(referencefile_mod_id: int,
             user: OktaUser = db_user,
             db: Session = db_session):
     set_global_user_from_okta(db, user)
-    referencefile_mod_crud.destroy(db, referencefile_mod_id)
+    referencefile_mod_utils.destroy(db, referencefile_mod_id)

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -138,7 +138,7 @@ def delete(referencefile_id: int,
            user: OktaUser = db_user,
            db: Session = db_session):
     set_global_user_from_okta(db, user)
-    referencefile_crud.destroy(db, referencefile_id)
+    referencefile_crud.destroy(db, referencefile_id, get_okta_mod_access(user))
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/tests/api/test_referencefile.py
+++ b/tests/api/test_referencefile.py
@@ -10,7 +10,7 @@ from agr_literature_service.lit_processing.tests.mod_populate_load import popula
 from .test_reference import test_reference # noqa
 from ..fixtures import db # noqa
 from .fixtures import auth_headers # noqa
-from agr_literature_service.api.crud.referencefile_utils import create as create_metadata
+from agr_literature_service.api.crud.referencefile_crud import create_metadata
 
 
 @pytest.fixture


### PR DESCRIPTION
- removing temp files when final file is uploaded
- file deletion now removes mod links first and removes file from db and s3 only when there are no more mods associated