### PR TITLE
Scrum 1807 - added docker-compose to jenkins

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -370,6 +370,7 @@ services:
       - /usr/share/jenkins_home:/var/jenkins_home
       - /var/run/docker.sock:/var/run/docker.sock
       - /usr/bin/docker:/usr/bin/docker
+      - /usr/local/bin/docker-compose:/usr/bin/docker-compose
     ports:
       - "49001:8080"
       - "50000:50000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -371,7 +371,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /usr/bin/docker:/usr/bin/docker
       - /usr/local/bin/docker-compose:/usr/bin/docker-compose
-      - /usr/share/agr_env_files/.env.dev_3001:/usr/share/agr_env_files/.env.dev_3001
     ports:
       - "49001:8080"
       - "50000:50000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -371,6 +371,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /usr/bin/docker:/usr/bin/docker
       - /usr/local/bin/docker-compose:/usr/bin/docker-compose
+      - /usr/share/agr_env_files/.env.dev_3001:/usr/share/agr_env_files/.env.dev_3001
     ports:
       - "49001:8080"
       - "50000:50000"


### PR DESCRIPTION
Also modified jenkins configuration in the UI pipeline on http://dev-ec2.alliancegenome.org:49001 to use docker-compose instead of docker. 

Some of the advantages of using docker-compose in jenkins are:
- simplified script
- build the image before stopping, so less downtime