### PR TITLE
move conversion job flag to correct place, plus fix for file upload s…

### DIFF
--- a/agr_literature_service/lit_processing/oneoff_scripts/workflow/data/file_upload.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/workflow/data/file_upload.py
@@ -9,18 +9,33 @@ def get_data(name_to_atp):
             'from': "file needed",
             'to': "file upload in progress",
         },
+        # Do not like this but it looks like some processes go from needed to uploaded so add transitions for this.
+        {
+            'mod': "NOT_WB",
+            'from': "file needed",
+            'to': "files uploaded",
+            'condition': 'on_success, text_convert_job',
+            'actions': [f"proceed_on_value::category::research_article::{name_to_atp['text conversion needed']}"]
+        },
+        {
+            'mod': "WB",
+            'from': "file needed",
+            'to': "files uploaded",
+            'condition': 'on_success, text_convert_job',
+            'actions': [f"proceed_on_value::reference_type::experimental::{name_to_atp['text conversion needed']}"]
+        },
         {
             'mod': "NOT_WB",
             'from': "file upload in progress",
             'to': "files uploaded",
-            'condition': 'on_success, text_convert_job',
-            'actions': [f"proceed_on_value::category::reasearch_article::{name_to_atp['text conversion needed']}"]
+            'condition': 'on_success',
+            'actions': [f"proceed_on_value::category::research_article::{name_to_atp['text conversion needed']}"]
         },
         {
             'mod': "WB",
             'from': "file upload in progress",
             'to': "files uploaded",
-            'condition': 'on_success, text_convert_job',
+            'condition': 'on_success',
             'actions': [f"proceed_on_value::reference_type::experimental::{name_to_atp['text conversion needed']}"]
         },
         {

--- a/agr_literature_service/lit_processing/oneoff_scripts/workflow/data/text_conversion.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/workflow/data/text_conversion.py
@@ -8,6 +8,13 @@ def get_data(name_to_atp):
     test_data = [
         {
             'mod': "ALL",
+            'from': "files uploaded",
+            'to': "file conversion needed",
+            'condition': 'text_convert_job',
+            'actions': []
+        },
+        {
+            'mod': "ALL",
             'from': "file conversion needed",
             'to': "file converted to text",
             'condition': 'on_success',

--- a/agr_literature_service/lit_processing/oneoff_scripts/workflow/transitions_add.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/workflow/transitions_add.py
@@ -29,6 +29,7 @@ from agr_literature_service.api.models import WorkflowTransitionModel
 # Data files
 from agr_literature_service.lit_processing.oneoff_scripts.workflow.data.file_upload import get_data as file_upload
 from agr_literature_service.lit_processing.oneoff_scripts.workflow.data.classification import get_data as classifications
+from agr_literature_service.lit_processing.oneoff_scripts.workflow.data.text_conversion import get_data as text_conversions
 
 logger = logging.getLogger(__name__)
 name_to_atp = {}
@@ -96,6 +97,8 @@ def add_transitions(db: Session, filename: str, debug: bool = False):  # noqa
         data_to_add = file_upload(name_to_atp)
     elif filename == "classifications":
         data_to_add = classifications(name_to_atp)
+    elif filename == "text_conversions":
+        data_to_add = text_conversions(name_to_atp)
     else:
         print(f"Unknown filename {filename}")
         return


### PR DESCRIPTION
…kipping in progress.
NOTE:  'text_convert_job' now on 'to': "file conversion needed" as this is the correct place.
              previously it was on to: 'files upload' BUT this would convert all file and no test would be done on the type of file.
              tests/checks are done when moving to "file conversion needed" which ensures only those are converted.