### PR TITLE
fix(auth): remove set_global_user_from_cognito from read endpoints

### DIFF
--- a/agr_literature_service/api/routers/author_router.py
+++ b/agr_literature_service/api/routers/author_router.py
@@ -56,7 +56,6 @@ async def patch(author_id: int,
 def show(author_id: int,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return author_crud.show(db, author_id)
 
 
@@ -65,5 +64,4 @@ def show(author_id: int,
 def show_versions(author_id: int,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return author_crud.show_changesets(db, author_id)

--- a/agr_literature_service/api/routers/bulk_downloads_router.py
+++ b/agr_literature_service/api/routers/bulk_downloads_router.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 from agr_literature_service.api import database
 from agr_literature_service.api.crud import reference_crud, resource_crud
 from agr_literature_service.api.auth import get_authenticated_user
-from agr_literature_service.api.user import set_global_user_from_cognito
 
 router = APIRouter(
     prefix="/bulk_download",
@@ -21,7 +20,6 @@ db_session: Session = Depends(get_db)
             status_code=200)
 async def show(db: Session = db_session,
                user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return reference_crud.show_all_references_external_ids(db)
 
 
@@ -29,5 +27,4 @@ async def show(db: Session = db_session,
             status_code=200)
 async def show_ex_ids(db: Session = db_session,
                       user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return resource_crud.show_all_resources_external_ids(db)

--- a/agr_literature_service/api/routers/check_router.py
+++ b/agr_literature_service/api/routers/check_router.py
@@ -7,7 +7,6 @@ from agr_literature_service.api import database
 from agr_literature_service.api.auth import get_authenticated_user
 from agr_literature_service.api.crud import check_crud
 from agr_literature_service.api.schemas import (AteamApiSchemaShow, DatabaseSchemaShow, EnvironmentsSchemaShow)
-from agr_literature_service.api.user import set_global_user_from_cognito
 
 router = APIRouter(
     prefix="/check",
@@ -35,7 +34,6 @@ def check_database(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return {"db_details": check_crud.check_database(db)}
 
 

--- a/agr_literature_service/api/routers/copyright_license_router.py
+++ b/agr_literature_service/api/routers/copyright_license_router.py
@@ -34,5 +34,4 @@ def create(request: CopyrightLicenseSchemaPost,
             status_code=200)
 def show_all(db: Session = db_session,
              user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return copyright_license_crud.show_all(db)

--- a/agr_literature_service/api/routers/cross_reference_router.py
+++ b/agr_literature_service/api/routers/cross_reference_router.py
@@ -60,7 +60,6 @@ async def patch(cross_reference_id: int,
 def show_version(cross_reference_id: int,
                  user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                  db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return cross_reference_crud.show_changesets(db, cross_reference_id)
 
 
@@ -72,7 +71,6 @@ def autocomplete_search(
         return_prefix: bool = False,
         user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
         db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return cross_reference_crud.autocomplete_on_id(prefix, query, return_prefix, db)
 
 
@@ -83,7 +81,6 @@ def autocomplete_search(
 def show_all(curies: List[str],
              user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
              db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return cross_reference_crud.show_from_curies(db, curies)
 
 
@@ -115,5 +112,4 @@ def check_curie_reference_pattern(datatype: str,
 def show(curie: str,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return cross_reference_crud.show(db, curie)

--- a/agr_literature_service/api/routers/curation_status_router.py
+++ b/agr_literature_service/api/routers/curation_status_router.py
@@ -28,7 +28,6 @@ def show_aggregated_curation_status_and_tet_info(reference_curie: str,
                                                  mod_abbreviation: str,
                                                  db: Session = db_session,
                                                  user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return curation_status_crud.get_aggregated_curation_status_and_tet_info(db, reference_curie, mod_abbreviation)
 
 
@@ -37,7 +36,6 @@ def show_aggregated_curation_status_and_tet_info(reference_curie: str,
 def show(curation_status_id: int,
          db: Session = db_session,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return curation_status_crud.show(db, curation_status_id)
 
 

--- a/agr_literature_service/api/routers/dataset_router.py
+++ b/agr_literature_service/api/routers/dataset_router.py
@@ -40,7 +40,6 @@ def create_dataset(request: DatasetSchemaPost,
 def show_dataset(mod_abbreviation: str, data_type: str, dataset_type: str, version: int = None,
                  db: Session = db_session,
                  user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return dataset_crud.show_dataset(db, mod_abbreviation=mod_abbreviation, data_type=data_type,
                                      dataset_type=dataset_type, version=version)
 
@@ -74,7 +73,6 @@ def patch_dataset(request: DatasetSchemaUpdate, mod_abbreviation: str, data_type
 def download_dataset(mod_abbreviation: str, data_type: str, dataset_type: str, version: int = None,
                      db: Session = db_session,
                      user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     db_dataset = dataset_crud.download_dataset(db, mod_abbreviation=mod_abbreviation, data_type=data_type,
                                                dataset_type=dataset_type, version=version)
     return db_dataset

--- a/agr_literature_service/api/routers/editor_router.py
+++ b/agr_literature_service/api/routers/editor_router.py
@@ -78,7 +78,6 @@ def show(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session
 ) -> EditorSchemaShow:
-    set_global_user_from_cognito(db, user)
     editor = editor_crud.show(db, editor_id)
     return EditorSchemaShow.model_validate(editor)
 
@@ -92,5 +91,4 @@ def show_versions(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session
 ):
-    set_global_user_from_cognito(db, user)
     return editor_crud.show_changesets(db, editor_id)

--- a/agr_literature_service/api/routers/email_router.py
+++ b/agr_literature_service/api/routers/email_router.py
@@ -49,7 +49,6 @@ def list_for_person(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return email_crud.list_for_person(db, person_id)
 
 
@@ -64,7 +63,6 @@ def show(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return email_crud.show(db, email_id)
 
 

--- a/agr_literature_service/api/routers/indexing_priority_router.py
+++ b/agr_literature_service/api/routers/indexing_priority_router.py
@@ -79,7 +79,6 @@ def show(
     db: Session = db_session,
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
 ) -> IndexingPrioritySchemaShow:
-    set_global_user_from_cognito(db, user)
     data = indexing_priority_crud.show(db, indexing_priority_id)
     return IndexingPrioritySchemaShow.model_validate(data)
 
@@ -94,7 +93,6 @@ def get_indexing_priority_tag(
     db: Session = db_session,
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
 ):
-    set_global_user_from_cognito(db, user)
     if mod_abbreviation != 'ZFIN':
         return {}
     return indexing_priority_crud.get_indexing_priority_tag(

--- a/agr_literature_service/api/routers/manual_indexing_tag_router.py
+++ b/agr_literature_service/api/routers/manual_indexing_tag_router.py
@@ -87,7 +87,6 @@ def show(
     db: Session = db_session,
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
 ) -> ManualIndexingTagSchemaShow:
-    set_global_user_from_cognito(db, user)
     data = manual_indexing_tag_crud.show(db, manual_indexing_tag_id)
     return ManualIndexingTagSchemaShow.model_validate(data)
 
@@ -102,7 +101,6 @@ def get_manual_indexing_tag(
     db: Session = db_session,
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
 ):
-    set_global_user_from_cognito(db, user)
     return manual_indexing_tag_crud.get_manual_indexing_tag(
         db, reference_curie, mod_abbreviation
     )

--- a/agr_literature_service/api/routers/mesh_detail_router.py
+++ b/agr_literature_service/api/routers/mesh_detail_router.py
@@ -58,7 +58,6 @@ async def patch(mesh_detail_id: int,
 def show(mesh_detail_id: int,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mesh_detail_crud.show(db, mesh_detail_id)
 
 
@@ -67,5 +66,4 @@ def show(mesh_detail_id: int,
 def show_versions(mesh_detail_id: int,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mesh_detail_crud.show_changesets(db, mesh_detail_id)

--- a/agr_literature_service/api/routers/ml_model_router.py
+++ b/agr_literature_service/api/routers/ml_model_router.py
@@ -110,7 +110,6 @@ def get_model_metadata(task_type: str,
                        version: str = None,
                        db: Session = db_session,
                        user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return ml_model_crud.get_model_metadata(db, task_type, mod_abbreviation, topic, version)
 
 
@@ -129,5 +128,4 @@ def download_model_file(task_type: str,
                         version: str = None,
                         db: Session = db_session,
                         user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return ml_model_crud.download_model_file(db, task_type, mod_abbreviation, topic, version)

--- a/agr_literature_service/api/routers/mod_corpus_association_router.py
+++ b/agr_literature_service/api/routers/mod_corpus_association_router.py
@@ -61,7 +61,6 @@ async def patch(mod_corpus_association_id: int,
 def show(mod_corpus_association_id: int,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_corpus_association_crud.show(db, mod_corpus_association_id)
 
 
@@ -71,7 +70,6 @@ def show(mod_corpus_association_id: int,
 def show_id(curie: str, mod_abbreviation: str,
             user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
             db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_corpus_association_crud.show_by_reference_mod_abbreviation(db, curie, mod_abbreviation)
 
 
@@ -80,5 +78,4 @@ def show_id(curie: str, mod_abbreviation: str,
 def show_versions(mod_corpus_association_id: int,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_corpus_association_crud.show_changesets(db, mod_corpus_association_id)

--- a/agr_literature_service/api/routers/mod_reference_type_router.py
+++ b/agr_literature_service/api/routers/mod_reference_type_router.py
@@ -61,7 +61,6 @@ async def patch(mod_reference_type_id: int,
 def show(mod_reference_type_id: int,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_reference_type_crud.show(db, mod_reference_type_id)
 
 
@@ -70,7 +69,6 @@ def show(mod_reference_type_id: int,
 def show_versions(mod_reference_type_id: int,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_reference_type_crud.show_changesets(db, mod_reference_type_id)
 
 
@@ -80,7 +78,6 @@ def show_versions(mod_reference_type_id: int,
 def show_by_mod(abbreviation: str,
                 user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                 db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_reference_type_crud.show_by_mod(db=db, mod_abbreviation=abbreviation)
 
 
@@ -89,5 +86,4 @@ def show_by_mod(abbreviation: str,
 def mod_reftype_to_mods_endpoint(
         user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
         db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_reference_type_crud.mod_reftype_to_mods(db=db)

--- a/agr_literature_service/api/routers/mod_router.py
+++ b/agr_literature_service/api/routers/mod_router.py
@@ -48,7 +48,6 @@ async def patch(mod_id: int,
 def show(abbreviation: str,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_crud.show(db, abbreviation)
 
 
@@ -57,7 +56,6 @@ def show(abbreviation: str,
 def taxons(type: str,
            user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
            db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_crud.taxons(db, type)
 
 
@@ -66,5 +64,4 @@ def taxons(type: str,
 def show_versions(mod_id: int,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return mod_crud.show_changesets(db, mod_id)

--- a/agr_literature_service/api/routers/person_cross_reference_router.py
+++ b/agr_literature_service/api/routers/person_cross_reference_router.py
@@ -48,7 +48,6 @@ def list_for_person(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return person_cross_reference_crud.list_for_person(db, person_id)
 
 
@@ -63,7 +62,6 @@ def show(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return person_cross_reference_crud.show(db, person_cross_reference_id)
 
 

--- a/agr_literature_service/api/routers/person_router.py
+++ b/agr_literature_service/api/routers/person_router.py
@@ -92,7 +92,6 @@ def show(
     """
     Get a person by internal ID.
     """
-    set_global_user_from_cognito(db, user)
     return person_crud.show(db, person_id)
 
 
@@ -110,7 +109,6 @@ def get_by_email(
     Get a single person by email (exact match).
     Returns 200 with the person if found; 204 (no content) if not found.
     """
-    set_global_user_from_cognito(db, user)
     person = person_crud.get_by_email(db, email)
     if not person:
         return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -131,5 +129,4 @@ def get_by_name(
     Find people by name. Returns a (possibly empty) list.
     Implement the matching strategy (exact/ILIKE) inside person_crud.
     """
-    set_global_user_from_cognito(db, user)
     return person_crud.find_by_name(db, name)

--- a/agr_literature_service/api/routers/person_setting_router.py
+++ b/agr_literature_service/api/routers/person_setting_router.py
@@ -79,7 +79,6 @@ def show(
     """
     Get a person_setting row by internal ID.
     """
-    set_global_user_from_cognito(db, user)
     return person_setting_crud.show(db, person_setting_id)
 
 
@@ -97,7 +96,6 @@ def get_by_email(
     Get person_setting rows by email (exact match).
     Returns 200 with a list (possibly multiple rows) or 204 if none.
     """
-    set_global_user_from_cognito(db, user)
     person_setting_list = person_setting_crud.get_by_email(db, email)
     if not person_setting_list:
         return Response(status_code=status.HTTP_204_NO_CONTENT)
@@ -118,5 +116,4 @@ def get_by_name(
     Find person_setting rows by person display name.
     Matching strategy (exact/ILIKE) is implemented inside person_setting_crud.
     """
-    set_global_user_from_cognito(db, user)
     return person_setting_crud.find_by_name(db, name)

--- a/agr_literature_service/api/routers/reference_relation_router.py
+++ b/agr_literature_service/api/routers/reference_relation_router.py
@@ -77,7 +77,6 @@ def show(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ) -> ReferenceRelationSchemaShow:
-    set_global_user_from_cognito(db, user)
     return reference_relation_crud.show(db, reference_relation_id)
 
 
@@ -90,5 +89,4 @@ def show_versions(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return reference_relation_crud.show_changesets(db, reference_relation_id)

--- a/agr_literature_service/api/routers/reference_router.py
+++ b/agr_literature_service/api/routers/reference_router.py
@@ -72,7 +72,6 @@ def add(request: ReferenceSchemaAddPmid,
 def external_lookup(external_curie: str,
                     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                     db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     prefix, identifier, _ = split_identifier(external_curie, ignore_error=True)
     if not prefix:
         raise HTTPException(
@@ -112,8 +111,6 @@ async def patch(curie_or_reference_id: str,
 def download_data_by_mod(mod: str,
                          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                          db: Session = db_session):
-
-    set_global_user_from_cognito(db, user)
     return download.get_json_file(mod)
 
 
@@ -122,8 +119,6 @@ def download_data_by_mod(mod: str,
 def download_data_by_filename(filename: str,
                               user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                               db: Session = db_session):
-
-    set_global_user_from_cognito(db, user)
     return download.get_json_file(None, filename)
 
 
@@ -184,7 +179,6 @@ def generate_data_ondemand(mod: str,
 def show_xref(curie_or_cross_reference_id: str,
               user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
               db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     cross_reference = cross_reference_crud.show(db, curie_or_cross_reference_id)
 
     if 'reference_curie' not in cross_reference:
@@ -201,7 +195,6 @@ def show_xref(curie_or_cross_reference_id: str,
 def show(curie_or_reference_id: str,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return reference_crud.show(db, curie_or_reference_id)
 
 
@@ -210,7 +203,6 @@ def show(curie_or_reference_id: str,
 def show_versions(curie_or_reference_id: str,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return reference_crud.show_changesets(db, curie_or_reference_id)
 
 
@@ -227,7 +219,6 @@ def get_reference_emails(
     """
     Get all emails associated with a given reference.
     """
-    set_global_user_from_cognito(db, user)
     return reference_crud.get_reference_emails(db, curie_or_reference_id)
 
 
@@ -325,7 +316,6 @@ def missing_files(mod_abbreviation: str,
                   filter: str,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     missing_files = reference_crud.missing_files(db, mod_abbreviation, order_by, page, filter)
     if not missing_files:
         return []
@@ -339,7 +329,6 @@ def download_tracker_table(mod_abbreviation: str,
                            filter: str,
                            user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                            db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return reference_crud.download_tracker_table(db, mod_abbreviation, order_by, filter)
 
 
@@ -350,7 +339,6 @@ def get_bib_info(curie: str,
                  return_format: str = 'txt',
                  user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                  db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return reference_crud.get_bib_info(db, curie, mod_abbreviation, return_format)
 
 
@@ -365,7 +353,6 @@ def get_textpresso_reference_list(mod_abbreviation: str,
                                   page_size: int = 1000,
                                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return reference_crud.get_textpresso_reference_list(db, mod_abbreviation,
                                                         files_updated_from_date,
                                                         reference_type,
@@ -391,7 +378,6 @@ def get_recently_sorted_references(mod_abbreviation: str,
                                    days: int = 7,
                                    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                                    db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     references = reference_crud.get_recently_sorted_references(db, mod_abbreviation, days)
 
     return references
@@ -403,7 +389,6 @@ def get_recently_sorted_pmids(mod_abbreviation: str,
                               days: int = 7,
                               user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                               db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     pmid_only = True
     pmids = reference_crud.get_recently_sorted_references(db, mod_abbreviation,
                                                           days, pmid_only)
@@ -416,7 +401,6 @@ def get_recently_deleted_references(mod_abbreviation: str,
                                     days: int = 7,
                                     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                                     db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     references = reference_crud.get_recently_deleted_references(db, mod_abbreviation, days)
 
     return references
@@ -427,7 +411,6 @@ def get_recently_deleted_references(mod_abbreviation: str,
 def get_obsolete_mod_curies(mod_abbreviation: str,
                             user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                             db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return reference_crud.get_obsolete_mod_curies(db, mod_abbreviation)
 
 
@@ -436,7 +419,6 @@ def get_obsolete_mod_curies(mod_abbreviation: str,
 def lock_status(referenceCurie: str,
                 user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                 db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     lock_details = reference_crud.lock_status(db, referenceCurie)
 
     return lock_details

--- a/agr_literature_service/api/routers/referencefile_mod_router.py
+++ b/agr_literature_service/api/routers/referencefile_mod_router.py
@@ -54,7 +54,6 @@ def show(
     db: Session = db_session,
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
 ) -> ReferencefileModSchemaShow:
-    set_global_user_from_cognito(db, user)
     return referencefile_mod_crud.show(db, referencefile_mod_id)
 
 

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -128,7 +128,6 @@ def file_upload(reference_curie: str = None,
 def download_file(referencefile_id: int,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return referencefile_crud.download_file(db, referencefile_id, get_mod_access(user) if user else [])
 
 
@@ -137,7 +136,6 @@ def download_file(referencefile_id: int,
 def download_additional_files_tarball(reference_id: int,
                                       user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                                       db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return referencefile_crud.download_additional_files_tarball(db, reference_id, get_mod_access(user) if user else [])
 
 
@@ -157,7 +155,6 @@ def delete(referencefile_id: int,
 def show(referencefile_id: int,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return referencefile_crud.show(db, referencefile_id)
 
 
@@ -167,7 +164,6 @@ def show(referencefile_id: int,
 def show_all(curie_or_reference_id: str,
              user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
              db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return referencefile_crud.show_all(db, curie_or_reference_id)
 
 
@@ -178,7 +174,6 @@ def show_all(curie_or_reference_id: str,
 def show_main_pdf_ids_for_curies(data: ReferenceFileAllMainPDFIdsSchemaPost,
                                  user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                                  db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return referencefile_crud.get_main_pdf_referencefile_ids_for_ref_curies_list(
         db=db, curies=data.curies, mod_abbreviation=data.mod_abbreviation)
 

--- a/agr_literature_service/api/routers/resource_descriptor_router.py
+++ b/agr_literature_service/api/routers/resource_descriptor_router.py
@@ -22,7 +22,6 @@ db_session: Session = Depends(get_db)
             status_code=200)
 def show(db: Session = db_session,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    set_global_user_from_cognito(db, user)
     return resource_descriptor_crud.show(db)
 
 

--- a/agr_literature_service/api/routers/resource_router.py
+++ b/agr_literature_service/api/routers/resource_router.py
@@ -43,7 +43,6 @@ def create(request: ResourceSchemaPost,
 def external_lookup(external_curie: str,
                     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                     db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     prefix, identifier, _ = split_identifier(external_curie, ignore_error=True)
     if not prefix:
         raise HTTPException(
@@ -118,7 +117,6 @@ def patch(curie: str,
                         "Use curl or programmatic access instead.")
 def show_all(user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
              db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return resource_crud.show_all(db)
 
 
@@ -128,7 +126,6 @@ def show_all(user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
 def show(curie: str,
          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
          db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return resource_crud.show(db, curie)
 
 
@@ -137,5 +134,4 @@ def show(curie: str,
 def show_versions(curie: str,
                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                   db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return resource_crud.show_changesets(db, curie)

--- a/agr_literature_service/api/routers/sort_router.py
+++ b/agr_literature_service/api/routers/sort_router.py
@@ -7,7 +7,6 @@ from agr_literature_service.api import database
 from agr_literature_service.api.auth import get_authenticated_user
 from agr_literature_service.api.crud import sort_crud
 from agr_literature_service.api.schemas import ReferenceSchemaNeedReviewShow
-from agr_literature_service.api.user import set_global_user_from_cognito
 
 
 router = APIRouter(
@@ -26,7 +25,6 @@ def show_need_review(mod_abbreviation: str,
                      count: int = None,
                      user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                      db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return sort_crud.show_need_review(mod_abbreviation, count, db)
 
 
@@ -37,7 +35,6 @@ def show_prepublication_pipeline(mod_abbreviation: str,
                                  count: int = None,
                                  user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                                  db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return sort_crud.show_prepublication_pipeline(mod_abbreviation, count, db)
 
 
@@ -49,5 +46,4 @@ def show_recently_sorted(mod_abbreviation: str,
                          db: Session = db_session,
                          curator: str = None,
                          day: int = 7):
-    set_global_user_from_cognito(db, user)
     return sort_crud.show_recently_sorted(db, mod_abbreviation, count, curator, day)

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -41,7 +41,6 @@ def create_tag(request: TopicEntityTagSchemaPost,
 def show_tag(topic_entity_tag_id: int,
              user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
              db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return topic_entity_tag_crud.show_tag(db, topic_entity_tag_id)
 
 
@@ -101,7 +100,6 @@ def patch_source(topic_entity_tag_source_id,
             status_code=200)
 def show_all_source(user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                     db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return topic_entity_tag_crud.show_all_source(db)
 
 
@@ -111,7 +109,6 @@ def show_all_source(user: Optional[Dict[str, Any]] = Security(get_authenticated_
 def show_source(topic_entity_tag_source_id: int,
                 user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                 db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return topic_entity_tag_crud.show_source(db, topic_entity_tag_source_id)
 
 
@@ -124,7 +121,6 @@ def show_source_by_name(source_evidence_assertion: str,
                         secondary_data_provider_abbreviation: str,
                         user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                         db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return topic_entity_tag_crud.show_source_by_name(db, source_evidence_assertion, source_method,
                                                      data_provider, secondary_data_provider_abbreviation)
 
@@ -144,7 +140,6 @@ def show_all_reference_tags(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session
 ) -> Union[List[TopicEntityTagSchemaRelated], int]:
-    set_global_user_from_cognito(db, user)
     result = topic_entity_tag_crud.show_all_reference_tags(
         db, curie_or_reference_id,
         page, page_size,
@@ -161,7 +156,6 @@ def get_reference_tags(mod_abbreviation: str,
                        days_updated: int = 7,
                        user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                        db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return topic_entity_tag_crud.get_all_topic_entity_tags_by_mod(db, mod_abbreviation, days_updated)
 
 
@@ -171,7 +165,6 @@ def get_reference_tags(mod_abbreviation: str,
 def get_curie_to_name_from_all_tets(curie_or_reference_id: str,
                                     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                                     db: Session = db_session):
-    set_global_user_from_cognito(db, user)
     return topic_entity_tag_crud.get_curie_to_name_from_all_tets(db, curie_or_reference_id)
 
 

--- a/agr_literature_service/api/routers/workflow_tag_router.py
+++ b/agr_literature_service/api/routers/workflow_tag_router.py
@@ -82,7 +82,6 @@ def show(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ) -> WorkflowTagSchemaShow:
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.show(db, reference_workflow_tag_id)
 
 
@@ -100,7 +99,6 @@ def get_jobs(
     reference: str = None,
     topic: str = None,
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.get_jobs(
         db, job_string, limit, offset,
         mod_abbr=mod_abbreviation,
@@ -170,7 +168,6 @@ def show_versions(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.show_changesets(db, reference_workflow_tag_id)
 
 
@@ -204,7 +201,6 @@ def get_current_workflow_status(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.get_current_workflow_status(
         db=db,
         curie_or_reference_id=curie_or_reference_id,
@@ -227,7 +223,6 @@ def counters(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.counters(
         db=db,
         mod_abbreviation=mod_abbreviation,
@@ -251,7 +246,6 @@ def get_reference_workflow_tags(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.get_reference_workflow_tags_by_mod(
         db, workflow_tag_id, mod_abbreviation, startDate, endDate
     )
@@ -267,7 +261,6 @@ def get_report_workflow_tags(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.report_workflow_tags(db, workflow_tag_id, mod_abbreviation)
 
 
@@ -280,7 +273,6 @@ def get_report_workflow_diagram(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.get_workflow_tag_diagram(mod, db)
 
 
@@ -305,7 +297,6 @@ def get_workflow_tags_subset(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.workflow_subset_list(workflow_name, mod_abbreviation, db)
 
 
@@ -338,7 +329,6 @@ def get_indexing_and_community_workflow_tags(
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    set_global_user_from_cognito(db, user)
     return workflow_tag_crud.get_indexing_and_community_workflow_tags(
         db, reference_curie, mod_abbreviation
     )

--- a/agr_literature_service/api/user.py
+++ b/agr_literature_service/api/user.py
@@ -1,4 +1,5 @@
 from typing import Optional, Dict, Any
+from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -78,7 +79,10 @@ def set_global_user_from_cognito(db: Session, cognito_user: Optional[Dict[str, A
     user_email: Optional[str] = cognito_user.get("email", "")
 
     if not user_email:
-        raise ValueError("Cognito user does not have an associated email address.")
+        raise HTTPException(
+            status_code=403,
+            detail="Cognito user does not have an associated email address."
+        )
 
     # Query using raw SQL to avoid circular import with EmailModel
     sql = text("""
@@ -93,7 +97,11 @@ def set_global_user_from_cognito(db: Session, cognito_user: Optional[Dict[str, A
     result = db.execute(sql, {"email": user_email}).fetchone()
 
     if result is None:
-        raise ValueError(f"No user found with email address: {user_email}")
+        raise HTTPException(
+            status_code=403,
+            detail=f"No user account linked to email address: {user_email}. "
+                   "Contact an administrator to create your user account."
+        )
 
     # Set the global user ID from the query result
     _current_user_id = result[0]

--- a/tests/api/test_user_auth_scenarios.py
+++ b/tests/api/test_user_auth_scenarios.py
@@ -1,0 +1,154 @@
+"""
+Tests for user authentication and authorization scenarios.
+
+Verifies that:
+1. Authenticated users can read regardless of DB user record
+2. Write endpoints require a DB user record (403 without one)
+3. Unauthenticated requests get 401 on everything
+"""
+
+from unittest.mock import patch
+from starlette.testclient import TestClient
+from fastapi import HTTPException, status
+
+from agr_literature_service.api.main import app
+from agr_literature_service.api.auth import get_authenticated_user
+from agr_literature_service.api import auth as auth_module
+from ..fixtures import db  # noqa
+
+
+# Mock user dicts that mimic what get_authenticated_user returns
+# ID token user whose email has NO matching users row in the DB
+VALID_USER_NO_DB_RECORD = {
+    "sub": "orphan-user-id",
+    "email": "orphan_no_db_user@example.com",
+    "name": "Orphan User",
+    "cognito:groups": [],
+    "token_type": "id",
+}
+
+# Access token user (service account) - always works via default_user
+ACCESS_TOKEN_USER = {
+    "sub": "service-account",
+    "token_type": "access",
+    "cognito:groups": [],
+}
+
+
+def _no_auth():
+    """Mock that simulates no credentials provided."""
+    raise HTTPException(status_code=401, detail="Missing authentication token")
+
+
+def _auth_no_db_user():
+    """Mock that returns a valid ID token user with no DB record."""
+    return VALID_USER_NO_DB_RECORD
+
+
+def _auth_access_token():
+    """Mock that returns an access token user (service account)."""
+    return ACCESS_TOKEN_USER
+
+
+class TestReadEndpointsNoUserLookup:
+    """Read endpoints should work for any authenticated user,
+    even without a DB user record."""
+
+    def test_read_with_valid_auth_no_db_user(self, db):  # noqa
+        """Authenticated user without DB user row can still read."""
+        app.dependency_overrides[get_authenticated_user] = _auth_no_db_user
+        try:
+            with patch.object(auth_module, 'is_skip_read_auth_ip', return_value=False), \
+                 patch.object(auth_module, 'is_skip_all_auth_ip', return_value=False):
+                with TestClient(app) as client:
+                    # GET /mod/{abbreviation} is a read endpoint
+                    response = client.get(url="/mod/WB")
+                    # Should succeed or 404 — NOT 403 or 500
+                    assert response.status_code in [
+                        status.HTTP_200_OK, status.HTTP_404_NOT_FOUND
+                    ]
+        finally:
+            app.dependency_overrides.pop(get_authenticated_user, None)
+
+    def test_read_with_access_token_works(self, db):  # noqa
+        """Access token user (service account) can read."""
+        app.dependency_overrides[get_authenticated_user] = _auth_access_token
+        try:
+            with patch.object(auth_module, 'is_skip_read_auth_ip', return_value=False), \
+                 patch.object(auth_module, 'is_skip_all_auth_ip', return_value=False):
+                with TestClient(app) as client:
+                    response = client.get(url="/mod/WB")
+                    assert response.status_code in [
+                        status.HTTP_200_OK, status.HTTP_404_NOT_FOUND
+                    ]
+        finally:
+            app.dependency_overrides.pop(get_authenticated_user, None)
+
+    def test_read_returns_401_without_auth(self, db):  # noqa
+        """No auth should return 401."""
+        app.dependency_overrides[get_authenticated_user] = _no_auth
+        try:
+            with patch.object(auth_module, 'is_skip_read_auth_ip', return_value=False), \
+                 patch.object(auth_module, 'is_skip_all_auth_ip', return_value=False):
+                with TestClient(app) as client:
+                    response = client.get(url="/mod/WB")
+                    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        finally:
+            app.dependency_overrides.pop(get_authenticated_user, None)
+
+
+class TestWriteEndpointsRequireDbUser:
+    """Write endpoints call set_global_user_from_cognito and need a DB user."""
+
+    def test_write_with_access_token_works(self, db):  # noqa
+        """Access token user (service account) can write via default_user."""
+        app.dependency_overrides[get_authenticated_user] = _auth_access_token
+        try:
+            with patch.object(auth_module, 'is_skip_read_auth_ip', return_value=False), \
+                 patch.object(auth_module, 'is_skip_all_auth_ip', return_value=False):
+                with TestClient(app) as client:
+                    new_mod = {
+                        "abbreviation": "TESTAUTH",
+                        "short_name": "TestAuth",
+                        "full_name": "Test Auth MOD"
+                    }
+                    response = client.post(url="/mod/", json=new_mod)
+                    # Should succeed — access token uses default_user
+                    assert response.status_code == status.HTTP_201_CREATED
+        finally:
+            app.dependency_overrides.pop(get_authenticated_user, None)
+
+    def test_write_with_no_db_user_returns_403(self, db):  # noqa
+        """ID token user with no DB user row should get 403 on write."""
+        app.dependency_overrides[get_authenticated_user] = _auth_no_db_user
+        try:
+            with patch.object(auth_module, 'is_skip_read_auth_ip', return_value=False), \
+                 patch.object(auth_module, 'is_skip_all_auth_ip', return_value=False):
+                with TestClient(app) as client:
+                    new_mod = {
+                        "abbreviation": "TESTFAIL",
+                        "short_name": "TestFail",
+                        "full_name": "Test Fail MOD"
+                    }
+                    response = client.post(url="/mod/", json=new_mod)
+                    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+        finally:
+            app.dependency_overrides.pop(get_authenticated_user, None)
+
+    def test_write_returns_401_without_auth(self, db):  # noqa
+        """No auth should return 401 on write."""
+        app.dependency_overrides[get_authenticated_user] = _no_auth
+        try:
+            with patch.object(auth_module, 'is_skip_read_auth_ip', return_value=False), \
+                 patch.object(auth_module, 'is_skip_all_auth_ip', return_value=False):
+                with TestClient(app) as client:
+                    new_mod = {
+                        "abbreviation": "TESTNOAUTH",
+                        "short_name": "TestNoAuth",
+                        "full_name": "Test NoAuth MOD"
+                    }
+                    response = client.post(url="/mod/", json=new_mod)
+                    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        finally:
+            app.dependency_overrides.pop(get_authenticated_user, None)


### PR DESCRIPTION
Read-only endpoints don't need to look up the user in the DB — they don't write audit fields (created_by/updated_by). Previously, any Cognito-authenticated user whose email had no matching users row would get a 500 ValueError on every endpoint, including reads.

- Remove set_global_user_from_cognito call from ~89 read-only endpoints across 28 router files. Auth is still required via the Security dependency — endpoints remain locked down, but authenticated users no longer need a DB user record to perform reads.
- Change ValueError to HTTPException(403) in user.py so write endpoints return a clear error instead of 500 when no DB user record exists.
- POST endpoints that only read (cross_reference/show_all, referencefile/show_main_pdf_ids_for_curies) also had the call removed.
- GET endpoint that writes (topic_entity_tag/revalidate_all_tags) retains the call since it needs user tracking for audit.
- Add test_user_auth_scenarios.py verifying: authenticated user without DB record can read, gets 403 on write; no auth gets 401 on both.