### PR TITLE
dev_app can now use the API_PORT from the .env file when starting wit…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -265,7 +265,7 @@ services:
       OKTA_API_AUDIENCE: "${OKTA_API_AUDIENCE}"
       REG: "${REG}"
     ports:
-      - "8080:8080"
+      - "${API_PORT}:8080"
     networks:
       - agr-literature
     volumes:


### PR DESCRIPTION
…h something like  docker-compose --env-file .env.devserver_4002 run --service-ports --rm dev_app /bin/bash