### PR TITLE
chore(crontab): remove ENV_STATE checks from scheduled tasks

### DIFF
--- a/crontab
+++ b/crontab
@@ -7,7 +7,7 @@ BASH_ENV=/container.env
 0 6 * * * python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_search_new_references.py > /var/log/automated_scripts/pubmed_search_new_references.log 2>&1
 0 1 * * * python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/interaction/load_interaction_papers.py > /var/log/automated_scripts/load_interaction_papers.log 2>&1
 0 11 * * 6 python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_update_references_all_mods.py > /var/log/automated_scripts/pubmed_update_references_all_mods.log 2>&1
-0 7 * * 6 [ "${ENV_STATE}" = "prod" ] && python3 /usr/src/app/agr_literature_service/lit_processing/data_check/check_wft_in_progress.py > /var/log/automated_scripts/check_wft_in_progress.log 2>&1
+0 7 * * 6 python3 /usr/src/app/agr_literature_service/lit_processing/data_check/check_wft_in_progress.py > /var/log/automated_scripts/check_wft_in_progress.log 2>&1
 # 0 9 * * 7 python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/dqm_ingest/load_dqm_resource.py > /var/log/automated_scripts/load_dqm_resource.log 2>&1
 0 8 * * * python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/dqm_ingest/sort_dqm_json_reference_updates.py > /var/log/automated_scripts/sort_dqm_json_reference_updates.log 2>&1
 0 15 * * 7 python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_download_pmc_files.py > /var/log/automated_scripts/download_pmc_files.log 2>&1
@@ -17,8 +17,7 @@ BASH_ENV=/container.env
 0 0 7 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_disappeared_atp_ids.py > /var/log/automated_scripts/report_obsolete_disappeared_atp_ids.log 2>&1
 0 3 7 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_disappeared_species_ids.py > /var/log/automated_scripts/report_obsolete_disappeared_species_ids.log 2>&1
 0 4 * * * python3 /usr/src/app/agr_literature_service/lit_processing/data_export/dump_database.py -t cron > /var/log/automated_scripts/dump_prod_database.log  2>&1
-0 14 * * 7 [ "${ENV_STATE}" = "build" ] && python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/upload_pdfs_to_s3.py > /var/log/automated_scripts/upload_pdfs_to_s3.log 2>&1
-0 0 15 * * [ "${ENV_STATE}" = "prod" ] && python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/full_text/compare_referencefiles_s3_to_db.py > /var/log/automated_scripts/compare_referencefiles_s3_to_db.log 2>&1
-0 18 * * 7 [ "${ENV_STATE}" = "prod" ] && python3 /usr/src/app/agr_literature_service/lit_processing/pdf2tei/pdf2tei.py > /var/log/automated_scripts/pdf2tei.log 2>&1
+0 0 15 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/full_text/compare_referencefiles_s3_to_db.py > /var/log/automated_scripts/compare_referencefiles_s3_to_db.log 2>&1
+0 18 * * 7 python3 /usr/src/app/agr_literature_service/lit_processing/pdf2tei/pdf2tei.py > /var/log/automated_scripts/pdf2tei.log 2>&1
 
 #0 1 * * 0 bash /usr/src/app/debezium/setup.sh > /var/log/automated_scripts/rebuild_debezium.log  2>&1


### PR DESCRIPTION
Removed conditional ENV_STATE checks from multiple crontab entries to run automated scripts also on stage. This ensures the affected scripts consistently run regardless of the environment.