### PR TITLE
refactoring the 'update_authors' function to try to update author rows as much as possible

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_update_references_single_mod.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_update_references_single_mod.py
@@ -76,7 +76,7 @@ def update_data(mod, pmids, resourceUpdated=None):  # noqa: C901 pragma: no cove
         email_subject = mod + " " + email_subject
 
     # remove old log files
-    remove_old_files(log_path, 30)
+    remove_old_files(log_path, 90)
 
     # set new log file with date stamp
     datestamp = str(date.today()).replace("-", "")

--- a/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
@@ -591,20 +591,24 @@ def compare_author_lists(old_list, new_list):
         return True
 
     def normalize_name(name):
-        """normalize 'FirstName LastName' to 'LastName FirstInitial'"""
-        # split by space
-        parts = name.split()
+        """Normalize names in various formats to 'LastName FirstInitials'."""
+        # Replace commas, dots, hyphens, and multiple spaces with a single space, then split by space
+        name = name.replace(',', ' ').replace('.', ' ').replace('-', ' ')
+        # Replace multiple spaces with a single space
+        while '  ' in name:
+            name = name.replace('  ', ' ')
+        parts = [part.strip() for part in name.split() if part]
+
         if len(parts) >= 2:
-            # for name like "Yi Heng Zhu", first_name_parts = ["Yi", "Heng"]
-            # for name like "Yi-Heng Zhu", first_name_parts = ["Yi-Heng"]
-            first_name_parts = parts[:-1]
+            # Last name is the last part
             last_name = parts[-1]
-            if len(first_name_parts) == 1 and '-' in first_name_parts[0]:
-                # for name like "Yi-Heng Zhu" => "Zhu YH"
-                first_name_parts = first_name_parts[0].split('-')
-            first_initials = ''.join([part[0] for part in first_name_parts if part])
+
+            # Handle multi-part first names
+            first_name_parts = parts[:-1]
+            first_initials = ''.join([part[0].upper() for part in first_name_parts if part])
+
             return f"{last_name} {first_initials}"
-        return name
+        return name.strip()
 
     def normalize_list(name_list):
         """normalize a list of 'FirstName LastName' to 'LastName FirstInitial'"""
@@ -621,8 +625,8 @@ def compare_author_lists(old_list, new_list):
 
 def check_delete_add_rows(author_count_db, author_order_to_add_record, author_order_to_delete_record):
     """
-    Check if every pair of corresponding old and new name has the same last name.
-    Normalize every name to remove accents and convert to lowercase before comparing.
+    check if every pair of corresponding old and new name has the same last name.
+    normalize every name to remove accents and convert to lowercase before comparing.
     """
 
     """
@@ -653,16 +657,12 @@ def check_delete_add_rows(author_count_db, author_order_to_add_record, author_or
     old: ['Zhu YH', 'Zhang C', 'Liu Y', 'Omenn GS', 'Freddolino PL', 'Yu DJ', 'Zhang Y']
     new: ['Yi-Heng Zhu', 'Chengxin Zhang', 'Yan Liu', 'Gilbert S Omenn', 'Peter L Freddolino',
           'Dong-Jun Yu', 'Yang Zhang']
-
-    old: ['Zhu YH', 'Zhang C', 'Liu Y', 'Omenn GS', 'Freddolino PL', 'Yu DJ', 'Zhang Y']
-    new: ['Yi-Heng Zhu', 'Chengxin Zhang', 'Yan Liu', 'Gilbert S Omenn', 'Peter L Freddolino',
-          'Dong-Jun Yu', 'Yang Zhang']
     """
 
     def normalize_string(s):
         """
-        Normalize a string by removing accents
-        In Unicode normalization, 'NFKD' stands for "Normalization Form KD"
+        normalize a string by removing accents
+        in Unicode normalization, 'NFKD' stands for "Normalization Form KD"
         """
         normalized = unicodedata.normalize('NFKD', s)
         return ''.join([c for c in normalized if not unicodedata.combining(c)])

