### PR TITLE
Speed up reports

### DIFF
--- a/agr_literature_service/api/crud/workflow_tag_crud.py
+++ b/agr_literature_service/api/crud/workflow_tag_crud.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 from datetime import datetime, timedelta
 from typing import Union, Optional, Dict
-import time  # Just for debugging and getting timings.
 
 from agr_literature_service.api.crud.reference_utils import get_reference
 from agr_literature_service.api.models import WorkflowTagModel, \
@@ -627,7 +626,6 @@ def show_changesets(db: Session, reference_workflow_tag_id: int):
 
 def counters(db: Session, mod_abbreviation: str = None, workflow_process_atp_id: str = None,
              date_option: str = None, date_range_start: str = None, date_range_end: str = None):  # pragma: no cover
-    start_time = time.time()
     all_WF_tags_for_process = None
     if workflow_process_atp_id:
         all_WF_tags_for_process = get_workflow_tags_from_process(workflow_process_atp_id)
@@ -702,8 +700,6 @@ def counters(db: Session, mod_abbreviation: str = None, workflow_process_atp_id:
         rows = db.execute(text(query), params).mappings().fetchall()  # type: ignore
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e))
-
-    start_time = time.time()
     data = []
     for x in rows:
         x_dict = dict(x)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -95,7 +95,7 @@ def load_sanitized_references(populate_test_mod_reference_types):
     yield None
 
 
-def load_workflow_parent_children_mock():
+def load_workflow_parent_children_mock(root_node='ATP:0000177'):
     workflow_children = {
         'ATP:0000177': ['ATP:0000172', 'ATP:0000140', 'ATP:0000165', 'ATP:0000161'],
         'ATP:0000172': ['ATP:0000175', 'ATP:0000174', 'ATP:0000173', 'ATP:0000178'],


### PR DESCRIPTION
The sql changes will speed up the queries a little but this was not the major problem. load_workflow_parent_children was being called with the root_node NOT being passed that meant the default value of the top one was called which meant a full load of the ATPs (with lots of calls) when only the sub parts were needed. SCRUM-4803