### PR TITLE
Scrum 2857 - fixing minor bugs in referencefile upload api

### DIFF
--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -214,8 +214,8 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
                 referencefile.file_publication_status = "final"
             # If WB uploads a temp and the same file is already present but not for WB, then set the status to temp
             elif "WB" not in {referencefile_mod.mod.abbreviation for referencefile_mod in
-                              referencefile.referencefile_mods} and metadata["file_publication_status"] == "temp" \
-                    and referencefile.file_publication_status == "final":
+                              referencefile.referencefile_mods if referencefile_mod.mod is not None} and \
+                    metadata["file_publication_status"] == "temp" and referencefile.file_publication_status == "final":
                 referencefile.file_publication_status = "temp"
             db.commit()
         if all(referencefile_mod.mod.abbreviation != mod_abbreviation for referencefile_mod in

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -219,7 +219,7 @@ def file_upload_single(db: Session, metadata: dict, file: UploadFile):  # pragma
                 referencefile.file_publication_status = "temp"
             db.commit()
         if all(referencefile_mod.mod.abbreviation != mod_abbreviation for referencefile_mod in
-               referencefile.referencefile_mods):
+               referencefile.referencefile_mods if referencefile_mod.mod is not None):
             create_mod_connection(db, ReferencefileModSchemaPost(referencefile_id=referencefile.referencefile_id,
                                                                  mod_abbreviation=mod_abbreviation))
     else:


### PR DESCRIPTION
code was breaking when PMC data was already in the system. Excluding PMC from check doesn't change the logic and simplifies things