### PR TITLE
Update API endpoints to clean up the WFT and TET tags when moving a paper out of corpus and

### DIFF
--- a/agr_literature_service/api/crud/mod_corpus_association_crud.py
+++ b/agr_literature_service/api/crud/mod_corpus_association_crud.py
@@ -13,7 +13,10 @@ from agr_literature_service.api.crud.cross_reference_crud import check_xref_and_
     set_mod_curie_to_invalid
 from agr_literature_service.api.models import ModCorpusAssociationModel, ReferenceModel, ModModel, WorkflowTagModel
 from agr_literature_service.api.schemas import ModCorpusAssociationSchemaPost
-from agr_literature_service.api.crud.workflow_tag_crud import transition_to_workflow_status, get_current_workflow_status
+from agr_literature_service.api.crud.workflow_tag_crud import transition_to_workflow_status, \
+    get_current_workflow_status, delete_workflow_tags
+from agr_literature_service.api.crud.topic_entity_tag_utils import delete_non_manual_tets, \
+    delete_manual_tets, has_manual_tet
 
 file_needed_tag_atp_id = "ATP:0000141"  # file needed
 manual_indexing_needed_tag_atp_id = "ATP:0000274"
@@ -149,7 +152,15 @@ def patch(db: Session, mod_corpus_association_id: int, mod_corpus_association_up
                                                workflow_tag_id=wft_id)
                     db.add(wft_obj)
             elif (value is False or value is None) and mod_corpus_association_db_obj.corpus is True:
-                delete_workflow_tag_if_file_needed(db, reference_obj, mod_corpus_association_db_obj.mod)
+                has_manual_tags = has_manual_tet(db, str(mod_corpus_association_db_obj.reference_id),
+                                                 mod_abbreviation)
+                if has_manual_tags and not mod_corpus_association_data.get('force_out'):
+                    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                        detail=f"Curated topic and entity tags or automated tags generated from your MOD are associated with this reference. Please check with the curator who added these tags. mod_corpus_association_id = {mod_corpus_association_db_obj.mod_corpus_association_id}")
+                delete_non_manual_tets(db, str(mod_corpus_association_db_obj.reference_id), mod_abbreviation)
+                if has_manual_tags:
+                    delete_manual_tets(db, str(mod_corpus_association_db_obj.reference_id), mod_abbreviation)
+                delete_workflow_tags(db, str(mod_corpus_association_db_obj.reference_id), mod_abbreviation)
                 set_mod_curie_to_invalid(db, reference_obj.reference_id, mod_corpus_association_db_obj.mod.abbreviation)
             setattr(mod_corpus_association_db_obj, field, value)
         else:

--- a/agr_literature_service/api/crud/topic_entity_tag_utils.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_utils.py
@@ -374,6 +374,20 @@ def delete_non_manual_tets(db: Session, curie_or_reference_id: str, mod_abbrevia
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                             detail=f"An error occurred when deleting non-manual tets: {e}")
 
+
+def has_manual_tet(db: Session, curie_or_reference_id: str, mod_abbreviation: str):
+
+    ref = get_reference(db=db, curie_or_reference_id=str(curie_or_reference_id))
+    if ref is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"The reference curie or id {curie_or_reference_id} is not in the database")
+    reference_id = ref.reference_id
+    mod = db.query(ModModel).filter_by(abbreviation=mod_abbreviation).one_or_none()
+    if mod is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"The mod abbreviation {mod_abbreviation} is not in the database")
+    mod_id = mod.mod_id
+
     sql_query = text("""
         SELECT * FROM topic_entity_tag
         WHERE reference_id = :reference_id
@@ -387,10 +401,10 @@ def delete_non_manual_tets(db: Session, curie_or_reference_id: str, mod_abbrevia
             )
         )
     """)
-
     rows = db.execute(sql_query, {
         'reference_id': reference_id,
         'mod_id': mod_id
     }).fetchall()
-
-    return len(rows)
+    if len(rows) > 0:
+        return True
+    return False

