### PR TITLE
Scrum 3049 - Validation now works for negative tags

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -257,9 +257,9 @@ def validate_tags(db: Session, new_tag_obj: TopicEntityTagModel):
     related_validating_tags_in_db = [related_tag for related_tag in related_tags_in_db if
                                      related_tag.topic_entity_tag_source.validation_type is not None]
     if new_tag_obj.negated is True:
-        validate_positive_tag_with_tags_in_db(new_tag_obj, related_validating_tags_in_db)
-    else:
         validate_negative_tag_with_tags_in_db(new_tag_obj, related_validating_tags_in_db)
+    else:
+        validate_positive_tag_with_tags_in_db(new_tag_obj, related_validating_tags_in_db)
     db.commit()
 
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -165,7 +165,7 @@ def validate_tags_already_in_db_with_positive_tag(new_tag_obj: TopicEntityTagMod
     if new_tag_obj.entity is not None and new_tag_obj.entity_type != new_tag_obj.topic:
         for tag_in_db in related_tags_in_db:
             if (tag_in_db.topic == tag_in_db.entity_type == new_tag_obj.entity_type
-                    and new_tag_obj.entity == tag_in_db.entity ):
+                    and new_tag_obj.entity == tag_in_db.entity):
                 tag_in_db.validated_by.append(new_tag_obj)
 
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -70,9 +70,10 @@ def calculate_validation_value_for_tag(topic_entity_tag_db_obj: TopicEntityTagMo
     validating_tags_added_ids.add(topic_entity_tag_db_obj.topic_entity_tag_id)
     while len(validating_tags_to_add) > 0:
         validating_tag = validating_tags_to_add.pop()
-        additional_validating_tags = [tag for tag in validating_tag.validated_by
-                                      if tag.topic_entity_tag_source.validation_type == validation_type and
-                                      tag.topic_entity_tag_id not in validating_tags_added_ids]
+        additional_validating_tags = [
+            tag for tag in validating_tag.validated_by
+            if tag.topic_entity_tag_source.validation_type == validation_type and tag.topic_entity_tag_id not in
+            validating_tags_added_ids]
         additional_validating_tag_values = [tag.negated for tag in additional_validating_tags]
         additional_validating_tag_ids = [tag.topic_entity_tag_id for tag in additional_validating_tags]
         validating_tags_values.extend(additional_validating_tag_values)

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -64,6 +64,9 @@ def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost) -> int:
 
 
 def calculate_validation_value_for_tag(topic_entity_tag_db_obj: TopicEntityTagModel, validation_type: str):
+    # TODO: validation at the moment works only for directly validating tags. Validation conflicts should be calculated
+    # in chain, for example in case a positive tag is validated negative by a more generic negative tag but there's also
+    # a more generic positive tag in conflict with the negative one.
     validating_tags_values = [validating_tag.negated for validating_tag in topic_entity_tag_db_obj.validated_by if
                               validating_tag.topic_entity_tag_source.validation_type == validation_type]
     if len(validating_tags_values) > 0:

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -240,7 +240,7 @@ def validate_tags(db: Session, new_tag_obj: TopicEntityTagModel):
             TopicEntityTagModel.topic_entity_tag_source.has(
                 TopicEntityTagSourceModel.mod_id == new_tag_obj.topic_entity_tag_source.mod_id
             ),
-            TopicEntityTagModel.negated.is_not(None)
+            TopicEntityTagModel.negated.isnot(None)
         )
     ).all()
     # The current tag can validate existing tags or be validated by other tags only if it has a True or False negated

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -395,8 +395,8 @@ class TestTopicEntityTag:
             assert len(specific_tag_obj_2.validated_by) == 0  # nothing should validate the more specific tag
 
     @pytest.mark.webtest
-    def test_validate_positive_with_pos_and_neg(self, test_topic_entity_tag, test_reference, test_mod, auth_headers, db,
-                                                test_topic_entity_tag_source):  # noqa
+    def test_validate_positive_with_pos_and_neg(self, test_topic_entity_tag, test_reference, test_mod,  # noqa
+                                                auth_headers, db, test_topic_entity_tag_source):  # noqa
         with TestClient(app) as client:
             author_source = {
                 "source_type": "manual",
@@ -475,8 +475,8 @@ class TestTopicEntityTag:
             assert int(more_generic_negative_tag_id) in validating_tags
 
     @pytest.mark.webtest
-    def test_validate_negative_with_pos_and_neg(self, test_topic_entity_tag, test_reference, test_mod, auth_headers, db,
-                                                test_topic_entity_tag_source):  # noqa
+    def test_validate_negative_with_pos_and_neg(self, test_topic_entity_tag, test_reference, test_mod,  # noqa
+                                                auth_headers, db, test_topic_entity_tag_source):  # noqa
         with TestClient(app) as client:
             author_source = {
                 "source_type": "manual",


### PR DESCRIPTION
- Re-organized validation code
- Added validation for negative tags
- When calculating validation values (on the fly from the API), chain of validating tags are now evaluated to make sure there are no conflicting tags upstream (e.g., a tag is validated positive by a tag that is validated negative by another tag that does not validate the first one)
- Code not completely factorized but left duplicated lines to maximize readability