### PR TITLE
Scrum 1999 - API changes to merge TET data

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -43,7 +43,7 @@ from agr_literature_service.api.crud.workflow_tag_crud import (
     patch as update_workflow_tag,
     show as show_workflow_tag
 )
-from agr_literature_service.api.crud.topic_entity_tag_crud import create_tag
+from agr_literature_service.api.crud.topic_entity_tag_crud import create_tag, revalidate_all_tags
 from agr_literature_service.global_utils import get_next_reference_curie
 from agr_literature_service.api.crud.referencefile_crud import destroy as destroy_referencefile
 from agr_literature_service.lit_processing.data_ingest.pubmed_ingest.pubmed_update_references_single_mod import \
@@ -547,6 +547,8 @@ def merge_references(db: Session,
         new_tet = TopicEntityTagSchemaPost(**new_tet_data)
         create_tag(db, new_tet)
     db.commit()
+
+    revalidate_all_tags(curie_or_reference_id=new_ref.curie)
 
     # Check if old_curie is already in the obsolete table (It may have been merged itself)
     # by looking for it in the new_id column.

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -512,6 +512,10 @@ def merge_references(db: Session,
     old_ref = get_reference(db=db, curie_or_reference_id=old_curie)
     new_ref = get_reference(db=db, curie_or_reference_id=new_curie)
 
+    if old_ref.prepublication_pipeline or new_ref.prepublication_pipeline:
+        new_ref.prepublication_pipeline = True
+        db.commit()
+
     merge_reference_relations(db, old_ref.reference_id, new_ref.reference_id,
                               old_curie, new_curie)
 
@@ -540,10 +544,6 @@ def merge_references(db: Session,
     # Delete the old_curie object
     db.delete(old_ref)
     db.commit()
-
-    if old_ref.prepublication_pipeline or new_ref.prepublication_pipeline:
-        new_ref.prepublication_pipeline = True
-        db.commit()
 
     # find which mods reference this paper
     mods = db.query(ModModel).join(ModCorpusAssociationModel). \

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -188,7 +188,7 @@ def create(db: Session, reference: ReferenceSchemaPost):  # noqa
                     except HTTPException:
                         logger.warning("skipping topic_entity_tag as that is already associated to "
                                        "the reference")
-                    revalidate_all_tags(curie_or_reference_id=str(reference_db_obj.reference_id))
+                revalidate_all_tags(curie_or_reference_id=str(reference_db_obj.reference_id))
         elif field == "mod_reference_types":
             for obj in value or []:
                 insert_mod_reference_type_into_db(db, reference.pubmed_types, obj.mod_abbreviation, obj.reference_type,

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -184,10 +184,11 @@ def create(db: Session, reference: ReferenceSchemaPost):  # noqa
                     obj_data["reference_curie"] = curie
                     obj_data["force_insertion"] = True
                     try:
-                        create_tag(db, obj_data)
+                        create_tag(db, obj_data, validate_on_insert=False)
                     except HTTPException:
                         logger.warning("skipping topic_entity_tag as that is already associated to "
                                        "the reference")
+                    revalidate_all_tags(curie_or_reference_id=str(reference_db_obj.reference_id))
         elif field == "mod_reference_types":
             for obj in value or []:
                 insert_mod_reference_type_into_db(db, reference.pubmed_types, obj.mod_abbreviation, obj.reference_type,
@@ -545,7 +546,7 @@ def merge_references(db: Session,
             "date_updated": str(old_tet.date_updated)
         }
         new_tet = TopicEntityTagSchemaPost(**new_tet_data)
-        create_tag(db, new_tet)
+        create_tag(db, new_tet, validate_on_insert=False)
     db.commit()
 
     revalidate_all_tags(curie_or_reference_id=new_ref.curie)

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -182,6 +182,7 @@ def create(db: Session, reference: ReferenceSchemaPost):  # noqa
                 for obj in value:
                     obj_data = obj.dict(exclude_unset=True)
                     obj_data["reference_curie"] = curie
+                    obj_data["force_insertion"] = True
                     try:
                         create_tag(db, obj_data)
                     except HTTPException:
@@ -523,22 +524,28 @@ def merge_references(db: Session,
     old_ref_tets = db.query(TopicEntityTagModel).filter(TopicEntityTagModel.reference_id == old_ref.reference_id).all()
 
     for old_tet in old_ref_tets:
-        new_tet_data = TopicEntityTagSchemaPost()
-        new_tet_data.topic = old_tet.topic
-        new_tet_data.entity_type = old_tet.entity_type
-        new_tet_data.entity = old_tet.entity
-        new_tet_data.entity_id_validation = old_tet.entity_id_validation
-        new_tet_data.entity_published_as = old_tet.entity_published_as
-        new_tet_data.species = old_tet.species
-        new_tet_data.display_tag = old_tet.display_tag
-        new_tet_data.topic_entity_tag_source_id = old_tet.topic_entity_tag_source_id
-        new_tet_data.negated = old_tet.negated
-        new_tet_data.novel_topic_data = old_tet.novel_topic_data
-        new_tet_data.confidence_level = old_tet.confidence_level
-        new_tet_data.note = old_tet.note
-        new_tet_data.reference_curie = new_ref.curie
-        new_tet_data.force_insertion = True
-        create_tag(db, new_tet_data)
+        new_tet_data = {
+            "topic": old_tet.topic,
+            "entity_type": old_tet.entity_type,
+            "entity": old_tet.entity,
+            "entity_id_validation": old_tet.entity_id_validation,
+            "entity_published_as": old_tet.entity_published_as,
+            "species": old_tet.species,
+            "display_tag": old_tet.display_tag,
+            "topic_entity_tag_source_id": old_tet.topic_entity_tag_source_id,
+            "negated": old_tet.negated,
+            "novel_topic_data": old_tet.novel_topic_data,
+            "confidence_level": old_tet.confidence_level,
+            "note": old_tet.note,
+            "reference_curie": new_ref.curie,
+            "force_insertion": True,
+            "created_by": str(old_tet.created_by),
+            "updated_by": str(old_tet.updated_by),
+            "date_created": str(old_tet.date_created),
+            "date_updated": str(old_tet.date_updated)
+        }
+        new_tet = TopicEntityTagSchemaPost(**new_tet_data)
+        create_tag(db, new_tet)
     db.commit()
 
     # Check if old_curie is already in the obsolete table (It may have been merged itself)

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -629,9 +629,12 @@ def merge_reference_relations(db, old_reference_id, new_reference_id, old_curie,
                 db.delete(x)
         db.commit()
     except Exception as e:
+        db.rollback()
         logger.warning(
             "An error occurred when transferring the reference_relations from " + old_curie + " to " + new_curie + " : " + str(
                 e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"Cannot merge these two references. {e}")
 
 
 def author_order_sort(author: AuthorModel):

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -37,7 +37,7 @@ ATP_ID_SOURCE_AUTHOR = "author"
 ATP_ID_SOURCE_CURATOR = "professional_biocurator"
 
 
-def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost) -> dict:
+def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost, validate_on_insert: bool = True) -> dict:
     topic_entity_tag_data = jsonable_encoder(topic_entity_tag)
     if topic_entity_tag_data["entity"] is None:
         topic_entity_tag_data["entity_type"] = None
@@ -47,7 +47,6 @@ def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost) -> dict:
                             detail="reference_curie not within topic_entity_tag_data")
     reference_id = get_reference_id_from_curie_or_id(db, reference_curie)
     topic_entity_tag_data["reference_id"] = reference_id
-    # if reference_curie.isdigit():
     force_insertion = topic_entity_tag_data.pop("force_insertion", None)
     source: TopicEntityTagSourceModel = db.query(TopicEntityTagSourceModel).filter(
         TopicEntityTagSourceModel.topic_entity_tag_source_id == topic_entity_tag_data["topic_entity_tag_source_id"]
@@ -78,7 +77,8 @@ def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost) -> dict:
         db.add(new_db_obj)
         db.flush()
         db.refresh(new_db_obj)
-        validate_tags(db=db, new_tag_obj=new_db_obj)
+        if validate_on_insert:
+            validate_tags(db=db, new_tag_obj=new_db_obj)
         return {
             "status": "success",
             "message": "New tag created successfully.",

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -283,21 +283,13 @@ def validate_new_tag_with_existing_tags(new_tag_obj: TopicEntityTagModel, relate
 
 def validate_tags(db: Session, new_tag_obj: TopicEntityTagModel, validate_new_tag: bool = True,
                   commit_changes: bool = True):
-    columns_to_load = [TopicEntityTagModel.negated, TopicEntityTagModel.topic, TopicEntityTagModel.entity_type,
-                       TopicEntityTagModel.entity, TopicEntityTagModel.species,
-                       TopicEntityTagSourceModel.validation_type]
-    related_tags_in_db = (
-        db.query(TopicEntityTagModel)
-        .join(TopicEntityTagSourceModel, TopicEntityTagModel.topic_entity_tag_source)
-        .filter(
+    related_tags_in_db = db.query(TopicEntityTagModel).join(
+        TopicEntityTagSourceModel, TopicEntityTagModel.topic_entity_tag_source).filter(
             TopicEntityTagModel.topic_entity_tag_id != new_tag_obj.topic_entity_tag_id,
             TopicEntityTagModel.reference_id == new_tag_obj.reference_id,
             TopicEntityTagSourceModel.secondary_data_provider_id == new_tag_obj.topic_entity_tag_source.secondary_data_provider_id,
             TopicEntityTagModel.negated.isnot(None)
-        )
-        .with_entities(*columns_to_load)
-        .all()
-    )
+        ).all()
     # The current tag can validate existing tags or be validated by other tags only if it has a True or False negated
     # value
     if len(related_tags_in_db) == 0 or new_tag_obj.negated is None:

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -285,11 +285,11 @@ def validate_tags(db: Session, new_tag_obj: TopicEntityTagModel, validate_new_ta
                   commit_changes: bool = True):
     related_tags_in_db = db.query(TopicEntityTagModel).join(
         TopicEntityTagSourceModel, TopicEntityTagModel.topic_entity_tag_source).filter(
-            TopicEntityTagModel.topic_entity_tag_id != new_tag_obj.topic_entity_tag_id,
-            TopicEntityTagModel.reference_id == new_tag_obj.reference_id,
-            TopicEntityTagSourceModel.secondary_data_provider_id == new_tag_obj.topic_entity_tag_source.secondary_data_provider_id,
-            TopicEntityTagModel.negated.isnot(None)
-        ).all()
+        TopicEntityTagModel.topic_entity_tag_id != new_tag_obj.topic_entity_tag_id,
+        TopicEntityTagModel.reference_id == new_tag_obj.reference_id,
+        TopicEntityTagSourceModel.secondary_data_provider_id == new_tag_obj.topic_entity_tag_source.secondary_data_provider_id,
+        TopicEntityTagModel.negated.isnot(None)
+    ).all()
     # The current tag can validate existing tags or be validated by other tags only if it has a True or False negated
     # value
     if len(related_tags_in_db) == 0 or new_tag_obj.negated is None:

--- a/tests/api/test_reference.py
+++ b/tests/api/test_reference.py
@@ -524,7 +524,8 @@ class TestReference:
                         "novel_topic_data": True,
                         "note": "test note",
                         "created_by": "WBPerson1",
-                        "date_created": "2020-01-01"
+                        "date_created": "2020-01-01",
+                        "date_updated": "2020-01-01"
                     },
                     {
                         "topic": "ATP:0000009",
@@ -575,7 +576,8 @@ class TestReference:
                         "novel_topic_data": True,
                         "note": "another note",  # only the note is different
                         "created_by": "WBPerson1",
-                        "date_created": "2020-01-01"
+                        "date_created": "2020-01-03",
+                        "date_updated": "2020-01-03"
                     },
                     {
                         "topic": "ATP:0000009",

--- a/tests/api/test_reference.py
+++ b/tests/api/test_reference.py
@@ -1,6 +1,7 @@
 import copy
 from collections import namedtuple
 import json
+from typing import Dict, Tuple
 
 import pytest
 from sqlalchemy_continuum import Operation
@@ -20,6 +21,12 @@ from .test_copyright_license import test_copyright_license # noqa
 from .test_topic_entity_tag_source import test_topic_entity_tag_source # noqa
 
 from agr_literature_service.api.crud.referencefile_crud import create_metadata
+
+
+CHECK_VALID_ATP_IDS_RETURN: Tuple[set, Dict[str, str]] = (
+    {'ATP:0000005', 'ATP:0000009', 'ATP:0000068', 'ATP:0000071', 'ATP:0000079', 'ATP:0000082', 'ATP:0000084',
+     'ATP:0000099', 'ATP:0000122', 'WB:WBGene00003001', 'NCBITaxon:6239'}, {})
+
 
 TestReferenceData = namedtuple('TestReferenceData', ['response', 'new_ref_curie'])
 
@@ -472,6 +479,139 @@ class TestReference:
             ########################################
             # 3) changesets, see test_001_reference.
             ########################################
+
+    def test_merge_with_tets(self, db, test_resource, test_topic_entity_tag_source, auth_headers): # noqa
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.check_atp_ids_validity") as \
+                mock_check_atp_ids_validity, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_map_ateam_curies_to_names") as \
+                mock_get_map_ateam_curies_to_name:
+            mock_check_atp_ids_validity.return_value = CHECK_VALID_ATP_IDS_RETURN
+            mock_get_map_ateam_curies_to_name.return_value = {
+                'ATP:0000009': 'phenotype', 'ATP:0000082': 'RNAi phenotype', 'ATP:0000122': 'ATP:0000122',
+                'ATP:0000084': 'overexpression phenotype', 'ATP:0000079': 'genetic phenotype', 'ATP:0000005': 'gene',
+                'WB:WBGene00003001': 'lin-12', 'NCBITaxon:6239': 'Caenorhabditis elegans'
+            }
+            ref1_data = {
+                "category": "research_article",
+                "abstract": "013 - abs B",
+                "authors": [
+                    {
+                        "name": "S. K",
+                        "order": 1
+                        # "orcid": 'ORCID:1234-1234-1234-123X'
+                    },
+                    {
+                        "name": "S. W",
+                        "order": 2
+                        # "orcid": 'ORCID:1111-2222-3333-444X'  # New
+                    }
+                ],
+                "resource": test_resource.new_resource_curie,
+                "title": "Another title",
+                "volume": "013b",
+                "prepublication_pipeline": True,
+                "topic_entity_tags": [
+                    {
+                        "topic": "ATP:0000122",
+                        "entity_type": "ATP:0000005",
+                        "entity": "WB:WBGene00003001",
+                        "entity_id_validation": "alliance",
+                        "entity_published_as": "test",
+                        "species": "NCBITaxon:6239",
+                        "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                        "negated": False,
+                        "novel_topic_data": True,
+                        "note": "test note",
+                        "created_by": "WBPerson1",
+                        "date_created": "2020-01-01"
+                    },
+                    {
+                        "topic": "ATP:0000009",
+                        "entity_type": None,
+                        "entity": None,
+                        "entity_id_validation": None,
+                        "species": "NCBITaxon:6239",
+                        "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                        "negated": False,
+                        "novel_topic_data": True,
+                        "note": "test note",
+                        "created_by": "WBPerson1",
+                        "date_created": "2020-01-02"
+                    }
+                ]
+            }
+            response1 = client.post(url="/reference/", json=ref1_data, headers=auth_headers)
+
+            ref2_data = {
+                "category": "research_article",
+                "abstract": "013 - abs A",
+                "authors": [
+                    {
+                        "name": "S. K",
+                        "order": 1
+                        # "orcid": 'ORCID:1234-1234-1234-123X'
+                    },
+                    {
+                        "name": "S. W",
+                        "order": 2
+                        # "orcid": 'ORCID:1111-2222-3333-444X'  # New
+                    }
+                ],
+                "resource": test_resource.new_resource_curie,
+                "title": "Another title",
+                "volume": "013a",
+                "prepublication_pipeline": False,
+                "topic_entity_tags": [
+                    {
+                        "topic": "ATP:0000122",
+                        "entity_type": "ATP:0000005",
+                        "entity": "WB:WBGene00003001",
+                        "entity_id_validation": "alliance",
+                        "entity_published_as": "test",
+                        "species": "NCBITaxon:6239",
+                        "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                        "negated": False,
+                        "novel_topic_data": True,
+                        "note": "another note",  # only the note is different
+                        "created_by": "WBPerson1",
+                        "date_created": "2020-01-01"
+                    },
+                    {
+                        "topic": "ATP:0000009",
+                        "entity_type": None,
+                        "entity": None,
+                        "entity_id_validation": None,
+                        "species": "NCBITaxon:6239",
+                        "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                        "negated": False,
+                        "novel_topic_data": True,
+                        "note": "test note",
+                        "created_by": "WBPerson1",
+                        "date_created": "2020-01-02"
+                    },
+                    {
+                        "topic": "ATP:0000009",
+                        "entity_type": None,
+                        "entity": None,
+                        "entity_id_validation": None,
+                        "species": "NCBITaxon:6239",
+                        "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                        "negated": False,
+                        "novel_topic_data": True,
+                        "note": "test note",
+                        "created_by": "WBPerson2",  # same tag but created by a different user
+                        "date_created": "2020-01-03"
+                    }
+                ]
+            }
+            response2 = client.post(url="/reference/", json=ref2_data, headers=auth_headers)
+            response_merge = client.post(url=f"/reference/merge/{response1.json()}/{response2.json()}",
+                                         headers=auth_headers)
+            assert response_merge.status_code == status.HTTP_201_CREATED
+            tets = client.get(url=f"/topic_entity_tag/by_reference/{response2.json()}").json()
+            assert len(tets) == 3
+            assert any(tet["note"] == "another note | test note" for tet in tets)
 
     def test_show_mod_reference_types_by_mod(self, populate_test_mod_reference_types): # noqa
         with TestClient(app) as client:


### PR DESCRIPTION
- Merge TET entries during reference merge API call
- Revalidate tags of winning paper to account for possible cross-reference validation between tags from losing and winning refs
- Fixed date_updated management for note updates on duplicate tags with different note values
- Changed force_insertion behavior for TET API - now only forces insertion on different created_by users and not for the very same tag by the same user
 