### PR TITLE
fix(topic_entity_tag): sort by now restricted to elements related to …

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -179,7 +179,7 @@ def show_source(db: Session, topic_entity_tag_source_id: int):
     return source_data
 
 
-def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1, page_size: int = None,
+def show_all_reference_tags(db: Session, curie_or_reference_id, token: str, page: int = 1, page_size: int = None,
                             count_only: bool = False, sort_by: str = None, desc_sort: bool = False):
     if page < 1:
         page = 1
@@ -196,8 +196,8 @@ def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1, p
             column_property = getattr(TopicEntityTagModel, sort_by, None)
             column = column_property.property.columns[0]
             order_expression = case([(column.is_(None), 1 if desc_sort else 0)], else_=0 if desc_sort else 1)
-            curie_ordering = case({curie: index for index, curie in enumerate(get_sorted_column_values(db, sort_by,
-                                                                                                       desc_sort))},
+            curie_ordering = case({curie: index for index, curie in
+                                   enumerate(get_sorted_column_values(reference_id, db, sort_by, token, desc_sort))},
                                   value=getattr(TopicEntityTagModel, sort_by))
             query = query.order_by(order_expression, curie_ordering)
         all_tet = []

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -114,10 +114,11 @@ def show_source_by_name(source_type: str,
 
 @router.get('/by_reference/{curie_or_reference_id}',
             status_code=200)
-def show_all_reference_tags(curie_or_reference_id: str, page: int = 1, page_size: int = None, count_only: bool = False,
+def show_all_reference_tags(curie_or_reference_id: str, token: str,
+                            page: int = 1, page_size: int = None, count_only: bool = False,
                             sort_by: str = None, desc_sort: bool = False,
                             db: Session = db_session) -> Union[List[TopicEntityTagSchemaRelated], int]:
-    return topic_entity_tag_crud.show_all_reference_tags(db, curie_or_reference_id, page, page_size, count_only,
+    return topic_entity_tag_crud.show_all_reference_tags(db, curie_or_reference_id, token, page, page_size, count_only,
                                                          sort_by, desc_sort)
 
 


### PR DESCRIPTION
…the specified reference

Also added mapping from a-team api on any possible value coming from atp. For now, this is restricted to entity_type and topic