### PR TITLE
Scrum 4310 fixed validation bugs

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -84,7 +84,7 @@ def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost, validate
 
     try:
         db.add(new_db_obj)
-        db.flush()
+        db.commit()
         db.refresh(new_db_obj)
         if validate_on_insert:
             validate_tags(db=db, new_tag_obj=new_db_obj)
@@ -340,7 +340,7 @@ def validate_tags(db: Session, new_tag_obj: TopicEntityTagModel, validate_new_ta
                                              related_tag.validation_type is not None]
             validate_new_tag_with_existing_tags(db, new_tag_obj, related_validating_tags_in_db,
                                                 calculate_validation_values=calculate_validation_values)
-    if calculate_validation_values and new_tag_obj.topic_entity_tag_source.validation_type is not None:
+    if calculate_validation_values:
         set_validation_values_to_tag(new_tag_obj)
     if commit_changes:
         db.commit()

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -26,7 +26,8 @@ from agr_literature_service.api.models import (
     TopicEntityTagModel,
     ReferenceModel, TopicEntityTagSourceModel, ModModel
 )
-from agr_literature_service.api.models.audited_model import get_default_user_value, disable_set_updated_by_onupdate
+from agr_literature_service.api.models.audited_model import get_default_user_value, disable_set_updated_by_onupdate, \
+    disable_set_date_updated_onupdate
 from agr_literature_service.api.routers.okta_utils import OktaAccess, OKTA_ACCESS_MOD_ABBR
 from agr_literature_service.api.schemas.topic_entity_tag_schemas import (TopicEntityTagSchemaPost,
                                                                          TopicEntityTagSourceSchemaUpdate,
@@ -349,6 +350,7 @@ def validate_tags(db: Session, new_tag_obj: TopicEntityTagModel, validate_new_ta
 
 def set_validation_values_to_tag(tag: TopicEntityTagModel):
     disable_set_updated_by_onupdate(tag)
+    disable_set_date_updated_onupdate(tag)
     tag.validation_by_professional_biocurator = calculate_validation_value_for_tag(tag, ATP_ID_SOURCE_CURATOR)
     tag.validation_by_author = calculate_validation_value_for_tag(tag, ATP_ID_SOURCE_AUTHOR)
 

--- a/agr_literature_service/api/models/audited_model.py
+++ b/agr_literature_service/api/models/audited_model.py
@@ -63,4 +63,3 @@ def disable_set_date_updated_onupdate(target):
 
 def enable_date_updated_onupdate(target):
     target.__table__.columns['date_updated'].onupdate = lambda: datetime.now(tz=pytz.timezone("UTC"))
-

--- a/agr_literature_service/api/models/audited_model.py
+++ b/agr_literature_service/api/models/audited_model.py
@@ -55,3 +55,12 @@ def disable_set_updated_by_onupdate(target):
 # Function to enable the `onupdate` behavior
 def enable_set_updated_by_onupdate(target):
     target.__table__.columns['updated_by'].onupdate = get_default_user_value
+
+
+def disable_set_date_updated_onupdate(target):
+    target.__table__.columns['date_updated'].onupdate = None
+
+
+def enable_date_updated_onupdate(target):
+    target.__table__.columns['date_updated'].onupdate = lambda: datetime.now(tz=pytz.timezone("UTC"))
+


### PR DESCRIPTION
- automatic update of date_updated now disabled when setting validation values
- calculating validation values for all types of created tags (even those that are not validating other tags)