### PR TITLE
fix: relax validation for optional fields in ML model schema to allow…

### DIFF
--- a/agr_literature_service/api/crud/ml_model_crud.py
+++ b/agr_literature_service/api/crud/ml_model_crud.py
@@ -69,7 +69,8 @@ def upload(db: Session, request: MLModelSchemaPost, file: UploadFile):
     # Upload model file to S3
     env_state = os.environ.get("ENV_STATE", "")
     extra_args = {'StorageClass': 'GLACIER_IR'} if env_state == "prod" else {'StorageClass': 'STANDARD'}
-    folder = get_ml_model_s3_folder(request.task_type, request.mod_abbreviation, request.topic)
+    topic = request.topic if request.topic is not None else "None"
+    folder = get_ml_model_s3_folder(request.task_type, request.mod_abbreviation, topic)
     temp_file_name = f"{str(request.version_num)}.gz"
     with gzip.open(temp_file_name, 'wb') as f_out:
         shutil.copyfileobj(file.file, f_out)

--- a/agr_literature_service/api/routers/ml_model_router.py
+++ b/agr_literature_service/api/routers/ml_model_router.py
@@ -44,7 +44,7 @@ def upload_model(
         user: OktaUser = db_user,
         db: Session = db_session):
     model_data = None
-    if task_type and mod_abbreviation and topic and version_num:
+    if task_type and mod_abbreviation:
         model_data = {
             "task_type": task_type,
             "mod_abbreviation": mod_abbreviation,

--- a/agr_literature_service/api/schemas/ml_model_schemas.py
+++ b/agr_literature_service/api/schemas/ml_model_schemas.py
@@ -1,4 +1,4 @@
-from typing import Union, Optional
+from typing import Union
 
 from pydantic import BaseModel
 

--- a/agr_literature_service/api/schemas/ml_model_schemas.py
+++ b/agr_literature_service/api/schemas/ml_model_schemas.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 
 from pydantic import BaseModel
 
@@ -7,14 +7,14 @@ class MLModelSchemaBase(BaseModel):
 
     task_type: str
     mod_abbreviation: str
-    topic: str
+    topic: Union[str, None]
     version_num: Union[int, None]
     model_type: str
     file_extension: str
-    precision: float
-    recall: float
-    f1_score: float
-    parameters: str
+    precision: Union[float, None]
+    recall: Union[float, None]
+    f1_score: Union[float, None]
+    parameters: Union[str, None]
     dataset_id: Union[int, None]
 
 


### PR DESCRIPTION
… for null topic

Modified `topic`, `precision`, `recall`, `f1_score`, and similar fields to be optional in the schema and adjusted related logic in the router. These changes ensure more flexibility when handling additional models without topics such as tfidf vectorizers while avoiding validation errors.