### PR TITLE
Fixed conversion from sqlalchemy db obj to dict + updated tests to use new tet post return values

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -432,7 +432,9 @@ def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1,
         mod_id_to_mod = dict([(x.mod_id, x.abbreviation) for x in db.query(ModModel).all()])
         all_tet = []
         for tet in query.offset((page - 1) * page_size if page_size else None).limit(page_size).all():
-            tet_data = jsonable_encoder(tet)
+            tet_data = jsonable_encoder(vars(tet), exclude={"validated_by"})
+            if "validated_by" in tet_data:
+                del tet_data["validated_by"]
             add_validation_values_to_tag(tet, tet_data)
             tet_data["topic_entity_tag_source"]["mod"] = mod_id_to_mod[tet.topic_entity_tag_source.mod_id]
             all_tet.append(tet_data)


### PR DESCRIPTION
Calling jsonable_encoder on a db obj with loops in the relationships was returning a max recursion error. The exclude parameter of jsonable_encoder only works if the passed object is in dict format. This looks like a bug in the decoder function. Made a first conversion with vars() and then called jsonable_encoder with the problematic relationship (validated_by) in the exclude list.

Updated tet web tests to use the new format returned by tet create function.

Please remember to run tests locally before creating PRs with changes to tet functions, as most tests are webtests skipped by github actions as they include calls to A-team APIs.