### PR TITLE
Scrum 4028 speed up revalidation of topic entity tags

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -188,6 +188,7 @@ def create(db: Session, reference: ReferenceSchemaPost):  # noqa
                     except HTTPException:
                         logger.warning("skipping topic_entity_tag as that is already associated to "
                                        "the reference")
+                db.commit()
                 revalidate_all_tags(curie_or_reference_id=str(reference_db_obj.reference_id))
         elif field == "mod_reference_types":
             for obj in value or []:

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -405,6 +405,8 @@ def revalidate_all_tags(email: str = None, delete_all_first: bool = False, curie
     for tag_counter, tag in enumerate(query_tags.all()):
         logger.info(f"Setting validation values to tag # {str(tag_counter)}")
         set_validation_values_to_tag(tag)
+        if tag_counter > 0 and tag_counter % 200 == 0:
+            db.commit()
     db.commit()
     db.close()
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -403,6 +403,7 @@ def revalidate_all_tags(email: str = None, delete_all_first: bool = False, curie
                 db.commit()
         db.commit()
     for tag_counter, tag in enumerate(query_tags.all()):
+        logger.info(f"Setting validation values to tag # {str(tag_counter)}")
         set_validation_values_to_tag(tag)
     db.commit()
     db.close()

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -402,11 +402,19 @@ def revalidate_all_tags(email: str = None, delete_all_first: bool = False, curie
             if tag_counter > 0 and tag_counter % 200 == 0:
                 db.commit()
         db.commit()
-    for tag_counter, tag in enumerate(query_tags.all()):
-        logger.info(f"Setting validation values to tag # {str(tag_counter)}")
-        set_validation_values_to_tag(tag)
-        if tag_counter > 0 and tag_counter % 200 == 0:
-            db.commit()
+    offset = 0
+    batch_size = 200
+    tag_counter = 0
+    while True:
+        batch_tags = query_tags.offset(offset).limit(batch_size).all()
+        if not batch_tags:
+            break  # All tags processed
+        for tag in batch_tags:
+            tag_counter += 1
+            logger.info(f"Setting validation values for tag #{tag_counter}")
+            set_validation_values_to_tag(tag)
+        db.commit()
+        offset += batch_size
     db.commit()
     db.close()
 

--- a/agr_literature_service/api/models/audited_model.py
+++ b/agr_literature_service/api/models/audited_model.py
@@ -45,3 +45,13 @@ class AuditedModel(object):
     def updated_by(cls):
         return Column('updated_by', ForeignKey('users.id'), default=get_default_user_value,
                       onupdate=get_default_user_value, nullable=True)
+
+
+# Function to disable the `onupdate` behavior
+def disable_set_updated_by_onupdate(target):
+    target.__table__.columns['updated_by'].onupdate = None
+
+
+# Function to enable the `onupdate` behavior
+def enable_set_updated_by_onupdate(target):
+    target.__table__.columns['updated_by'].onupdate = get_default_user_value

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -148,11 +148,13 @@ def get_curie_to_name_from_all_tets(curie_or_reference_id: str,
     return topic_entity_tag_crud.get_curie_to_name_from_all_tets(db, curie_or_reference_id)
 
 
-def revalidate_tags_process_wrapper(already_running, email: str, delete_all_first: bool, curie_or_reference_id: str):
+def revalidate_tags_process_wrapper(already_running, email: str, delete_all_first: bool, curie_or_reference_id: str,
+                                    validation_values_only: bool):
     try:
         already_running.value = True
         topic_entity_tag_crud.revalidate_all_tags(email=email, delete_all_first=delete_all_first,
-                                                  curie_or_reference_id=curie_or_reference_id)
+                                                  curie_or_reference_id=curie_or_reference_id,
+                                                  validation_values_only=validation_values_only)
     finally:
         already_running.value = False
 
@@ -162,6 +164,7 @@ def revalidate_tags_process_wrapper(already_running, email: str, delete_all_firs
 def revalidate_all_tags(email: str = None,
                         delete_all_tags_first: bool = False,
                         curie_or_reference_id: str = None,
+                        validation_values_only: bool = False,
                         user: OktaUser = db_user,
                         db: Session = db_session):
     if not user.groups or "SuperAdmin" not in user.groups:
@@ -180,7 +183,8 @@ def revalidate_all_tags(email: str = None,
         }
     else:
         p = Process(target=revalidate_tags_process_wrapper,
-                    args=(revalidate_all_tags_already_running, email, delete_all_tags_first, curie_or_reference_id))
+                    args=(revalidate_all_tags_already_running, email, delete_all_tags_first, curie_or_reference_id,
+                          validation_values_only))
         p.start()
         return {
             "message": "Revalidation of all tags started. You will receive an email when done."


### PR DESCRIPTION
* caching list of related tags for the same reference and mod
* removed extra commits
* added function to avoid automatically setting updated_by to api user when revalidating tags
* removed validation values from tags comparison to find duplicates (these values are set after the tag is inserted)
* used join to speed up query to retrieve all tags and their related info on subobjects