### PR TITLE
fixed TET create, MCA create and patch endpoints to add manual indexing workflow tags for SGD papers

### DIFF
--- a/agr_literature_service/api/crud/mod_corpus_association_crud.py
+++ b/agr_literature_service/api/crud/mod_corpus_association_crud.py
@@ -16,6 +16,7 @@ from agr_literature_service.api.schemas import ModCorpusAssociationSchemaPost
 from agr_literature_service.api.crud.workflow_tag_crud import transition_to_workflow_status, get_current_workflow_status
 
 file_needed_tag_atp_id = "ATP:0000141"  # file needed
+manual_indexing_needed_tag_atp_id = "ATP:0000274"
 
 
 def create(db: Session, mod_corpus_association: ModCorpusAssociationSchemaPost) -> int:
@@ -63,6 +64,12 @@ def create(db: Session, mod_corpus_association: ModCorpusAssociationSchemaPost) 
         if get_current_workflow_status(db, reference_curie, "ATP:0000140",
                                        mod_abbreviation) is None:
             transition_to_workflow_status(db, reference_curie, mod_abbreviation, file_needed_tag_atp_id)
+        if mod_abbreviation == 'SGD':
+            wft_obj = WorkflowTagModel(reference_id=reference.reference_id,
+                                       mod_id=mod.mod_id,
+                                       workflow_tag_id=manual_indexing_needed_tag_atp_id)
+            db.add(wft_obj)
+            db.commit()
     return int(db_obj.mod_corpus_association_id)
 
 
@@ -135,6 +142,11 @@ def patch(db: Session, mod_corpus_association_id: int, mod_corpus_association_up
                                                "ATP:0000140",
                                                mod_abbreviation=mod_abbreviation) is None:
                     transition_to_workflow_status(db, reference_obj.curie, mod_abbreviation, file_needed_tag_atp_id)
+                if mod_abbreviation == 'SGD':
+                    wft_obj = WorkflowTagModel(reference_id=mod_corpus_association_db_obj.reference_id,
+                                               mod_id=mod_corpus_association_db_obj.mod_id,
+                                               workflow_tag_id='ATP:0000274')
+                    db.add(wft_obj)
             elif (value is False or value is None) and mod_corpus_association_db_obj.corpus is True:
                 delete_workflow_tag_if_file_needed(db, reference_obj, mod_corpus_association_db_obj.mod)
                 set_mod_curie_to_invalid(db, reference_obj.reference_id, mod_corpus_association_db_obj.mod.abbreviation)

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -391,7 +391,7 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
         JOIN referencefile_mod rfm ON rf.referencefile_id = rfm.referencefile_id
         WHERE rf.reference_id = {reference.reference_id}
         AND rf.file_class = 'main'
-        AND rf.file_extension = 'pdf'
+        AND rf.pdf_type = 'pdf'
         AND rf.date_created <= NOW() - INTERVAL '7 days'
         """
         rows = db.execute(text(sql_query)).mappings().fetchall()
@@ -1005,7 +1005,7 @@ def get_textpresso_reference_list(db, mod_abbreviation, files_updated_from_date=
         WHERE mca.corpus is True
         AND mca.mod_id = :mod_id
         AND rf.file_class = 'main'
-        AND rf.file_extension = 'pdf'
+        AND rf.pdf_type = 'pdf'
         AND (rfm.mod_id is NULL OR rfm.mod_id = :mod_id)
     """
 

--- a/agr_literature_service/api/schemas/topic_entity_tag_schemas.py
+++ b/agr_literature_service/api/schemas/topic_entity_tag_schemas.py
@@ -54,6 +54,7 @@ class TopicEntityTagSchemaCreate(AuditedObjectModelSchema):
 class TopicEntityTagSchemaPost(TopicEntityTagSchemaCreate):
     reference_curie: str
     force_insertion: Optional[bool] = False
+    index_wft: Optional[str] = None
 
 
 class TopicEntityTagSchemaRelated(AuditedObjectModelSchema):

--- a/tests/api/test_referencefile_mod.py
+++ b/tests/api/test_referencefile_mod.py
@@ -75,7 +75,7 @@ class TestReferencefileMod:
                                            f"{test_referencefile_mod.new_referencefile_mod_id}")
             response_file = client.get(url=f"/reference/referencefile/{response_file_mod.json()['referencefile_id']}")
             response = client.get(url=f"/reference/referencefile/show_all/{response_file.json()['reference_curie']}")
-            assert response.json()[0]["referencefile_mods"][0]["mod_abbreviation"] == "WB"
+            assert response.json()[0]["referencefile_mods"][1]["mod_abbreviation"] == "WB"
 
     def test_add_referencefile_to_mod(self, test_referencefile_mod, auth_headers): # noqa
         with TestClient(app) as client:

--- a/tests/api/test_referencefile_mod.py
+++ b/tests/api/test_referencefile_mod.py
@@ -75,7 +75,7 @@ class TestReferencefileMod:
                                            f"{test_referencefile_mod.new_referencefile_mod_id}")
             response_file = client.get(url=f"/reference/referencefile/{response_file_mod.json()['referencefile_id']}")
             response = client.get(url=f"/reference/referencefile/show_all/{response_file.json()['reference_curie']}")
-            assert response.json()[0]["referencefile_mods"][1]["mod_abbreviation"] == "WB"
+            assert response.json()[0]["referencefile_mods"][0]["mod_abbreviation"] == "WB"
 
     def test_add_referencefile_to_mod(self, test_referencefile_mod, auth_headers): # noqa
         with TestClient(app) as client:


### PR DESCRIPTION
* TET create endpoint will add "manual indexing complete" or  "manual indexing in progress" into the WFT table for SGD papers if the tag is not already there and if the index_wft is passed in.
* MCA create endpoint will add "manual indexing needed" into the WFT table for newly created SGD papers 
* MCA patch endpoint will add "manual indexing needed" into the WFT table for newly sorted in-corpus SGD papers
* fixed textpresso main pdf retrieval endpoint only return main pdf with pdf_type = 'pdf'
* globally fixed code to identify main pdfs based on pdf_type = 'pdf', file_class = 'main', and file_publication_status = 'final'
* also set default pdf_type to 'pdf' if it is a main pdf file and its pdf_type is not set
API fixes for SCRUM-4564, SCRUM-4587, & SCRUM-4583