### PR TITLE
fix those reference withotu citation_id on stage database

### DIFF
--- a/agr_literature_service/lit_processing/oneoff_scripts/add_citation.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/add_citation.py
@@ -10,7 +10,7 @@ logger.setLevel(logging.INFO)
 def add_citations():
 
     db_session = create_postgres_session(False)
-    rows = db_session.execute("SELECT reference_id FROM reference").fetchall()
+    rows = db_session.execute("SELECT reference_id FROM reference where citation_id is null").fetchall()
     count = 0
     for x in rows:
         count += 1


### PR DESCRIPTION
all trigger scripts look fine, and data look OK in production, problem only occured in stage database, so we suspect that for some reason, the initial step to generate reference.citation for all records were interrupt. so we only need to run script to fix those without ciation_id on stage database. 

docker exec -it agr-literature-rdsdev-4001_api_1 sh
 python3 agr_literature_service/lit_processing/oneoff_scripts/add_citation.py