### PR TITLE
fixed to return all topics and associated data for a paper and a mod

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -61,10 +61,11 @@ from agr_literature_service.lit_processing.utils.db_read_utils import \
     get_journal_by_resource_id
 from agr_literature_service.api.crud.topic_entity_tag_utils import \
     get_reference_id_from_curie_or_id
-from agr_literature_service.api.crud.workflow_tag_crud import \
-    get_workflow_tags_from_process
+# from agr_literature_service.api.crud.workflow_tag_crud import \
+#    get_workflow_tags_from_process
 from agr_literature_service.lit_processing.data_export.export_single_mod_references_to_json import \
     get_meta_data, get_reference_col_names, generate_json_data
+from agr_literature_service.api.crud.ateam_db_helpers import map_curies_to_names
 from agr_literature_service.lit_processing.utils.report_utils import send_report
 
 logger = logging.getLogger(__name__)
@@ -1309,66 +1310,56 @@ def get_tet_info(db: Session, reference_curie, mod_abbreviation):
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                             detail=f"The reference curie {reference_curie} is not in the database.")
 
-    topic_to_root_atp_ids = {
-        "phenotype": "ATP:0000009",
-        "interaction": "ATP:0000015",
-        "pathway": "ATP:0000022",
-        "expression": "ATP:0000010"
-    }
-
-    data = {}
-    for topic, root_atp_id in topic_to_root_atp_ids.items():
-        topic_atpid_list = (get_workflow_tags_from_process(root_atp_id) or []) + [root_atp_id]
-        # retrieve tet data for this topic
-        query = (
-            db.query(TopicEntityTagModel, TopicEntityTagSourceModel)
-            .join(
-                TopicEntityTagSourceModel,
-                TopicEntityTagModel.topic_entity_tag_source_id == TopicEntityTagSourceModel.topic_entity_tag_source_id
-            )
-            .filter(
-                TopicEntityTagModel.topic.in_(topic_atpid_list),
-                TopicEntityTagModel.reference_id == reference_id,
-                TopicEntityTagSourceModel.data_provider == mod_abbreviation
-            )
+    query = (
+        db.query(TopicEntityTagModel, TopicEntityTagSourceModel)
+        .join(
+            TopicEntityTagSourceModel,
+            TopicEntityTagModel.topic_entity_tag_source_id == TopicEntityTagSourceModel.topic_entity_tag_source_id
         )
-        rows = query.all()
+        .filter(
+            TopicEntityTagModel.reference_id == reference_id,
+            TopicEntityTagSourceModel.data_provider == mod_abbreviation
+        )
+    )
+    rows = query.all()
 
-        if len(rows) == 0:
-            continue
+    topic_to_data = defaultdict(list)
+    topic_atpids = set()
+    for tet, tet_source in rows:
+        topic_to_data[tet.topic].append((tet, tet_source))
+        topic_atpids.add(tet.topic)
 
-        topic_sources = []
-        oldest_date = None
-        has_data = False
-        novel_data = False
-        no_data = False
-        for tet, tet_source in rows:
-            topic_source = 'computational'
-            if tet_source.source_evidence_assertion == 'ATP:0000035':
-                topic_source = 'author'
-            elif tet_source.source_evidence_assertion == 'ATP:0000036':
-                topic_source = 'biocurator'
-            if topic_source not in topic_sources:
-                topic_sources.append(topic_source)
-            date_str = str(tet.date_created).split(" ")[0]  # "2025-03-05"
-            dt = datetime.strptime(date_str, "%Y-%m-%d")
-            if oldest_date is None or dt < oldest_date:
-                oldest_date = dt
+    topic_to_name = map_curies_to_names('atpterm', list(topic_atpids))
+    data = {}
+    for topic, topic_rows in topic_to_data.items():
+        topic_sources = set()
+        earliest_dt = None
+        has_data = novel_data = no_data = False
+        for tet, tet_source in topic_rows:
+            source_map = {
+                'ATP:0000035': 'author',
+                'ATP:0000036': 'biocurator'
+            }
+            topic_sources.add(source_map.get(tet_source.source_evidence_assertion, 'computational'))
+            if isinstance(tet.date_created, datetime):
+                dt = tet.date_created
+            else:
+                date_str = str(tet.date_created).split()[0]  # "2025-03-05"
+                dt = datetime.strptime(date_str, "%Y-%m-%d")
+            if earliest_dt is None or dt < earliest_dt:
+                earliest_dt = dt
+
             if tet.novel_topic_data:
                 novel_data = True
             if tet.negated:
                 no_data = True
             else:
                 has_data = True
-        topic_sources.sort()
-        topic_added = (
-            oldest_date.strftime("%b. ") + str(oldest_date.day) + oldest_date.strftime(", %Y")
-            if oldest_date
-            else None
-        )
-        data[topic] = {
+        topic_added = earliest_dt.strftime("%b. ") + str(earliest_dt.day) + earliest_dt.strftime(", %Y")
+        topic_name = topic_to_name.get(topic, topic)
+        data[topic_name] = {
             "topic_added": topic_added,
-            "topic_source": topic_sources,
+            "topic_source": sorted(topic_sources),
             "has_data": has_data,
             "novel_data": novel_data,
             "no_data": no_data

--- a/agr_literature_service/api/routers/reference_router.py
+++ b/agr_literature_service/api/routers/reference_router.py
@@ -281,6 +281,17 @@ def get_recently_sorted_references(mod_abbreviation: str,
     return references
 
 
+@router.get('/get_recently_sorted_pmids/{mod_abbreviation}',
+            status_code=status.HTTP_200_OK)
+def get_recently_sorted_pmids(mod_abbreviation: str,
+                              days: int = 7,
+                              db: Session = db_session):
+    pmid_only = True
+    pmids = reference_crud.get_recently_sorted_references(db, mod_abbreviation,
+                                                          days, pmid_only)
+    return pmids
+
+
 @router.get('/get_recently_deleted_references/{mod_abbreviation}',
             status_code=status.HTTP_200_OK)
 def get_recently_deleted_references(mod_abbreviation: str,

--- a/crontab
+++ b/crontab
@@ -10,7 +10,7 @@ BASH_ENV=/container.env
 0 7 * * 6 python3 /usr/src/app/agr_literature_service/lit_processing/data_check/check_wft_in_progress.py > /var/log/automated_scripts/check_wft_in_progress.log 2>&1
 # 0 9 * * 7 python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/dqm_ingest/load_dqm_resource.py > /var/log/automated_scripts/load_dqm_resource.log 2>&1
 0 8 * * * python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/dqm_ingest/sort_dqm_json_reference_updates.py > /var/log/automated_scripts/sort_dqm_json_reference_updates.log 2>&1
-0 11 * * 3 python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_download_pmc_files.py > /var/log/automated_scripts/download_pmc_files.log 2>&1
+0 23 * * 3 python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_download_pmc_files.py > /var/log/automated_scripts/download_pmc_files.log 2>&1
 0 17 * * 7 python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_update_references_by_doi.py > /var/log/automated_scripts/pubmed_update_references_by_doi.log 2>&1
 0 0 17 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/check_references_for_cross_references.py > /var/log/automated_scripts/find_refs_with_no_xrefs.log 2>&1
 0 0 18 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/remove_obsolete_pubmed_types.py > /var/log/automated_scripts/remove_obsolete_pubmed_types.log 2>&1


### PR DESCRIPTION
plus a new endpoint to return a list newly added PMIDs for a given mod, in the past N days (by default, it is 7 days). THese  new papers got added into MOD corpus, but without a MOD paper ID.