### PR TITLE
feat(ml_model): add file_classes column to ml_model

### DIFF
--- a/agr_literature_service/api/crud/ml_model_crud.py
+++ b/agr_literature_service/api/crud/ml_model_crud.py
@@ -71,7 +71,8 @@ def upload(db: Session, request: MLModelSchemaPost, file: UploadFile):
         production=request.production,
         species=request.species,
         data_novelty=request.data_novelty,
-        negated=request.negated
+        negated=request.negated,
+        file_classes=request.file_classes
     )
     try:
         db.add(new_model)
@@ -164,7 +165,8 @@ def get_model_schema_from_orm(model: MLModel):
         "production": model.production,
         "species": model.species,
         "data_novelty": model.data_novelty,
-        "negated": model.negated
+        "negated": model.negated,
+        "file_classes": model.file_classes
     }
     return MLModelSchemaShow(**model_data)
 

--- a/agr_literature_service/api/models/ml_model_model.py
+++ b/agr_literature_service/api/models/ml_model_model.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Float, ForeignKey, UniqueConstraint, Boolean
+from sqlalchemy import Column, Integer, String, Float, ForeignKey, UniqueConstraint, Boolean, ARRAY
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 from agr_literature_service.api.database.base import Base
 
@@ -87,6 +87,11 @@ class MLModel(Base):
 
     data_novelty = Column(
         String,
+        nullable=True
+    )
+
+    file_classes = Column(
+        ARRAY(String),
         nullable=True
     )
 

--- a/agr_literature_service/api/routers/ml_model_router.py
+++ b/agr_literature_service/api/routers/ml_model_router.py
@@ -1,8 +1,8 @@
 import json
 from json import JSONDecodeError
-from typing import List, Union, Dict, Any, Optional
+from typing import Union, Dict, Any, Optional
 
-from fastapi import APIRouter, Depends, Query, Security, status, UploadFile, File, HTTPException
+from fastapi import APIRouter, Depends, Security, status, UploadFile, File, HTTPException
 
 from sqlalchemy.orm import Session
 
@@ -39,14 +39,14 @@ def upload_model(
         parameters: str = None,
         dataset_id: int = None,
         file: UploadFile = File(...),  # noqa: B008
-        model_data_file: Union[UploadFile, str, None] = File(default=None),  # noqa: B008
+        model_data_file: Union[UploadFile, None] = File(default=None),  # noqa: B008
         user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
         db: Session = db_session,
         production: bool = False,
         negated: bool = True,
         data_novelty: str = None,
         species: str = None,
-        file_classes: str = Query(default=None)):
+        file_classes: str = None):
     model_data = None
     if task_type and mod_abbreviation:
         file_classes_list = [c.strip() for c in file_classes.split(",") if c.strip()] if file_classes else None
@@ -68,7 +68,7 @@ def upload_model(
             "species": species,
             "file_classes": file_classes_list
         }
-    elif isinstance(model_data_file, UploadFile):
+    elif model_data_file is not None:
         try:
             model_data = json.load(model_data_file.file)
         except JSONDecodeError:

--- a/agr_literature_service/api/routers/ml_model_router.py
+++ b/agr_literature_service/api/routers/ml_model_router.py
@@ -1,6 +1,6 @@
 import json
 from json import JSONDecodeError
-from typing import Union, Dict, Any, Optional
+from typing import List, Union, Dict, Any, Optional
 
 from fastapi import APIRouter, Depends, Security, status, UploadFile, File, HTTPException
 
