### PR TITLE
fix(docker): added ateam api var to docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -105,6 +105,7 @@ services:
       SENDER_EMAIL: "${SENDER_EMAIL}"
       SENDER_PASSWORD: "${SENDER_PASSWORD}"
       REPLY_TO: "${REPLY_TO}"
+      ATEAM_API_URL: "${ATEAM_API_URL}"
     hostname: literature_api
     networks:
       - agr-literature


### PR DESCRIPTION
quick fix to add the ateam api url to the env vars