### PR TITLE
Scrum 2669 - fixed API to map curies to names using A-team api

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -159,7 +159,7 @@ def get_map_entity_curie_to_name(db: Session, curie_or_reference_id: str, token:
             all_topics_and_entities.append(tag.entity_type)
             all_entities[tag.entity_type].append(tag.entity)
     entity_curie_to_name = get_map_ateam_curies_to_names(curies_category="atpterm", curies=all_topics_and_entities,
-                                                     token=token)
+                                                         token=token)
     for atpterm_curie in all_entities.keys():
         entity_curie_to_name.update(get_map_ateam_curies_to_names(curies_category=entity_curie_to_name[atpterm_curie],
                                                                   curies=all_entities[atpterm_curie],

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -13,7 +13,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
 from agr_literature_service.api.crud.topic_entity_tag_utils import get_reference_id_from_curie_or_id, \
-    get_source_from_db, add_source_obj_to_db_session, allowed_entity_type_map, get_sorted_column_values
+    get_source_from_db, add_source_obj_to_db_session, allowed_entity_type_map, get_sorted_column_values, \
+    get_map_ateam_curies_to_names
 from agr_literature_service.api.models import (
     TopicEntityTagModel,
     ReferenceModel, TopicEntityTagQualifierModel, ModModel, TopicEntityTagSourceModel
@@ -151,31 +152,18 @@ def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1, p
 
 def get_map_entity_curie_to_name(db: Session, curie_or_reference_id: str, token: str):
     reference_id = get_reference_id_from_curie_or_id(db, curie_or_reference_id)
-    topics_and_entities = db.query(TopicEntityTagModel).filter(
-        and_(TopicEntityTagModel.reference_id == reference_id,
-             TopicEntityTagModel.entity_type.in_([key for key in allowed_entity_type_map.keys()]),
-             TopicEntityTagModel.alliance_entity.isnot(None))).all()
-    tags_by_entity_type = defaultdict(set)
-    entity_curie_to_name = {}
+    topics_and_entities = db.query(TopicEntityTagModel).filter(TopicEntityTagModel.reference_id == reference_id).all()
+    all_topics_and_entities = []
+    all_entities = defaultdict(list)
     for tag in topics_and_entities:
-        tags_by_entity_type[allowed_entity_type_map[tag.entity_type]].add(tag.alliance_entity)
-    for entity_type, entity_curies in tags_by_entity_type.items():
-        ateam_api = f'https://beta-curation.alliancegenome.org/api/{entity_type}/search?limit=1000&page=0'
-        request_body = {"searchFilters": {
-            "nameFilters": {
-                "curie_keyword": {"queryString": " ".join(entity_curies), "tokenOperator": "OR"}
-            }
-
-        }}
-        request_data_encoded = json.dumps(request_body)
-        request_data_encoded_str = str(request_data_encoded)
-        request = urllib.request.Request(url=ateam_api, data=request_data_encoded_str.encode('utf-8'))
-        request.add_header("Authorization", f"Bearer {token}")
-        request.add_header("Content-type", "application/json")
-        request.add_header("Accept", "application/json")
-        with urllib.request.urlopen(request) as response:
-            resp = response.read().decode("utf8")
-            resp_obj = json.loads(resp)
-            entity_curie_to_name.update({entity["curie"]: entity[entity_type + "Symbol"]["displayText"]
-                                         for entity in resp_obj["results"]})
+        all_topics_and_entities.append(tag.topic)
+        if tag.entity_type is not None:
+            all_topics_and_entities.append(tag.entity_type)
+            all_entities[tag.entity_type].append(tag.entity)
+    entity_curie_to_name = get_map_ateam_curies_to_names(curies_category="atpterm", curies=all_topics_and_entities,
+                                                     token=token)
+    for atpterm_curie in all_entities.keys():
+        entity_curie_to_name.update(get_map_ateam_curies_to_names(curies_category=entity_curie_to_name[atpterm_curie],
+                                                                  curies=all_entities[atpterm_curie],
+                                                                  token=token))
     return entity_curie_to_name

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -2,18 +2,16 @@
 topic_entity_tag_crud.py
 ===========================
 """
-import json
-import urllib.request
 from collections import defaultdict
 
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import and_, case
+from sqlalchemy import case
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
 from agr_literature_service.api.crud.topic_entity_tag_utils import get_reference_id_from_curie_or_id, \
-    get_source_from_db, add_source_obj_to_db_session, allowed_entity_type_map, get_sorted_column_values, \
+    get_source_from_db, add_source_obj_to_db_session, get_sorted_column_values, \
     get_map_ateam_curies_to_names
 from agr_literature_service.api.models import (
     TopicEntityTagModel,

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -6,6 +6,7 @@ from starlette.testclient import TestClient
 from fastapi import status
 
 from agr_literature_service.api.main import app
+from agr_literature_service.lit_processing.utils.okta_utils import get_authentication_token
 from ..fixtures import db # noqa
 from .fixtures import auth_headers # noqa
 from .test_reference import test_reference # noqa
@@ -22,12 +23,12 @@ def test_topic_entity_tag(db, auth_headers, test_reference, test_mod): # noqa
     with TestClient(app) as client:
         new_tet = {
             "reference_curie": test_reference.new_ref_curie,
-            "topic": "Topic1",
-            "entity_type": "Gene",
-            "entity": "Bob_gene_name",
+            "topic": "ATP:0000122",
+            "entity_type": "ATP:0000005",
+            "entity": "WB:WBGene00003001",
             "entity_source": "alliance",
             "entity_published_as": "test",
-            "species": "NCBITaxon:1234",
+            "species": "NCBITaxon:6239",
             "sources": [{
                 "source": "WB_NN_1",
                 "confidence_level": "high",
@@ -63,12 +64,12 @@ class TestTopicEntityTag:
         with TestClient(app) as client:
             xml = {
                 "reference_curie": test_topic_entity_tag.related_ref_curie,
-                "topic": "Topic1",
-                "entity_type": "Gene",
-                "entity": "Bob_gene_name",
+                "topic": "ATP:0000122",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
                 "entity_source": "alliance",
                 "entity_published_as": "test",
-                "species": "NCBITaxon:1234",
+                "species": "NCBITaxon:6239",
                 "sources": [{
                     "source": "WB_NN_1",
                     "confidence_level": "high",
@@ -86,11 +87,11 @@ class TestTopicEntityTag:
         with TestClient(app) as client:
             xml = {
                 "reference_curie": test_topic_entity_tag.related_ref_curie,
-                "topic": "Topic1",
-                "entity_type": "Gene",
-                "entity": "Gene1",
+                "topic": "ATP:0000122",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
                 "entity_source": "alliance",
-                "species": "NCBITaxon:1234",
+                "species": "NCBITaxon:6239",
                 "sources": [{
                     "source": "WB_NN_1",
                     "confidence_level": "high",
@@ -131,9 +132,9 @@ class TestTopicEntityTag:
 
             # Duplicate tag
             xml6 = copy.deepcopy(xml)
-            xml6["topic"] = "Topic1"
-            xml6["entity_type"] = "Gene"
-            xml6["entity"] = "Bob_gene_name"
+            xml6["topic"] = "ATP:0000122"
+            xml6["entity_type"] = "ATP:0000005"
+            xml6["entity"] = "WB:WBGene00003001"
             xml6["entity_source"] = "alliance"
             response = client.post(url="/topic_entity_tag/", json=xml6, headers=auth_headers)
             assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -148,12 +149,12 @@ class TestTopicEntityTag:
             expected_fields = {
                 "topic_entity_tag_id": int(test_topic_entity_tag.new_tet_id),
                 "reference_curie": test_topic_entity_tag.related_ref_curie,
-                "topic": "Topic1",
-                "entity_type": "Gene",
-                "entity": "Bob_gene_name",
+                "topic": "ATP:0000122",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
                 "entity_source": "alliance",
                 "entity_published_as": "test",
-                "species": "NCBITaxon:1234"
+                "species": "NCBITaxon:6239"
             }
             for key, value in expected_fields.items():
                 assert resp_data[key] == value
@@ -217,11 +218,11 @@ class TestTopicEntityTag:
                 ],
                 "topic_entity_tags": [
                     {
-                        "topic": "string",
-                        "entity_type": "string",
-                        "entity": "string",
+                        "topic": "ATP:0000122",
+                        "entity_type": "ATP:0000005",
+                        "entity": "WB:WBGene00003001",
                         "entity_source": "alliance",
-                        "species": "string"
+                        "species": "NCBITaxon:6239"
                     }
                 ]
             }
@@ -229,3 +230,29 @@ class TestTopicEntityTag:
             new_curie = client.post(url="/reference/", json=reference_data, headers=auth_headers).json()
             response = client.get(url=f"/topic_entity_tag/by_reference/{new_curie}").json()
             assert len(response) > 0
+
+    @pytest.mark.webtest
+    def test_get_map_entity_curie_to_name(self, test_topic_entity_tag, test_mod, auth_headers):
+        with TestClient(app) as client:
+            topic_tag = {
+                "reference_curie": test_topic_entity_tag.related_ref_curie,
+                "topic": "ATP:0000009",
+                "sources": [{
+                    "source": "WB_NN_1",
+                    "confidence_level": "high",
+                    "mod_abbreviation": test_mod.new_mod_abbreviation,
+                    "note": "test note"
+                }]
+            }
+            client.post(url="/topic_entity_tag/", json=topic_tag, headers=auth_headers)
+            response = client.get(url="/topic_entity_tag/map_entity_curie_to_name/",
+                                  params={"curie_or_reference_id": test_topic_entity_tag.related_ref_curie,
+                                          "token": get_authentication_token()},
+                                  headers=auth_headers)
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json() == {
+                'ATP:0000005': 'gene',
+                'ATP:0000009': 'phenotype',
+                'ATP:0000122': 'entity type',
+                'WB:WBGene00003001': 'lin-12'
+            }

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -232,7 +232,7 @@ class TestTopicEntityTag:
             assert len(response) > 0
 
     @pytest.mark.webtest
-    def test_get_map_entity_curie_to_name(self, test_topic_entity_tag, test_mod, auth_headers):
+    def test_get_map_entity_curie_to_name(self, test_topic_entity_tag, test_mod, auth_headers): # noqa
         with TestClient(app) as client:
             topic_tag = {
                 "reference_curie": test_topic_entity_tag.related_ref_curie,


### PR DESCRIPTION
- Mapping API endpoint now works with new model
- API now returns curie->name mappings for entities and ATP nodes (topic and entity_type)
- Added test (webtest only, not part of PR testing)