### PR TITLE
Scrum 3187 - fixed validation by including current tag when calculating validation values

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -3,7 +3,6 @@ topic_entity_tag_crud.py
 ===========================
 """
 from collections import defaultdict
-from functools import reduce
 from typing import Dict
 
 from fastapi import HTTPException, status

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -66,7 +66,7 @@ def calculate_validation_value_for_tag(topic_entity_tag_db_obj: TopicEntityTagMo
     if len(validating_tags_values) > 0:
         if topic_entity_tag_db_obj.topic_entity_tag_source.validation_type == validation_type:
             validating_tags_values.append(topic_entity_tag_db_obj.negated)
-        if reduce(lambda x, y: x*y, validating_tags_values) == 1:
+        if len(set(validating_tags_values)) == 1:
             return topic_entity_tag_db_obj.negated == validating_tags_values[0]
     return None
 

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -225,14 +225,45 @@ class TestTopicEntityTag:
             }
             client.post(url="/topic_entity_tag/", json=validating_tag_cur_1, headers=auth_headers)
             cur_2_tag_id = client.post(url="/topic_entity_tag/", json=validating_tag_cur_2, headers=auth_headers).json()
+            curation_tools_source = {
+                "source_type": "curation",
+                "source_method": "WB curation",
+                "validation_type": "curation_tools",
+                "evidence": "test_eco_code",
+                "description": "curation from WB",
+                "mod_abbreviation": test_mod.new_mod_abbreviation
+            }
+            response = client.post(url="/topic_entity_tag/source", json=curation_tools_source, headers=auth_headers)
+            validating_tag_cur_tools_1 = {
+                "reference_curie": test_reference.new_ref_curie,
+                "topic": "ATP:0000122",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
+                "entity_source": "alliance",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": response.json(),
+                "negated": False
+            }
+            validating_tag_cur_tools_2 = {
+                "reference_curie": test_reference.new_ref_curie,
+                "topic": "ATP:0000122",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
+                "entity_source": "alliance",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": response.json(),
+                "negated": False
+            }
+            client.post(url="/topic_entity_tag/", json=validating_tag_cur_tools_1, headers=auth_headers)
+            client.post(url="/topic_entity_tag/", json=validating_tag_cur_tools_2, headers=auth_headers)
             response = client.get(f"/topic_entity_tag/{test_topic_entity_tag.new_tet_id}")
             assert response.json()["validation_value_author"] is False
             assert response.json()["validation_value_curator"] is None
-            assert response.json()["validation_value_curation_tools"] is None
+            assert response.json()["validation_value_curation_tools"] is True
             response = client.get(f"/topic_entity_tag/{cur_2_tag_id}")
             assert response.json()["validation_value_author"] is False
             assert response.json()["validation_value_curator"] is None
-            assert response.json()["validation_value_curation_tools"] is None
+            assert response.json()["validation_value_curation_tools"] is True
 
     @pytest.mark.webtest
     def test_get_map_entity_curie_to_name(self, test_topic_entity_tag, test_topic_entity_tag_source, test_mod, # noqa

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -224,8 +224,12 @@ class TestTopicEntityTag:
                 "negated": False
             }
             client.post(url="/topic_entity_tag/", json=validating_tag_cur_1, headers=auth_headers)
-            client.post(url="/topic_entity_tag/", json=validating_tag_cur_2, headers=auth_headers)
+            cur_2_tag_id = client.post(url="/topic_entity_tag/", json=validating_tag_cur_2, headers=auth_headers).json()
             response = client.get(f"/topic_entity_tag/{test_topic_entity_tag.new_tet_id}")
+            assert response.json()["validation_value_author"] is False
+            assert response.json()["validation_value_curator"] is None
+            assert response.json()["validation_value_curation_tools"] is None
+            response = client.get(f"/topic_entity_tag/{cur_2_tag_id}")
             assert response.json()["validation_value_author"] is False
             assert response.json()["validation_value_curator"] is None
             assert response.json()["validation_value_curation_tools"] is None


### PR DESCRIPTION
If validation_type for the current tag is equal to the provided validation_type, the 'negated' value of the current tag is added to the validation. This covers the case where only one additional tag for the validation_type exists and it has a conflicting 'negated' value with the current tag. The resulting validation value is now None instead of False. This makes validation on conflicting 'negated' values for the same type always None, which is more consistent and easier to interpret.