### PR TITLE
Scrum 3497 - new API endpoint to read xrefs in bulk using list of curies

### DIFF
--- a/agr_literature_service/api/crud/cross_reference_crud.py
+++ b/agr_literature_service/api/crud/cross_reference_crud.py
@@ -3,7 +3,7 @@ cross_reference_crud.py
 =======================
 """
 import os
-from typing import List
+from typing import List, Dict
 
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
@@ -13,8 +13,7 @@ from sqlalchemy.orm import Session, subqueryload
 
 from agr_literature_service.api.crud.reference_resource import (add_reference_resource,
                                                                 create_obj)
-from agr_literature_service.api.models import (CrossReferenceModel, ReferenceModel,
-                                               ResourceDescriptorModel, ResourceModel)
+from agr_literature_service.api.models import (CrossReferenceModel, ReferenceModel, ResourceDescriptorModel)
 
 
 def set_curie_prefix(xref_db_obj: CrossReferenceModel):
@@ -71,7 +70,7 @@ def show_from_curies(db: Session, curies: List[str]) -> List[dict]:
     cross_references = db.query(CrossReferenceModel).options(subqueryload(CrossReferenceModel.reference)).options(
         subqueryload(CrossReferenceModel.resource)).filter(
         CrossReferenceModel.curie.in_(curies)).all()
-    unique_cross_refs = {}
+    unique_cross_refs: Dict[str, CrossReferenceModel] = {}
     for xref in cross_references:
         if xref.curie not in unique_cross_refs or unique_cross_refs[xref.curie].is_obsolete is True:
             unique_cross_refs[xref.curie] = xref

--- a/agr_literature_service/api/crud/cross_reference_crud.py
+++ b/agr_literature_service/api/crud/cross_reference_crud.py
@@ -110,9 +110,9 @@ def format_cross_reference_data(db: Session, cross_reference_object: CrossRefere
                         page_url = rd_page.url
                         break
                 pages_data.append({
-                                      "name": cr_page,
-                                      "url": page_url.replace("[%s]", local_id)
-                                  })
+                    "name": cr_page,
+                    "url": page_url.replace("[%s]", local_id)
+                })
             cross_reference_data["pages"] = pages_data
     elif cross_reference_data["pages"]:
         pages_data = []

--- a/agr_literature_service/api/crud/cross_reference_crud.py
+++ b/agr_literature_service/api/crud/cross_reference_crud.py
@@ -96,9 +96,8 @@ def format_cross_reference_data(db: Session, cross_reference_object: CrossRefere
         cross_reference_data["reference_curie"] = cross_reference_object.reference.curie
     del cross_reference_data["reference_id"]
 
-    # TODO: read resource descriptor data for all xrefs to minimize number of db queries
     [db_prefix, local_id] = cross_reference_object.curie.split(":", 1)
-    resource_descriptor = resource_desc_prefix_obj_map[db_prefix]
+    resource_descriptor = resource_desc_prefix_obj_map[db_prefix] if db_prefix in resource_desc_prefix_obj_map else None
     if resource_descriptor:
         default_url = resource_descriptor.default_url.replace("[%s]", local_id)
         cross_reference_data["url"] = default_url

--- a/agr_literature_service/api/crud/cross_reference_crud.py
+++ b/agr_literature_service/api/crud/cross_reference_crud.py
@@ -127,7 +127,7 @@ def show(db: Session, curie_or_cross_reference_id: str) -> dict:
     cross_reference_data = jsonable_encoder(cross_reference)
     db_prefix = cross_reference.curie.split(":")[0]
     resource_descriptor = db.query(ResourceDescriptorModel).filter(
-        ResourceDescriptorModel.db_prefix == db_prefix).all()
+        ResourceDescriptorModel.db_prefix == db_prefix).first()
     resource_desc_prefix_obj_map = {db_prefix: resource_descriptor}
     return format_cross_reference_data(db=db, cross_reference_object=cross_reference,
                                        cross_reference_data=cross_reference_data,

--- a/agr_literature_service/api/routers/cross_reference_router.py
+++ b/agr_literature_service/api/routers/cross_reference_router.py
@@ -75,4 +75,3 @@ def show(curie: str,
 def show_all(curies: List[str],
              db: Session = db_session):
     return cross_reference_crud.show_from_curies(db, curies)
-

--- a/agr_literature_service/api/routers/cross_reference_router.py
+++ b/agr_literature_service/api/routers/cross_reference_router.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from fastapi import APIRouter, Depends, Response, Security, status
 from fastapi_okta import OktaUser
 from sqlalchemy.orm import Session
@@ -65,3 +67,12 @@ def show_version(cross_reference_id: int,
 def show(curie: str,
          db: Session = db_session):
     return cross_reference_crud.show(db, curie)
+
+
+@router.post('/show_all',
+             response_model=List[CrossReferenceSchemaShow],
+             status_code=200)
+def show_all(curies: List[str],
+             db: Session = db_session):
+    return cross_reference_crud.show_from_curies(db, curies)
+


### PR DESCRIPTION
This reduces the number of calls to the xref API that were blocking the UI while loading the results in the search page