--- a/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
@@ -366,6 +366,13 @@ def update_authors(db_session, reference_id, author_list_in_db, author_list_in_j
     * Ensure that author order values are updated while respecting unique constraints.
     """
 
+    """
+    ABC currently does not have any author rows with the first_author or corresponding_author
+    tags set to true. We will address authors with these tags and those connected to PERSON
+    in the future simultaneously.
+    TODO: Skip these authors during the update and send a report to the curators.
+    """
+
     if author_list_in_json is None:
         author_list_in_json = []
 
@@ -458,21 +465,6 @@ def update_authors(db_session, reference_id, author_list_in_db, author_list_in_j
         author_order_to_update_record = author_order_to_add_record
         author_order_to_add_record = {}
         author_order_to_delete_record = {}
-
-    """
-    orcid_to_add_record = {}
-    for author_order in author_order_to_add_record:
-        author = author_order_to_add_record[author_order]
-        if author['orcid']:
-            orcid_to_add_record[author['orcid']] = (author_order, author)
-    for author_order in author_order_to_delete_record:
-        author = author_order_to_add_record[author_order]
-        if author['orcid'] and author['orcid'] in orcid_to_add_record:
-            (author_order_to_add, author_to_add) = orcid_to_add_record[author['orcid']]
-            author_order_to_update_record[author_order] = author_to_add
-            author_order_to_add_record.pop(author_order_to_add)
-            author_order_to_delete_record.pop(author_order)
-    """
 
     """
     if author_order_to_update_record:
@@ -661,9 +653,6 @@ def check_delete_add_rows(author_count_db, author_order_to_add_record, author_or
     old: ['Kurat CF', 'Recht J', 'Radovani E', 'Durbic T', 'Andrews B', 'Fillingham J']
     new: ['Christoph F Kurat', 'Judith Recht', 'Ernest Radovani', 'Tanja Durbic', 'Brenda Andrews',
           'Jeffrey Fillingham']
-
-    old: ['Strahl T', 'Thorner J']
-    new: ['Thomas Strahl', 'Jeremy Thorner']
 
     old: ['T Kutateladze']
     new: ['T G Kutateladze']

--- a/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/db_write_utils.py
@@ -686,7 +686,7 @@ def synchronize_author_lists(author_order_to_add_record, author_order_to_delete_
     return old_order_to_new_order_mapping
 
 
-def generate_author_key(name, last_name, first_initial):  # pragma: no cover
+def generate_author_key(name, last_name, first_initial):
 
     name = normalize_string(name)
     last_name = normalize_string(last_name)

--- a/agr_literature_service/lit_processing/utils/report_utils.py
+++ b/agr_literature_service/lit_processing/utils/report_utils.py
@@ -352,26 +352,42 @@ def write_log_and_send_pubmed_update_report(fw, mod, field_names_to_report, upda
             data = data_change_for_status[pmid]
             for colName in data:
                 displayColName = "journal" if colName == 'resource_id' else colName
-                logger.info(f"PMID:{pmid}: {displayColName} {data[colName]}")
-                fw.write(f"PMID:{pmid}: {displayColName} {data[colName]}\n")
-                # email_message = email_message + f"PMID:{pmid}: {displayColName} {data[colName]}<br>"
+                messages = []
+                if colName == 'authors':
+                    messages = data[colName]
+                else:
+                    messages = [data[colName]]
+                for message in messages:
+                    logger.info(f"PMID:{pmid}: {displayColName} {message}")
+                    fw.write(f"PMID:{pmid}: {displayColName} {message}\n")
 
     i = 0
     rows = ''
     for pmid in sorted(changes_for_published_papers):
         if i == 0:
-            email_message = email_message + "<p><b>Updates in Journal, Author, Volume, or Issue Fields for Published Papers:</b><p>"
+            email_message += "<p><b>Updates in Journal, Author, Volume, or Issue Fields for Published Papers:</b><p>"
             rows = "<tr><th style='text-align:left' width=150>PubMed ID</th><th style='text-align:left' width=130>Data Type</th><th style='text-align:left' width=300>Old Value</th><th style='text-align:left' width=300>New Value</th></tr>"
         i += 1
         data = changes_for_published_papers[pmid]
         for colName in sorted(data):
             displayColName = "journal" if colName == 'resource_id' else colName
             displayColName = displayColName.lower()
-            [fromVal, toVal] = data[colName].replace("from '", "").split("' to '")
-            toVal = toVal.replace("'", "")
-            rows = rows + f"<tr><th style='text-align:left'>PMID:{pmid}</th><td style='text-align:left'><strong>{displayColName}</strong></td><td style='text-align:left'>{fromVal}</td><td style='text-align:left'>{toVal}</td></tr>"
+            messages = []
+            if colName == 'authors':
+                messages = data[colName]
+            else:
+                messages = [data[colName]]
+            for message in messages:
+                [fromVal, toVal] = message.replace("from '", "").split(" to ")
+                fromVal = fromVal.replace("'", "")
+                toVal = toVal.replace("'", "")
+                if colName == 'authors' and 'Deleted' in fromVal:
+                    fromVal = fromVal.replace("Deleted:", "<span style='color:red;'>Deleted:</span>")
+                    toVal = toVal.replace("Inserted:", "<span style='color:green;'>Inserted:</span>")
+                if fromVal or toVal:
+                    rows += f"<tr><td style='text-align:left'>PMID:{pmid}</td><td style='text-align:left'><strong>{displayColName}</strong></td><td style='text-align:left'>{fromVal}</td><td style='text-align:left'>{toVal}</td></tr>"
     if rows:
-        email_message = email_message + "<table></tbody>" + rows + "</tbody></table>"
+        email_message += "<table><tbody>" + rows + "</tbody></table>"
 
     if mod:
         email_message = email_message + "DONE!<p>"

--- a/agr_literature_service/lit_processing/utils/report_utils.py
+++ b/agr_literature_service/lit_processing/utils/report_utils.py
@@ -378,7 +378,7 @@ def write_log_and_send_pubmed_update_report(fw, mod, field_names_to_report, upda
             else:
                 messages = [data[colName]]
             for message in messages:
-                [fromVal, toVal] = message.replace("from '", "").split(" to ")
+                [fromVal, toVal] = message.replace("from '", "").split("' to '")
                 fromVal = fromVal.replace("'", "")
                 toVal = toVal.replace("'", "")
                 if colName == 'authors' and 'Deleted' in fromVal:

--- a/tests/lit_processing/data_ingest/utils/test_db_write_utils.py
+++ b/tests/lit_processing/data_ingest/utils/test_db_write_utils.py
@@ -10,7 +10,8 @@ from agr_literature_service.lit_processing.data_ingest.utils.db_write_utils impo
     add_cross_references, update_mod_corpus_associations, \
     update_mod_reference_types, add_mca_to_existing_references, \
     update_reference_relations, update_mesh_terms, \
-    mark_false_positive_papers_as_out_of_corpus, mark_not_in_mod_papers_as_out_of_corpus
+    mark_false_positive_papers_as_out_of_corpus, mark_not_in_mod_papers_as_out_of_corpus, \
+    generate_author_key
 
 from ....fixtures import db, load_sanitized_references, populate_test_mod_reference_types # noqa
 
@@ -190,3 +191,48 @@ class TestDbReadUtils:
                              "WHERE curie_prefix = 'Xenbase'").fetchall()
         for x in cr_rows:
             assert x[0] is True
+
+        ## test generate_author_key
+        name = generate_author_key("Noda T", "", "")
+        name2 = generate_author_key("Taichi Noda", "Noda", "T")
+        assert name == name2
+
+        name = generate_author_key(" Blaha A", "", "")
+        name2 = generate_author_key("Andreas Blaha", "Blaha", "A")
+        assert name == name2
+
+        name = generate_author_key("Bahrami AH", "", "")
+        name2 = generate_author_key("Bahrami A", "Bahrami", "A")
+        assert name == name2
+
+        name = generate_author_key("Kurat CF", "", "")
+        name2 = generate_author_key("Christoph F Kurat", "Kurat", "C")
+        assert name == name2
+
+        name = generate_author_key("Bahrami AH", "", "")
+        name2 = generate_author_key("Amir Houshang Bahrami", "Bahrami", "")
+        assert name == name2
+
+        name = generate_author_key("Li H", "", "")
+        name2 = generate_author_key("H Li", "", "")
+        assert name == name2
+
+        name = generate_author_key("Anderson,C", "", "")
+        name2 = generate_author_key("Carrie Anderson", "Anderson", "C")
+        assert name == name2
+
+        name = generate_author_key("Wang,Y.", "", "")
+        name2 = generate_author_key("Yicui Wang", "Wang", "Y")
+        assert name == name2
+
+        name = generate_author_key("T Kutateladze", "", "")
+        name2 = generate_author_key("T G Kutateladze", "", "")
+        assert name == name2
+
+        name = generate_author_key("David J. Smith", "", "")
+        name2 = generate_author_key("David Smith", "", "")
+        assert name == name2
+
+        name = generate_author_key("Smith,David", "", "")
+        name2 = generate_author_key("Smith, David", "", "")
+        assert name == name2


### PR DESCRIPTION
* Perform case-insensitive comparisons of author names after trimming leading and  trailing whitespace
* Update existing author records to maintain author IDs as much as possible by comparing the key (combination of name, last_name, first_name, & first_initial), orcid ID, combination of lastName and firstInitial.
* Handle updates to affiliations and ORCIDs without deleting the entire author record
* Update author names if the order remains the same to maintain author IDs
* Update author names if the order is changed by using temp order mapping 