### PR TITLE
Use centralized Claude review thresholds from .github repo

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,8 +26,7 @@ jobs:
       review_focus: "critical bugs, database performance issues, and security vulnerabilities in the Python FastAPI backend. Focus on: SQLAlchemy N+1 queries, missing database indexes, inefficient ORM usage, SQL injection risks, async/await misuse, API rate limiting issues, improper transaction handling, and data validation gaps"
       trigger_phrase: "@claude"
       use_zen_tools: true
-      pr_size_threshold: "300"
-      skip_threshold: "25"
+      # Use centralized thresholds from .github repo (skip_threshold: 3, pr_size_threshold: 40)
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
- Remove hardcoded pr_size_threshold and skip_threshold
- Let workflow inherit defaults from alliance-genome/.github
- Centralized thresholds: skip ≤3 lines, zen >40 lines
- Supports Skip 10%, Zen 50% strategy across all repos