--- a/agr_literature_service/api/crud/workflow_tag_crud.py
+++ b/agr_literature_service/api/crud/workflow_tag_crud.py
@@ -629,9 +629,6 @@ def counters(db: Session, mod_abbreviation: str = None, workflow_process_atp_id:
         SELECT m.abbreviation, wt.workflow_tag_id, COUNT(*) AS tag_count
         FROM mod m
         JOIN workflow_tag wt ON m.mod_id = wt.mod_id
-        JOIN mod_corpus_association mca ON wt.reference_id = mca.reference_id
-          AND mca.mod_id = m.mod_id
-          AND mca.corpus = TRUE
         """
     if mod_abbreviation:
         where_clauses.append("m.abbreviation = :mod_abbreviation")
@@ -641,8 +638,7 @@ def counters(db: Session, mod_abbreviation: str = None, workflow_process_atp_id:
         where_clauses.append("wt.workflow_tag_id = ANY(:all_WF_tags_for_process)")
         params["all_WF_tags_for_process"] = all_WF_tags_for_process
 
-    # if date_range_start is not None and date_range_end is not None and date_range_start != "" and date_range_end != "":
-    if date_range_start and date_range_end:
+    if date_range_start is not None and date_range_end is not None and date_range_start != "" and date_range_end != "":
         if isinstance(date_range_end, str):
             date_range_end_date = datetime.strptime(date_range_end, "%Y-%m-%d")
             new_timestamp = date_range_end_date + timedelta(days=1)
@@ -666,7 +662,11 @@ def counters(db: Session, mod_abbreviation: str = None, workflow_process_atp_id:
             params["start_date"] = date_range_start
             params["end_date"] = date_range_end
         elif date_option == 'inside_corpus':
-            # Since the mod_corpus_association join is already included, just filter its date
+            query += """
+                JOIN mod_corpus_association mca ON wt.reference_id = mca.reference_id
+                AND mca.mod_id = m.mod_id
+                AND mca.corpus = TRUE
+                """
             where_clauses.append("mca.date_updated BETWEEN :start_date AND :end_date")
             params["start_date"] = date_range_start
             params["end_date"] = date_range_end
@@ -712,12 +712,9 @@ def _counters_total(db: Session, atp_curie_to_name: Dict[str, str], all_WF_tags_
     query = """
     SELECT   COUNT(distinct(wt.reference_id)) AS ref_count
     FROM workflow_tag wt
-    JOIN mod_corpus_association mca ON wt.reference_id = mca.reference_id
-      AND mca.corpus = TRUE
     """
 
-    # if date_range_start is not None and date_range_end is not None and date_range_start != "" and date_range_end != "":
-    if date_range_start and date_range_end:
+    if date_range_start is not None and date_range_end is not None and date_range_start != "" and date_range_end != "":
         # if isinstance(date_range_end, str): # already format in counters function
         #    date_range_end_date = datetime.strptime(date_range_end, "%Y-%m-%d")
         #    new_timestamp = date_range_end_date + timedelta(days=1)
@@ -893,6 +890,43 @@ def is_file_upload_blocked(db: Session, reference_curie: str, mod_abbreviation: 
     return None
 
 
+def delete_workflow_tags(db: Session, curie_or_reference_id: str, mod_abbreviation: str):
+
+    ref = get_reference(db=db, curie_or_reference_id=str(curie_or_reference_id))
+    if ref is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"The reference curie or id {curie_or_reference_id} is not in the database")
+    reference_id = ref.reference_id
+    mod = db.query(ModModel).filter_by(abbreviation=mod_abbreviation).one_or_none()
+    if mod is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"The mod abbreviation {mod_abbreviation} is not in the database")
+    mod_id = mod.mod_id
+
+    all_text_conversion_wft = get_workflow_tags_from_process("ATP:0000161")
+    all_ref_classification_wft = get_workflow_tags_from_process("ATP:0000165")
+    all_entity_extraction_wft = get_workflow_tags_from_process("ATP:0000172")
+    all_manual_indexing_wft = get_workflow_tags_from_process("ATP:0000293")
+    all_workflow_tags = all_text_conversion_wft + all_ref_classification_wft + all_entity_extraction_wft + all_manual_indexing_wft
+
+    try:
+        sql_query = text("""
+        DELETE FROM workflow_tag
+        WHERE reference_id = :reference_id
+        AND mod_id = :mod_id
+        AND workflow_tag_id IN :all_workflow_tags
+        """)
+        db.execute(sql_query, {
+            'reference_id': reference_id,
+            'mod_id': mod_id,
+            'all_workflow_tags': tuple(all_workflow_tags)
+        })
+        db.commit()
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                            detail=f"An error occurred when resetting text conversion/ref classication/entity extraction for mod_id = {mod_id} and reference_id = {reference_id}. Error = {e}")
+
+
 def reset_workflow_tags_after_deleting_main_pdf(db: Session, curie_or_reference_id: str, mod_abbreviation: str, change_file_status=False):
 
     ref = get_reference(db=db, curie_or_reference_id=str(curie_or_reference_id))
@@ -1006,14 +1040,11 @@ def report_workflow_tags(db: Session, workflow_parent: str, mod_abbreviation: st
     # get overall paper statuses
     atp_list = "'" + "', '".join(overall_paper_status[workflow_parent].keys()) + "'"
     sql_query = text(f"""
-    SELECT wt.workflow_tag_id, COUNT(1) AS count
-    FROM workflow_tag wt
-    JOIN mod_corpus_association mca ON wt.reference_id = mca.reference_id
-    WHERE wt.workflow_tag_id IN ({atp_list})
-      AND wt.mod_id = {mod.mod_id}
-      AND mca.mod_id = {mod.mod_id}
-      AND mca.corpus = TRUE
-    GROUP BY wt.workflow_tag_id;
+    select workflow_tag_id, count(1) as count
+       from workflow_tag
+         where workflow_tag_id in ({atp_list}) and
+               mod_id = {mod.mod_id}
+             group by workflow_tag_id;
     """)
     overall_total = 0
     overall_dict = {}
@@ -1032,15 +1063,13 @@ def report_workflow_tags(db: Session, workflow_parent: str, mod_abbreviation: st
     type_total: Dict = {}
     status_total: Dict = {}
     atp_list = "'" + "', '".join(name_to_atp.values()) + "'"
+
     sql_query = text(f"""
-    SELECT wt.workflow_tag_id, COUNT(1) AS count
-    FROM workflow_tag wt
-    JOIN mod_corpus_association mca ON wt.reference_id = mca.reference_id
-    WHERE wt.workflow_tag_id IN ({atp_list})
-      AND wt.mod_id = {mod.mod_id}
-      AND mca.mod_id = {mod.mod_id}
-      AND mca.corpus = TRUE
-    GROUP BY wt.workflow_tag_id;
+    select workflow_tag_id, count(1) as count
+       from workflow_tag
+         where workflow_tag_id in ({atp_list}) and
+               mod_id = {mod.mod_id}
+             group by workflow_tag_id;
     """)
     rows = db.execute(sql_query).fetchall()
     for (atp, count) in rows:

--- a/agr_literature_service/api/crud/workflow_tag_crud.py
+++ b/agr_literature_service/api/crud/workflow_tag_crud.py
@@ -903,28 +903,20 @@ def delete_workflow_tags(db: Session, curie_or_reference_id: str, mod_abbreviati
                             detail=f"The mod abbreviation {mod_abbreviation} is not in the database")
     mod_id = mod.mod_id
 
-    all_text_conversion_wft = get_workflow_tags_from_process("ATP:0000161")
-    all_ref_classification_wft = get_workflow_tags_from_process("ATP:0000165")
-    all_entity_extraction_wft = get_workflow_tags_from_process("ATP:0000172")
-    all_manual_indexing_wft = get_workflow_tags_from_process("ATP:0000293")
-    all_workflow_tags = all_text_conversion_wft + all_ref_classification_wft + all_entity_extraction_wft + all_manual_indexing_wft
-
     try:
         sql_query = text("""
         DELETE FROM workflow_tag
         WHERE reference_id = :reference_id
         AND mod_id = :mod_id
-        AND workflow_tag_id IN :all_workflow_tags
         """)
         db.execute(sql_query, {
             'reference_id': reference_id,
-            'mod_id': mod_id,
-            'all_workflow_tags': tuple(all_workflow_tags)
+            'mod_id': mod_id
         })
         db.commit()
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                            detail=f"An error occurred when resetting text conversion/ref classication/entity extraction for mod_id = {mod_id} and reference_id = {reference_id}. Error = {e}")
+                            detail=f"An error occurred when deleting WFTs for mod_id = {mod_id} and reference_id = {reference_id}. Error = {e}")
 
 
 def reset_workflow_tags_after_deleting_main_pdf(db: Session, curie_or_reference_id: str, mod_abbreviation: str, change_file_status=False):

--- a/agr_literature_service/api/schemas/mod_corpus_association_schemas.py
+++ b/agr_literature_service/api/schemas/mod_corpus_association_schemas.py
@@ -55,6 +55,7 @@ class ModCorpusAssociationSchemaUpdate(BaseModel):
     mod_corpus_sort_source: Optional[ModCorpusSortSourceType] = None
     corpus: Optional[bool] = None
     index_wft_id: Optional[str] = None
+    force_out: Optional[bool] = None
 
     class Config():
         orm_mode = True


### PR DESCRIPTION
will return a warning message if manually added TET tags exist. Also removed the mod_corpus_association join code for report APIs.