### PR TITLE
fixed to not load papers in the MOD false positive list even though they are in the current dqm files

### DIFF
--- a/agr_literature_service/lit_processing/utils/sqlalchemy_utils.py
+++ b/agr_literature_service/lit_processing/utils/sqlalchemy_utils.py
@@ -75,7 +75,7 @@ def sqlalchemy_load_ref_xref(datatype):
         for result in results:
             # print(result)
             agr = result[0]
-            xref = result[1]
+            xref = result[1].replace("DOI:10.1037//", "DOI:10.1037/")
             is_obsolete = result[2]
             prefix, identifier, separator = split_identifier(xref, True)
             if is_obsolete is False:


### PR DESCRIPTION
also to make sure all pubmed papers in the current dqm files got added into database even though there is any XREF ID conflict (they should be there already, just to make sure).

another thing I added in the PR is to get rid of '//' in the DOIs  from ABC before comparing them with the data from MODs in order to make the slack report a bit cleaner for WB.