### PR TITLE
Add input validation for MOD curie in the reference router

### DIFF
--- a/agr_literature_service/api/routers/reference_router.py
+++ b/agr_literature_service/api/routers/reference_router.py
@@ -56,6 +56,11 @@ def add(pubmed_id: str,
         mod_mca: str,
         user: OktaUser = db_user,
         db: Session = db_session):
+    if mod_curie.count(":") != 1:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Malformed MOD curie")
+    mod_curie_prefix, mod_curie_id = mod_curie.split(":")
+    if len(mod_curie_prefix) == 0 or len(mod_curie_id) == 0:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Malformed MOD curie")
     set_global_user_from_okta(db, user)
     return process_pmid(pubmed_id, mod_curie, mod_mca)
 

--- a/agr_literature_service/api/routers/reference_router.py
+++ b/agr_literature_service/api/routers/reference_router.py
@@ -57,10 +57,10 @@ def add(pubmed_id: str,
         user: OktaUser = db_user,
         db: Session = db_session):
     if mod_curie.count(":") != 1:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Malformed MOD curie")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Malformed MOD curie")
     mod_curie_prefix, mod_curie_id = mod_curie.split(":")
     if len(mod_curie_prefix) == 0 or len(mod_curie_id) == 0:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=f"Malformed MOD curie")
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Malformed MOD curie")
     set_global_user_from_okta(db, user)
     return process_pmid(pubmed_id, mod_curie, mod_mca)
 


### PR DESCRIPTION
This commit adds checks to verify the input format of MOD curie in the reference_router.py file. It enforces a strict format for MOD curie that it must contain a character ':' exactly once and neither of its prefix nor id can be an empty string. HTTP exceptions have been added to throw errors when these conditions are not met. This validation is necessary to ensure data integrity and prevent potential errors caused by invalid inputs.