### PR TITLE
feat(ontology): add get_or_create_species endpoint (SCRUM-5679)

### DIFF
--- a/agr_literature_service/api/crud/ateam_db_helpers.py
+++ b/agr_literature_service/api/crud/ateam_db_helpers.py
@@ -125,6 +125,25 @@ def search_species(species: str) -> JSONResponse:
     return JSONResponse(content=jsonable_encoder(data))
 
 
+def get_or_create_species(taxon_id: str) -> JSONResponse:
+    """Get or create a species (NCBITaxonTerm) in the A-Team system.
+
+    Returns the existing taxon if found, or auto-imports it from NCBI
+    if it doesn't exist yet.
+
+    Args:
+        taxon_id: Numeric NCBI Taxon ID (e.g., '6239') or full CURIE
+                  (e.g., 'NCBITaxon:6239')
+    """
+    cli = _get_client()
+    try:
+        term = cli.get_or_create_species(taxon_id)
+    except AGRAPIError as e:
+        raise HTTPException(status_code=502, detail=f"Get or create species failed: {e}")
+    data = {"curie": term.curie, "name": term.name}
+    return JSONResponse(content=jsonable_encoder(data))
+
+
 def search_ancestors_or_descendants(ontology_node: str, ancestors_or_descendants: str) -> List[str]:
     """
     Return a list of ancestor or descendant curies for the given ontology node.

--- a/agr_literature_service/api/routers/ontology_router.py
+++ b/agr_literature_service/api/routers/ontology_router.py
@@ -60,3 +60,10 @@ def search_descendants(ancestor_curie: str,
 def search_species(species: str,
                    user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
     return ateam_db_helpers.search_species(species)
+
+
+@router.get('/get_or_create_species/{taxon_id}',
+            status_code=200)
+def get_or_create_species(taxon_id: str,
+                          user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
+    return ateam_db_helpers.get_or_create_species(taxon_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ retry==0.9.2                 # No update needed.
 cachetools==5.3.1            # Updated for better performance.
 lxml==4.9.4
 fastapi-okta==1.4.0
-agr-curation-api-client==0.8.3
+agr-curation-api-client==0.9.0
 
 # JWT support
 PyJWT>=2.8.0


### PR DESCRIPTION
## Summary
- New `GET /ontology/get_or_create_species/{taxon_id}` endpoint that delegates to `AGRCurationAPIClient.get_or_create_species`. Returns the existing `NCBITaxonTerm` if present, or triggers the A-Team's auto-import from NCBI if absent.
- Adds the corresponding helper in `ateam_db_helpers.get_or_create_species`.
- Bumps `agr-curation-api-client` from `0.8.3` → `0.9.0` to pick up the new client method.

## Related
- UI PR: https://github.com/alliance-genome/agr_literature_ui/pull/567
- Jira: [SCRUM-5679](https://agr-jira.atlassian.net/browse/SCRUM-5679)

## Test plan
- [ ] `make run-local-flake8 && make run-local-mypy` pass.
- [ ] `curl -H 'Authorization: Bearer <token>' ${API_BASE}/ontology/get_or_create_species/9606` returns `{"curie": "NCBITaxon:9606", "name": "Homo sapiens"}`.
- [ ] Call the endpoint with a taxon NOT yet present in the target curation DB and verify the row gets persisted (`SELECT curie, name, dbdatecreated FROM ontologyterm WHERE curie = 'NCBITaxon:<id>'`).
- [ ] Endpoint returns a 502 with a useful detail if the A-Team call fails (e.g., unreachable host / auth failure).

[SCRUM-5679]: https://agr-jira.atlassian.net/browse/SCRUM-5679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