### PR TITLE
Improve cross-ref search results limit handling and ordering

### DIFF
--- a/agr_literature_service/api/crud/cross_reference_crud.py
+++ b/agr_literature_service/api/crud/cross_reference_crud.py
@@ -195,7 +195,10 @@ def autocomplete_on_id(prefix: str, query: str, return_prefix: bool, db: Session
                        matching_xref in matching_xrefs]
     if matching_xrefs_count < 20:
         matching_xrefs_query_expanded = db.query(CrossReferenceModel.curie).filter(
-            CrossReferenceModel.curie.like(f"{prefix}:{string_before_id}%{query}%")
+            and_(
+                CrossReferenceModel.curie.like(f"{prefix}:{string_before_id}%{query}%"),
+                CrossReferenceModel.curie.notin_([matching_xref.curie for matching_xref in matching_xrefs])
+            )
         )
         matching_xrefs_expanded = matching_xrefs_query_expanded.order_by(CrossReferenceModel.curie).limit(
             20 - matching_xrefs_count).all()

--- a/agr_literature_service/api/crud/cross_reference_crud.py
+++ b/agr_literature_service/api/crud/cross_reference_crud.py
@@ -190,9 +190,18 @@ def autocomplete_on_id(prefix: str, query: str, return_prefix: bool, db: Session
         CrossReferenceModel.curie.like(f"{prefix}:{string_before_id}{query}%")
     )
     matching_xrefs_count = matching_xrefs_query.count()
-    matching_xrefs = matching_xrefs_query.limit(20).all()
+    matching_xrefs = matching_xrefs_query.order_by(CrossReferenceModel.curie).limit(20).all()
     matching_curies = ["".join(matching_xref.curie.split(":")[1:]) if not return_prefix else matching_xref.curie for
                        matching_xref in matching_xrefs]
+    if matching_xrefs_count < 20:
+        matching_xrefs_query_expanded = db.query(CrossReferenceModel.curie).filter(
+            CrossReferenceModel.curie.like(f"{prefix}:{string_before_id}%{query}%")
+        )
+        matching_xrefs_expanded = matching_xrefs_query_expanded.order_by(CrossReferenceModel.curie).limit(
+            20 - matching_xrefs_count).all()
+        matching_xrefs_count = matching_xrefs_count + matching_xrefs_query_expanded.count()
+        matching_curies.extend(["".join(matching_xref_expanded.curie.split(":")[1:]) if not return_prefix else
+                                matching_xref_expanded.curie for matching_xref_expanded in matching_xrefs_expanded])
     if matching_xrefs_count > 20:
         matching_curies.append("more ...")
     matching_curies_plain_text = "\n".join(matching_curies)


### PR DESCRIPTION
Made an improvement to the handling of limit results in the cross-reference search within `cross_reference_crud.py`. Now, if matching cross-references count is less than 20, an expanded query is executed, and matching curies are extended with the results. Also, results are ordered by `CrossReferenceModel.curie` to provide a structured display of data.