### PR TITLE
fixed dqm loading script to work with newly updated 'update_authors' function

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/dqm_ingest/sort_dqm_json_reference_updates.py
+++ b/agr_literature_service/lit_processing/data_ingest/dqm_ingest/sort_dqm_json_reference_updates.py
@@ -881,9 +881,13 @@ def update_db_entries(mod_to_mod_id, dqm_entries, report_fh, processing_flag):  
                 #     logger.info("patch %s field keywords from db %s to dqm %s", agr, keywords_changed[2], keywords_changed[1])
                 #     update_json['keywords'] = keywords_changed[1]
 
+                pub_status_changed = "publication status change place holder"
+                pmids_with_pub_status_changed = {}
                 update_authors(db_session, db_entry['reference_id'],
                                db_entry.get('author', []),
                                dqm_entry.get('authors', []),
+                               pub_status_changed,
+                               pmids_with_pub_status_changed,
                                logger)
 
                 # if curators want to get reports of how resource change, put this back,

--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_update_references_single_mod.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_update_references_single_mod.py
@@ -36,7 +36,7 @@ logging.basicConfig(format='%(message)s')
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
-refColName_to_update = ['title', 'volume', 'issue_name', 'page_range', 'citation',
+refColName_to_update = ['title', 'volume', 'issue_name', 'page_range',
                         'abstract', 'pubmed_types', 'pubmed_publication_status',
                         'keywords', 'category', 'plain_language_abstract',
                         'pubmed_abstract_languages', 'language', 'date_published',
@@ -488,9 +488,10 @@ def update_reference_table(db_session, fw, pmid, x, json_data, new_resource_id, 
     for colName in refColName_to_update:
         if colName == 'resource_id':
             handle_resource_id_update(fw, pmid, x, new_resource_id, journal_title, update_log, has_update)
+            old_journal_title = x.resource.title if x.resource else None
             set_data_changed(pmid, colName, pub_status_changed,
                              pmids_with_pub_status_changed,
-                             x.resource.title, journal_title)
+                             old_journal_title, journal_title)
         elif colName in ['date_last_modified_in_pubmed', 'date_arrived_in_pubmed']:
             old_value = str(getattr(x, colName, ''))[0:10]
             j_key = colName_to_json_key[colName]
@@ -561,7 +562,8 @@ def log_update(fw, pmid, colName, old_value, new_value, update_log, has_update):
 
 
 def handle_resource_id_update(fw, pmid, x, new_resource_id, journal_title, update_log, has_update):
-    if new_resource_id and new_resource_id != x.resource_id and x.resource.title != journal_title:
+    old_title = x.resource.title if x.resource else None
+    if new_resource_id and new_resource_id != x.resource_id and old_title != journal_title:
         log_update(fw, pmid, 'resource_id', x.resource_id, new_resource_id,
                    update_log, has_update)
         x.resource_id = new_resource_id

--- a/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
@@ -1015,6 +1015,10 @@ def _insert_pmcid(db_session, fw, pmid, reference_id, pmcid, logger=None):  # pr
         if logger:
             logger.info(f"Key (curie_prefix, reference_id)=(PMCID, {reference_id}) already exists")
         return
+    x = db_session.query(CrossReferenceModel).filter_by(curie="PMCID:" + pmcid, reference_id=reference_id).one_or_none()
+    if x and x.is_obsolete is True:
+        x.is_obsolete = False
+        return
     data = {"curie": "PMCID:" + pmcid,
             "curie_prefix": "PMCID",
             "reference_id": reference_id,


### PR DESCRIPTION
and add check before inserting a new PMCID into database (check if this ID is in database in invalid form, just in case)
also check if the paper has a resource info before accessing the resource title