### PR TITLE
Use new session when querying db from separate process

### DIFF
--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -138,10 +138,10 @@ def get_map_entity_curie_to_name(curie_or_reference_id: str,
     return topic_entity_tag_crud.get_map_entity_curie_to_name(db, curie_or_reference_id)
 
 
-def revalidate_tags_process_wrapper(already_running, email: str, delete_all_first: bool, db: Session):
+def revalidate_tags_process_wrapper(already_running, email: str, delete_all_first: bool):
     try:
         already_running.value = True
-        topic_entity_tag_crud.revalidate_all_tags(db=db, email=email, delete_all_first=delete_all_first)
+        topic_entity_tag_crud.revalidate_all_tags(email=email, delete_all_first=delete_all_first)
     finally:
         already_running.value = False
 
@@ -168,7 +168,7 @@ def revalidate_all_tags(email: str,
         }
     else:
         p = Process(target=revalidate_tags_process_wrapper,
-                    args=(revalidate_all_tags_already_running, email, delete_all_tags_first, db))
+                    args=(revalidate_all_tags_already_running, email, delete_all_tags_first))
         p.start()
         return {
             "message": "Revalidation of all tags started. You will receive an email when done."


### PR DESCRIPTION
When querying the db from a subprocess of the api a separate session must be used. This PR adds code to create this session in the function to revalidate all tags