@@ -45,7 +45,8 @@ def upload_model(
         production: bool = False,
         negated: bool = True,
         data_novelty: str = None,
-        species: str = None):
+        species: str = None,
+        file_classes: List[str] = None):
     model_data = None
     if task_type and mod_abbreviation:
         model_data = {
@@ -63,7 +64,8 @@ def upload_model(
             "production": production,
             "negated": negated,
             "data_novelty": data_novelty,
-            "species": species
+            "species": species,
+            "file_classes": file_classes
         }
     elif model_data_file is not None:
         try:
@@ -89,7 +91,8 @@ def upload_model(
         production=model_data["production"],
         negated=model_data["negated"],
         data_novelty=model_data["data_novelty"],
-        species=model_data["species"]
+        species=model_data["species"],
+        file_classes=model_data.get("file_classes")
     )
     set_global_user_from_cognito(db, user)
     return ml_model_crud.upload(db, request, file)

--- a/agr_literature_service/api/routers/ml_model_router.py
+++ b/agr_literature_service/api/routers/ml_model_router.py
@@ -2,7 +2,7 @@ import json
 from json import JSONDecodeError
 from typing import List, Union, Dict, Any, Optional
 
-from fastapi import APIRouter, Depends, Security, status, UploadFile, File, HTTPException
+from fastapi import APIRouter, Depends, Query, Security, status, UploadFile, File, HTTPException
 
 from sqlalchemy.orm import Session
 
@@ -39,16 +39,17 @@ def upload_model(
         parameters: str = None,
         dataset_id: int = None,
         file: UploadFile = File(...),  # noqa: B008
-        model_data_file: Union[UploadFile, None] = File(default=None),  # noqa: B008
+        model_data_file: Union[UploadFile, str, None] = File(default=None),  # noqa: B008
         user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
         db: Session = db_session,
         production: bool = False,
         negated: bool = True,
         data_novelty: str = None,
         species: str = None,
-        file_classes: List[str] = None):
+        file_classes: str = Query(default=None)):
     model_data = None
     if task_type and mod_abbreviation:
