### PR TITLE
fix(api): add resource descriptor obj to the db inside the for loop

### DIFF
--- a/agr_literature_service/api/initialize.py
+++ b/agr_literature_service/api/initialize.py
@@ -46,8 +46,8 @@ def update_resource_descriptor(db: Session = db_session):
                     else:
                         resource_descriptor_data[field] = value
 
-            resource_descriptor_obj = ResourceDescriptorModel(**resource_descriptor_data)
-            db.add(resource_descriptor_obj)
+                resource_descriptor_obj = ResourceDescriptorModel(**resource_descriptor_data)
+                db.add(resource_descriptor_obj)
             db.commit()
     except Exception as e:
         logging.error(f"Unable to process resource_descriptor '{config.RESOURCE_DESCRIPTOR_URL}' with error {e}")


### PR DESCRIPTION
This fixes a bug for which only the last obj in the resource descriptor yaml file was loaded