+        file_classes_list = [c.strip() for c in file_classes.split(",") if c.strip()] if file_classes else None
         model_data = {
             "task_type": task_type,
             "mod_abbreviation": mod_abbreviation,
@@ -65,9 +66,9 @@ def upload_model(
             "negated": negated,
             "data_novelty": data_novelty,
             "species": species,
-            "file_classes": file_classes
+            "file_classes": file_classes_list
         }
-    elif model_data_file is not None:
+    elif isinstance(model_data_file, UploadFile):
         try:
             model_data = json.load(model_data_file.file)
         except JSONDecodeError:

--- a/agr_literature_service/api/routers/ml_model_router.py
+++ b/agr_literature_service/api/routers/ml_model_router.py
@@ -1,6 +1,6 @@
 import json
 from json import JSONDecodeError
-from typing import Union, Dict, Any, Optional
+from typing import Dict, Any, Optional
 
 from fastapi import APIRouter, Depends, Security, status, UploadFile, File, HTTPException
 
@@ -39,7 +39,7 @@ def upload_model(
         parameters: str = None,
         dataset_id: int = None,
         file: UploadFile = File(...),  # noqa: B008
-        model_data_file: Union[UploadFile, None] = File(default=None),  # noqa: B008
+        model_data_file: Optional[bytes] = File(default=None),  # noqa: B008
         user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
         db: Session = db_session,
         production: bool = False,
@@ -68,10 +68,10 @@ def upload_model(
             "species": species,
             "file_classes": file_classes_list
         }
-    elif model_data_file is not None:
+    elif model_data_file:
         try:
-            model_data = json.load(model_data_file.file)
-        except JSONDecodeError:
+            model_data = json.loads(model_data_file)
+        except (JSONDecodeError, ValueError):
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                                 detail="The provided model data file is not a valid json file")
     if not model_data:

--- a/agr_literature_service/api/schemas/ml_model_schemas.py
+++ b/agr_literature_service/api/schemas/ml_model_schemas.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -25,6 +25,7 @@ class MLModelSchemaBase(BaseModel):
     negated: Optional[bool] = None
     data_novelty: Optional[str] = None
     species: Optional[str] = None
+    file_classes: Optional[List[str]] = None
 
 
 class MLModelSchemaPost(MLModelSchemaBase):

--- a/agr_literature_service/lit_processing/oneoff_scripts/backfill_ml_model_file_classes.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/backfill_ml_model_file_classes.py
@@ -1,0 +1,60 @@
+"""Backfill file_classes column on existing ml_model rows.
+
+Rules:
+  - task_type = 'biocuration_topic_classification' → ['main']
+  - task_type = 'biocuration_entity_extraction'    → ['main', 'supplement']
+  - all other task_types                           → NULL (metadata-only models)
+"""
+import logging
+from os import environ
+
+from sqlalchemy import create_engine, text
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+TASK_TYPE_FILE_CLASSES = {
+    "biocuration_topic_classification": ["main"],
+    "biocuration_entity_extraction": ["main", "supplement"],
+}
+
+
+def backfill_file_classes():
+    db_host = environ.get("PSQL_HOST", "localhost")
+    db_port = environ.get("PSQL_PORT", "5432")
+    db_name = environ.get("PSQL_DATABASE", "literature")
+    db_user = environ.get("PSQL_USERNAME", "")
+    db_pass = environ.get("PSQL_PASSWORD", "")
+    url = f"postgresql://{db_user}:{db_pass}@{db_host}:{db_port}/{db_name}"
+    engine = create_engine(url)
+
+    with engine.begin() as conn:
+        for task_type, file_classes in TASK_TYPE_FILE_CLASSES.items():
+            result = conn.execute(
+                text(
+                    "UPDATE ml_model SET file_classes = :file_classes "
+                    "WHERE task_type = :task_type AND file_classes IS NULL"
+                ),
+                {"file_classes": file_classes, "task_type": task_type}
+            )
+            logger.info(
+                "Set file_classes=%s for task_type='%s': %d rows updated",
+                file_classes, task_type, result.rowcount
+            )
+
+        # Report any rows that remain NULL (metadata-only models)
+        remaining = conn.execute(
+            text("SELECT ml_model_id, task_type, topic FROM ml_model WHERE file_classes IS NULL")
+        ).fetchall()
+        if remaining:
+            logger.info(
+                "%d models left with file_classes=NULL (metadata-only):", len(remaining)
+            )
+            for row in remaining:
+                logger.info("  ml_model_id=%s task_type='%s' topic='%s'", row[0], row[1], row[2])
+        else:
+            logger.info("All models now have file_classes set.")
+
+
+if __name__ == "__main__":
+    backfill_file_classes()

--- a/alembic/versions/20260410_b9cadadb4c32_add_missing_fields.py
+++ b/alembic/versions/20260410_b9cadadb4c32_add_missing_fields.py
@@ -1,0 +1,199 @@
+"""fix model-db drift: add missing indexes, FKs, and rename misnamed indexes
+
+Revision ID: b9cadadb4c32
+Revises: e7695936840b
+Create Date: 2026-04-10 19:04:27.228941
+
+Fixes accumulated drift between SQLAlchemy models and the production DB:
+- person_setting: missing individual column indexes and AuditedModel FKs
+- reference_email: missing AuditedModel FKs on created_by/updated_by
+- topic_entity_tag: rename idx_ prefixed indexes to ix_ (Alembic convention)
+- workflow_tag: rename idx_ prefixed index to ix_
+- workflow_tag_version: add missing workflow_tag_id index
+- transaction: add missing user_id index
+
+NOTE: users table drift (id nullable, user_id PK swap) is intentionally
+excluded — changing it would break the users_pkey primary key, the
+transaction_user_id_fkey FK (sqlalchemy-continuum), and all created_by/
+updated_by FKs across the schema. That requires its own dedicated migration.
+"""
+from alembic import op
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision = 'b9cadadb4c32'
+down_revision = 'e7695936840b'
+branch_labels = None
+depends_on = None
+
+
+def _replace_index(conn, old_name, new_name):
+    """Replace an idx_-prefixed index with ix_-prefixed name.
+
+    If ix_ already exists (e.g. create_all_tables ran), drop the old idx_.
+    If only idx_ exists (production), rename it.
+    """
+    ix_exists = conn.execute(text(
+        "SELECT 1 FROM pg_indexes "
+        "WHERE schemaname = current_schema() AND indexname = :name"
+    ), {"name": new_name}).scalar()
+
+    idx_exists = conn.execute(text(
+        "SELECT 1 FROM pg_indexes "
+        "WHERE schemaname = current_schema() AND indexname = :name"
+    ), {"name": old_name}).scalar()
+
+    if idx_exists and ix_exists:
+        conn.execute(text(f'DROP INDEX {old_name}'))
+    elif idx_exists:
+        conn.execute(text(f'ALTER INDEX {old_name} RENAME TO {new_name}'))
+
+
+def _create_index_if_not_exists(conn, index_name, table, column):
+    """Create an index only if it doesn't already exist."""
+    exists = conn.execute(text(
+        "SELECT 1 FROM pg_indexes "
+        "WHERE schemaname = current_schema() AND indexname = :name"
+    ), {"name": index_name}).scalar()
+    if not exists:
+        conn.execute(text(
+            f'CREATE INDEX {index_name} ON {table} ({column})'
+        ))
+
+
+def _create_fk_if_not_exists(conn, fk_name, table, column, ref_table,
+                             ref_column):
+    """Create a foreign key only if it doesn't already exist."""
+    exists = conn.execute(text(
+        "SELECT 1 FROM pg_constraint c "
+        "JOIN pg_class r ON r.oid = c.conrelid "
+        "JOIN pg_namespace n ON n.oid = r.relnamespace "
+        "WHERE n.nspname = current_schema() "
+        "AND r.relname = :table AND c.conname = :name"
+    ), {"table": table, "name": fk_name}).scalar()
+    if not exists:
+        conn.execute(text(
+            f'ALTER TABLE {table} ADD CONSTRAINT {fk_name} '
+            f'FOREIGN KEY ({column}) REFERENCES {ref_table}({ref_column})'
+        ))
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # --- person_setting: add missing individual indexes from index=True ---
+    _create_index_if_not_exists(
+        conn, 'ix_person_setting_component_name',
+        'person_setting', 'component_name')
+    _create_index_if_not_exists(
+        conn, 'ix_person_setting_date_created',
+        'person_setting', 'date_created')
+    _create_index_if_not_exists(
+        conn, 'ix_person_setting_date_updated',
+        'person_setting', 'date_updated')
+    _create_index_if_not_exists(
+        conn, 'ix_person_setting_person_id',
+        'person_setting', 'person_id')
+
+    # --- person_setting: add missing AuditedModel FKs ---
+    _create_fk_if_not_exists(
+        conn, 'person_setting_created_by_fkey',
+        'person_setting', 'created_by', 'users', 'id')
+    _create_fk_if_not_exists(
+        conn, 'person_setting_updated_by_fkey',
+        'person_setting', 'updated_by', 'users', 'id')
+
+    # --- reference_email: add missing AuditedModel FKs ---
+    _create_fk_if_not_exists(
+        conn, 'reference_email_created_by_fkey',
+        'reference_email', 'created_by', 'users', 'id')
+    _create_fk_if_not_exists(
+        conn, 'reference_email_updated_by_fkey',
+        'reference_email', 'updated_by', 'users', 'id')
+
+    # --- topic_entity_tag: normalize idx_ indexes to ix_ ---
+    for col in ('data_novelty', 'entity', 'entity_type',
+                'negated', 'species', 'topic'):
+        _replace_index(
+            conn,
+            f'idx_topic_entity_tag_{col}',
+            f'ix_topic_entity_tag_{col}')
+
+    # --- workflow_tag: normalize idx_ index to ix_ ---
+    _replace_index(
+        conn,
+        'idx_workflow_tag_workflow_tag_id',
+        'ix_workflow_tag_workflow_tag_id')
+
+    # --- workflow_tag_version: add missing index ---
+    _create_index_if_not_exists(
+        conn, 'ix_workflow_tag_version_workflow_tag_id',
+        'workflow_tag_version', 'workflow_tag_id')
+
+    # --- transaction: add missing user_id index (sqlalchemy-continuum) ---
+    _create_index_if_not_exists(
+        conn, 'ix_transaction_user_id',
+        'transaction', 'user_id')
+
+
+def downgrade():
+    # --- transaction ---
+    op.drop_index(op.f('ix_transaction_user_id'), table_name='transaction')
+
+    # --- workflow_tag_version ---
+    op.drop_index(
+        op.f('ix_workflow_tag_version_workflow_tag_id'),
+        table_name='workflow_tag_version')
+
+    # --- workflow_tag: restore idx_ name ---
+    op.execute(text(
+        'ALTER INDEX ix_workflow_tag_workflow_tag_id '
+        'RENAME TO idx_workflow_tag_workflow_tag_id'))
+
+    # --- topic_entity_tag: restore idx_ names ---
+    op.execute(text(
+        'ALTER INDEX ix_topic_entity_tag_topic '
+        'RENAME TO idx_topic_entity_tag_topic'))
+    op.execute(text(
+        'ALTER INDEX ix_topic_entity_tag_species '
+        'RENAME TO idx_topic_entity_tag_species'))
+    op.execute(text(
+        'ALTER INDEX ix_topic_entity_tag_negated '
+        'RENAME TO idx_topic_entity_tag_negated'))
+    op.execute(text(
+        'ALTER INDEX ix_topic_entity_tag_entity_type '
+        'RENAME TO idx_topic_entity_tag_entity_type'))
+    op.execute(text(
+        'ALTER INDEX ix_topic_entity_tag_entity '
+        'RENAME TO idx_topic_entity_tag_entity'))
+    op.execute(text(
+        'ALTER INDEX ix_topic_entity_tag_data_novelty '
+        'RENAME TO idx_topic_entity_tag_data_novelty'))
+
+    # --- reference_email: drop FKs ---
+    op.drop_constraint(
+        'reference_email_updated_by_fkey', 'reference_email',
+        type_='foreignkey')
+    op.drop_constraint(
+        'reference_email_created_by_fkey', 'reference_email',
+        type_='foreignkey')
+
+    # --- person_setting: drop FKs ---
+    op.drop_constraint(
+        'person_setting_updated_by_fkey', 'person_setting',
+        type_='foreignkey')
+    op.drop_constraint(
+        'person_setting_created_by_fkey', 'person_setting',
+        type_='foreignkey')
+
+    # --- person_setting: drop indexes ---
+    op.drop_index(
+        op.f('ix_person_setting_person_id'), table_name='person_setting')
+    op.drop_index(
+        op.f('ix_person_setting_date_updated'), table_name='person_setting')
+    op.drop_index(
+        op.f('ix_person_setting_date_created'), table_name='person_setting')
+    op.drop_index(
+        op.f('ix_person_setting_component_name'),
+        table_name='person_setting')

--- a/alembic/versions/20260410_e7695936840b_add_file_classes_to_models.py
+++ b/alembic/versions/20260410_e7695936840b_add_file_classes_to_models.py
@@ -1,0 +1,24 @@
+"""add file_classes to models
+
+Revision ID: e7695936840b
+Revises: 78e9d4f87ed5
+Create Date: 2026-04-10 17:58:44.493581
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e7695936840b'
+down_revision = '78e9d4f87ed5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('ml_model', sa.Column('file_classes', sa.ARRAY(sa.String()), nullable=True))
+
+
+def downgrade():
+    op.drop_column('ml_model', 'file_classes')

--- a/alembic/versions/20260410_e7695936840b_add_file_classes_to_models.py
+++ b/alembic/versions/20260410_e7695936840b_add_file_classes_to_models.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'e7695936840b'
-down_revision = '78e9d4f87ed5'
+down_revision = '8a3f5c7d9e2b'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/20260410_e7695936840b_add_file_classes_to_models.py
+++ b/alembic/versions/20260410_e7695936840b_add_file_classes_to_models.py
@@ -19,6 +19,22 @@ depends_on = None
 def upgrade():
     op.add_column('ml_model', sa.Column('file_classes', sa.ARRAY(sa.String()), nullable=True))
 
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE ml_model SET file_classes = :file_classes "
+            "WHERE task_type = :task_type AND file_classes IS NULL"
+        ),
+        {"file_classes": ["main"], "task_type": "biocuration_topic_classification"}
+    )
+    conn.execute(
+        sa.text(
+            "UPDATE ml_model SET file_classes = :file_classes "
+            "WHERE task_type = :task_type AND file_classes IS NULL"
+        ),
+        {"file_classes": ["main", "supplement"], "task_type": "biocuration_entity_extraction"}
+    )
+
 
 def downgrade():
     op.drop_column('ml_model', 'file_classes')

--- a/tests/api/test_ml_model.py
+++ b/tests/api/test_ml_model.py
@@ -44,7 +44,8 @@ def test_ml_model(db, auth_headers, test_mod):  # noqa
                 "production": True,
                 "negated": True,
                 "data_novelty": "ATP:0000062",
-                "species": None
+                "species": None,
+                "file_classes": ["main"]
             }
             model_data_json = json.dumps(new_model)
             files = {
@@ -91,6 +92,7 @@ class TestMLModel:
         assert ml_model.topic == "ATP:0000061"
         assert ml_model.version_num == 1
         assert ml_model.data_novelty == "ATP:0000062"
+        assert ml_model.file_classes == ["main"]
 
     def test_get_model_metadata(self, test_ml_model, test_mod, auth_headers):  # noqa
         with TestClient(app) as client:


### PR DESCRIPTION
## Summary
- Add `file_classes` column (string array) to `ml_model` table to specify which file types a model processes
- Alembic migration adds the column and backfills existing rows: `biocuration_topic_classification` → `["main"]`, `biocuration_entity_extraction` → `["main", "supplement"]`
- Fix ML model upload endpoint: accept `file_classes` as comma-separated query string, use `bytes` type for `model_data_file` to handle Swagger UI sending empty strings for optional file fields
- Include standalone backfill script and migration to resolve model-db drift for indexes/foreign keys

## Test plan
- [ ] Verify `file_classes` column is created and backfilled correctly via alembic migration
- [ ] Upload model via Swagger UI with `file_classes=main,supplement` — should store as `["main", "supplement"]`
- [ ] Upload model via JSON metadata file with `file_classes: ["main"]` — should work as before
- [ ] Upload model without selecting `model_data_file` in Swagger — should not return 422
- [ ] Existing ml_model tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)