### PR TITLE
feat(pdf2md): prefer nXML, process supplements, add CLI flags

### DIFF
--- a/agr_literature_service/lit_processing/pdf2md/pdf2md.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md.py
@@ -1,9 +1,15 @@
 """
-PDF to Markdown conversion using PDFX service.
+Reference to Markdown conversion.
 
-This script converts PDF files to Markdown using the PDFX service at
-https://pdfx.alliancegenome.org. It supports multiple extraction methods
-(grobid, docling, marker, merged) and stores each output as a separate file.
+For each reference processed, this script prefers converting a publisher-provided
+nXML/JATS file to Markdown (via agr_abc_document_parsers) when available, and
+falls back to extracting the main PDF via the PDFX service
+(https://pdfx.alliancegenome.org) otherwise. All supplemental PDFs for the
+reference are also converted via PDFX.
+
+PDFX supports multiple extraction methods (grobid, docling, marker, merged) and
+stores each output as a separate file; nXML conversion produces a single
+merged-style markdown output.
 """
 import logging
 import time
@@ -31,6 +37,9 @@ from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     submit_pdf_to_pdfx,
     poll_pdfx_status,
     download_pdfx_result,
+    get_nxml_referencefile,
+    process_nxml_to_markdown,
+    process_supplemental_pdfs,
 )
 
 
@@ -196,38 +205,45 @@ def get_unprocessed_pdfs_since_year(
     return results
 
 
-def _process_pdf_list(  # pragma: no cover
+def _process_reference_list(  # pragma: no cover
     db: Session,
-    pdf_list: List[Dict],
+    reference_list: List[Dict],
     token: str,
     start_time: float,
     summary_suffix: str = "",
-    report_subject: str = "pdf2md conversion errors"
+    report_subject: str = "pdf2md conversion errors",
+    prefer_nxml: bool = True,
+    process_supplements: bool = True
 ) -> Dict:
     """
-    Common processing loop for PDF to Markdown conversion.
+    Common processing loop for reference-to-Markdown conversion.
 
-    This is a shared helper function used by process_pdfs_since_year and process_newest_pdfs.
+    Used by process_references_since_year and process_newest_references. Each
+    reference is converted via nXML when available (unless prefer_nxml is
+    False), or via PDFX otherwise; supplemental PDFs are also processed when
+    process_supplements is True.
 
     Args:
         db: Database session.
-        pdf_list: List of PDF info dicts to process.
+        reference_list: List of reference info dicts to process.
         token: Initial PDFX bearer token.
         start_time: Start time for timing statistics.
         summary_suffix: Suffix for log summary title (e.g., " (Since 2025)").
         report_subject: Subject line for error report email.
+        prefer_nxml: Prefer nXML over PDFX for main-file conversion.
+        process_supplements: Also convert supplemental PDFs.
 
     Returns:
         Dict with processing statistics.
     """
-    total_count = len(pdf_list)
+    total_count = len(reference_list)
     success_count = 0
     failure_count = 0
     objects_with_errors: List[Dict] = []
-    pdf_times: List[float] = []
+    ref_times: List[float] = []
 
-    for idx, ref_file_info in enumerate(pdf_list, 1):
-        pdf_start_time = time.time()
+    for idx, ref_file_info in enumerate(reference_list, 1):
+        ref_start_time = time.time()
         reference_curie = ref_file_info["reference_curie"]
 
         logger.info(f"Processing {idx}/{total_count}: {reference_curie}")
@@ -247,14 +263,18 @@ def _process_pdf_list(  # pragma: no cover
             })
             continue
 
-        success, error_msg = process_single_pdf(db, ref_file_info, token)
+        success, error_msg = process_single_reference(
+            db, ref_file_info, token,
+            prefer_nxml=prefer_nxml,
+            process_supplements=process_supplements
+        )
 
-        pdf_elapsed = time.time() - pdf_start_time
-        pdf_times.append(pdf_elapsed)
+        ref_elapsed = time.time() - ref_start_time
+        ref_times.append(ref_elapsed)
 
         if success:
             success_count += 1
-            logger.info(f"Completed {reference_curie} in {pdf_elapsed:.2f}s")
+            logger.info(f"Completed {reference_curie} in {ref_elapsed:.2f}s")
         else:
             failure_count += 1
             objects_with_errors.append({
@@ -264,34 +284,34 @@ def _process_pdf_list(  # pragma: no cover
                 "mod_abbreviation": ref_file_info.get("mod_abbreviation", "N/A"),
                 "error": error_msg
             })
-            logger.error(f"Failed {reference_curie} after {pdf_elapsed:.2f}s: {error_msg}")
+            logger.error(f"Failed {reference_curie} after {ref_elapsed:.2f}s: {error_msg}")
 
     # Calculate timing statistics
     total_elapsed = time.time() - start_time
-    avg_time = sum(pdf_times) / len(pdf_times) if pdf_times else 0
-    min_time = min(pdf_times) if pdf_times else 0
-    max_time = max(pdf_times) if pdf_times else 0
+    avg_time = sum(ref_times) / len(ref_times) if ref_times else 0
+    min_time = min(ref_times) if ref_times else 0
+    max_time = max(ref_times) if ref_times else 0
 
     # Log summary
     logger.info("=" * 60)
-    logger.info(f"PDF to Markdown Conversion Summary{summary_suffix}")
+    logger.info(f"Reference to Markdown Conversion Summary{summary_suffix}")
     logger.info("=" * 60)
-    logger.info(f"Total PDFs processed: {total_count}")
+    logger.info(f"Total references processed: {total_count}")
     logger.info(f"Successful: {success_count}")
     logger.info(f"Failed: {failure_count}")
     logger.info("-" * 60)
     logger.info("Timing Statistics:")
     logger.info(f"  Total time: {total_elapsed:.2f}s ({total_elapsed / 60:.2f} minutes)")
-    logger.info(f"  Average per PDF: {avg_time:.2f}s")
+    logger.info(f"  Average per reference: {avg_time:.2f}s")
     logger.info(f"  Min time: {min_time:.2f}s")
     logger.info(f"  Max time: {max_time:.2f}s")
     logger.info("=" * 60)
 
     # Send error report if there were failures
     if objects_with_errors:
-        error_message = f"PDF to Markdown Conversion Errors{summary_suffix}\n\n"
+        error_message = f"Reference to Markdown Conversion Errors{summary_suffix}\n\n"
         error_message += f"Total: {total_count}, Success: {success_count}, Failed: {failure_count}\n\n"
-        error_message += f"Total time: {total_elapsed:.2f}s, Avg per PDF: {avg_time:.2f}s\n\n"
+        error_message += f"Total time: {total_elapsed:.2f}s, Avg per reference: {avg_time:.2f}s\n\n"
         error_message += "Failed conversions:\n"
         for error_obj in objects_with_errors:
             error_message += f"{error_obj['mod_abbreviation']}\t{error_obj['reference_curie']}\t"
@@ -304,20 +324,32 @@ def _process_pdf_list(  # pragma: no cover
         "success": success_count,
         "failed": failure_count,
         "total_time_seconds": total_elapsed,
-        "avg_time_per_pdf": avg_time,
+        "avg_time_per_reference": avg_time,
         "min_time": min_time,
         "max_time": max_time
     }
 
 
-def process_pdfs_since_year(since_year: int, skip_xml: bool = False, limit: Optional[int] = None):  # pragma: no cover
+def process_references_since_year(  # pragma: no cover
+    since_year: int,
+    skip_xml: bool = False,
+    limit: Optional[int] = None,
+    prefer_nxml: bool = True,
+    process_supplements: bool = True
+):
     """
-    Process all unprocessed PDFs since a given year.
+    Process all unconverted references whose main PDF is from a given year onwards.
+
+    Enumeration is keyed on main-PDF presence (see get_unprocessed_pdfs_since_year);
+    per-reference processing prefers nXML (unless prefer_nxml=False) and also
+    handles supplemental PDFs (unless process_supplements=False).
 
     Args:
         since_year: Year to filter from (e.g., 2025 means Jan 1, 2025 onwards).
         skip_xml: If True, skip papers that already have XML/nXML files.
-        limit: Optional limit on number of PDFs to process. If None, process all.
+        limit: Optional limit on number of references to process. If None, process all.
+        prefer_nxml: Prefer nXML over PDFX for main-file conversion.
+        process_supplements: Also convert supplemental PDFs.
     """
     start_time = time.time()
 
@@ -326,11 +358,15 @@ def process_pdfs_since_year(since_year: int, skip_xml: bool = False, limit: Opti
     db = new_session()
 
     try:
-        logger.info(f"Starting PDF to Markdown conversion for PDFs since {since_year}")
+        logger.info(f"Starting reference-to-Markdown conversion for papers since {since_year}")
         if skip_xml:
             logger.info("Skipping papers that already have XML/nXML files")
         if limit:
-            logger.info(f"Limiting to {limit} PDFs")
+            logger.info(f"Limiting to {limit} references")
+        if not prefer_nxml:
+            logger.info("Forcing PDFX for main file (nXML preference disabled)")
+        if not process_supplements:
+            logger.info("Skipping supplemental PDFs")
 
         # Get token
         try:
@@ -339,56 +375,46 @@ def process_pdfs_since_year(since_year: int, skip_xml: bool = False, limit: Opti
             logger.error(f"Failed to obtain PDFX token: {e}")
             return None
 
-        # Get unprocessed PDFs
-        pdf_list = get_unprocessed_pdfs_since_year(
+        # Get unprocessed references
+        reference_list = get_unprocessed_pdfs_since_year(
             db, since_year=since_year, skip_xml=skip_xml, limit=limit
         )
-        logger.info(f"Found {len(pdf_list)} unprocessed PDFs to convert")
+        logger.info(f"Found {len(reference_list)} unprocessed references to convert")
 
-        if not pdf_list:
-            logger.info("No unprocessed PDFs found. Exiting.")
+        if not reference_list:
+            logger.info("No unprocessed references found. Exiting.")
             return {"total": 0, "success": 0, "failed": 0}
 
-        return _process_pdf_list(
+        return _process_reference_list(
             db=db,
-            pdf_list=pdf_list,
+            reference_list=reference_list,
             token=token,
             start_time=start_time,
             summary_suffix=f" (Since {since_year})",
-            report_subject=f"pdf2md conversion errors (since {since_year})"
+            report_subject=f"pdf2md conversion errors (since {since_year})",
+            prefer_nxml=prefer_nxml,
+            process_supplements=process_supplements
         )
     finally:
         db.close()
 
 
-def process_single_pdf(  # pragma: no cover
+def _convert_main_pdf_via_pdfx(  # pragma: no cover
     db: Session,
-    ref_file_info: Dict,
+    referencefile_id: int,
+    reference_curie: str,
+    display_name: str,
+    mod_abbreviation: Optional[str],
     token: str,
-    methods_to_extract: Optional[List[str]] = None
+    methods_to_extract: List[str]
 ) -> Tuple[bool, Optional[str]]:
     """
-    Process a single PDF file through PDFX.
-
-    Args:
-        db: Database session.
-        ref_file_info: Dict with referencefile info.
-        token: PDFX bearer token.
-        methods_to_extract: List of methods to extract (default: all 4).
+    Convert a main PDF via PDFX and upload the resulting markdown files.
 
     Returns:
         Tuple of (success: bool, error_message: Optional[str]).
     """
-    if methods_to_extract is None:
-        methods_to_extract = list(EXTRACTION_METHODS.keys())
-
-    referencefile_id = ref_file_info["referencefile_id"]
-    reference_curie = ref_file_info["reference_curie"]
-    display_name = ref_file_info["display_name"]
-    mod_abbreviation = ref_file_info.get("mod_abbreviation")
-
     try:
-        # Download the PDF content
         file_content = download_file(
             db=db,
             referencefile_id=referencefile_id,
@@ -400,7 +426,6 @@ def process_single_pdf(  # pragma: no cover
         request_methods = [m for m in methods_to_extract if m != "merged"]
         include_merge = "merged" in methods_to_extract
 
-        # Submit to PDFX
         process_id = submit_pdf_to_pdfx(
             file_content=file_content,
             token=token,
@@ -410,10 +435,8 @@ def process_single_pdf(  # pragma: no cover
             mod_abbreviation=mod_abbreviation
         )
 
-        # Poll for completion
         poll_pdfx_status(process_id, token)
 
-        # Download and store each method's output
         successful_methods = []
         for method in methods_to_extract:
             try:
@@ -454,24 +477,155 @@ def process_single_pdf(  # pragma: no cover
                 logger.error(f"Failed to download/upload {method} for {reference_curie}: {e}")
 
         if successful_methods:
-            logger.info(f"Successfully processed {reference_curie} with methods: {successful_methods}")
+            logger.info(
+                f"Successfully processed main PDF for {reference_curie} "
+                f"with methods: {successful_methods}"
+            )
             return True, None
-        else:
-            return False, "No methods successfully extracted"
+        return False, "No methods successfully extracted"
 
     except Exception as e:
         error_msg = str(e)
-        logger.error(f"Failed to process {reference_curie}: {error_msg}")
+        logger.error(f"Failed to process main PDF for {reference_curie}: {error_msg}")
         return False, error_msg
 
 
-def process_newest_pdfs(limit: int = 50, skip_xml: bool = False):  # pragma: no cover
+def process_single_reference(  # pragma: no cover
+    db: Session,
+    ref_file_info: Dict,
+    token: str,
+    methods_to_extract: Optional[List[str]] = None,
+    prefer_nxml: bool = True,
+    process_supplements: bool = True
+) -> Tuple[bool, Optional[str]]:
     """
-    Process the newest main PDFs and convert them to markdown.
+    Convert the main content of a single reference to Markdown, plus any
+    supplemental PDFs.
+
+    Flow:
+      1. If prefer_nxml is True and the reference has an nXML file, convert
+         it to markdown via agr_abc_document_parsers. On nXML failure, fall
+         back to PDFX.
+      2. Otherwise, run the main PDF through PDFX (grobid, docling, marker, merged).
+      3. If process_supplements is True, process every supplemental PDF for
+         the reference via PDFX.
+
+    Supplement failures are logged/reported but do not fail the reference; the
+    reference succeeds if its main conversion produced any markdown output.
 
     Args:
-        limit: Number of newest PDFs to process.
+        db: Database session.
+        ref_file_info: Dict with reference/file info. Must include
+            reference_id, reference_curie, display_name, and (for PDF fallback)
+            referencefile_id of the main PDF plus file_extension. May include
+            mod_abbreviation.
+        token: PDFX bearer token.
+        methods_to_extract: List of methods to extract (default: all 4).
+        prefer_nxml: When True (default), prefer nXML conversion over PDFX for
+            the main file when an nXML file is available. When False, always
+            use PDFX on the main PDF.
+        process_supplements: When True (default), also convert supplemental
+            PDFs via PDFX. When False, skip supplement processing.
+
+    Returns:
+        Tuple of (success: bool, error_message: Optional[str]).
+    """
+    if methods_to_extract is None:
+        methods_to_extract = list(EXTRACTION_METHODS.keys())
+
+    reference_id = ref_file_info["reference_id"]
+    reference_curie = ref_file_info["reference_curie"]
+    display_name = ref_file_info["display_name"]
+    mod_abbreviation = ref_file_info.get("mod_abbreviation")
+
+    main_success = False
+    main_error: Optional[str] = None
+
+    # 1. Prefer nXML when available (unless forced to PDFX)
+    if prefer_nxml:
+        nxml_ref_file = get_nxml_referencefile(db, reference_id)
+        if nxml_ref_file is not None:
+            main_success, main_error = process_nxml_to_markdown(
+                db=db,
+                nxml_ref_file=nxml_ref_file,
+                reference_curie=reference_curie,
+                mod_abbreviation=mod_abbreviation
+            )
+            if not main_success:
+                logger.warning(
+                    f"nXML conversion failed for {reference_curie} ({main_error}); "
+                    f"falling back to PDFX on main PDF"
+                )
+
+    # 2. Fall back to (or use directly) PDFX on the main PDF
+    if not main_success:
+        referencefile_id = ref_file_info.get("referencefile_id")
+        if referencefile_id is None:
+            combined = "No nXML conversion succeeded and no main PDF available"
+            if main_error:
+                combined = f"{combined} (nXML error: {main_error})"
+            return False, combined
+
+        pdfx_success, pdfx_error = _convert_main_pdf_via_pdfx(
+            db=db,
+            referencefile_id=referencefile_id,
+            reference_curie=reference_curie,
+            display_name=display_name,
+            mod_abbreviation=mod_abbreviation,
+            token=token,
+            methods_to_extract=methods_to_extract
+        )
+        main_success = pdfx_success
+        if not pdfx_success:
+            if main_error:
+                main_error = f"nXML error: {main_error}; PDFX error: {pdfx_error}"
+            else:
+                main_error = pdfx_error
+
+    # 3. Optionally convert supplemental PDFs regardless of main path used
+    if process_supplements:
+        try:
+            sup_succeeded, sup_failed, sup_errors = process_supplemental_pdfs(
+                db=db,
+                reference_id=reference_id,
+                reference_curie=reference_curie,
+                token=token,
+                methods_to_extract=methods_to_extract
+            )
+            if sup_succeeded or sup_failed:
+                logger.info(
+                    f"Supplemental PDFs for {reference_curie}: "
+                    f"{sup_succeeded} succeeded, {sup_failed} failed"
+                )
+            for err in sup_errors:
+                logger.error(f"Supplemental PDF error for {reference_curie}: {err}")
+        except Exception as e:
+            logger.error(
+                f"Unexpected error while processing supplemental PDFs for "
+                f"{reference_curie}: {e}"
+            )
+
+    if main_success:
+        return True, None
+    return False, main_error or "Main reference conversion failed"
+
+
+def process_newest_references(  # pragma: no cover
+    limit: int = 50,
+    skip_xml: bool = False,
+    prefer_nxml: bool = True,
+    process_supplements: bool = True
+):
+    """
+    Process the newest references (keyed on main-PDF enumeration) and convert
+    them to markdown (nXML-preferred unless disabled) plus their supplemental
+    PDFs (unless disabled).
+
+    Args:
+        limit: Number of newest references to process.
         skip_xml: If True, skip papers that already have XML/nXML files.
+        prefer_nxml: Prefer nXML over PDFX for main-file conversion.
+        process_supplements: Also convert supplemental PDFs.
     """
     start_time = time.time()
 
@@ -480,9 +634,15 @@ def process_newest_pdfs(limit: int = 50, skip_xml: bool = False):  # pragma: no 
     db = new_session()
 
     try:
-        logger.info(f"Starting PDF to Markdown conversion for {limit} newest PDFs")
+        logger.info(
+            f"Starting reference-to-Markdown conversion for {limit} newest references"
+        )
         if skip_xml:
             logger.info("Skipping papers that already have XML/nXML files")
+        if not prefer_nxml:
+            logger.info("Forcing PDFX for main file (nXML preference disabled)")
+        if not process_supplements:
+            logger.info("Skipping supplemental PDFs")
 
         # Get token
         try:
@@ -491,31 +651,120 @@ def process_newest_pdfs(limit: int = 50, skip_xml: bool = False):  # pragma: no 
             logger.error(f"Failed to obtain PDFX token: {e}")
             return None
 
-        # Get newest PDFs
-        pdf_list = get_newest_main_pdfs(db, limit=limit, skip_xml=skip_xml)
-        logger.info(f"Found {len(pdf_list)} PDFs to process")
+        # Enumerate via newest main PDFs
+        reference_list = get_newest_main_pdfs(db, limit=limit, skip_xml=skip_xml)
+        logger.info(f"Found {len(reference_list)} references to process")
 
-        if not pdf_list:
-            logger.info("No PDFs found to process. Exiting.")
+        if not reference_list:
+            logger.info("No references found to process. Exiting.")
             return {"total": 0, "success": 0, "failed": 0}
 
-        return _process_pdf_list(
+        return _process_reference_list(
             db=db,
-            pdf_list=pdf_list,
+            reference_list=reference_list,
             token=token,
             start_time=start_time,
             summary_suffix="",
-            report_subject="pdf2md conversion errors"
+            report_subject="pdf2md conversion errors",
+            prefer_nxml=prefer_nxml,
+            process_supplements=process_supplements
         )
     finally:
         db.close()
 
 
-def main():  # pragma: no cover
+def _resolve_workflow_ref_file_info(  # pragma: no cover
+    db: Session,
+    ref_id: int,
+    reference_curie: str,
+    mod_abbreviation: str,
+    prefer_nxml: bool
+) -> Tuple[Optional[Dict], Optional[str]]:
     """
-    Main entry point for workflow-based PDF to Markdown conversion.
+    Look up the main source file (nXML preferred when enabled, else main PDF)
+    for a workflow job and build the ref_file_info dict.
 
-    This processes PDFs based on workflow tags (text_convert_job).
+    Returns:
+        (ref_file_info, None) when a source was found; (None, error_msg) when
+        neither an nXML nor a main PDF is available for the reference.
+    """
+    nxml_ref_file = (
+        get_nxml_referencefile(db, ref_id) if prefer_nxml else None
+    )
+    ref_file_id = get_main_pdf_referencefile_id(
+        db=db,
+        curie_or_reference_id=str(ref_id),
+        mod_abbreviation=mod_abbreviation
+    )
+
+    if nxml_ref_file is None and not ref_file_id:
+        if prefer_nxml:
+            return None, "No nXML or main PDF found for reference"
+        return None, "No main PDF found for reference"
+
+    if nxml_ref_file is not None:
+        display_name = nxml_ref_file.display_name
+        file_extension = nxml_ref_file.file_extension
+    else:
+        pdf_ref_obj = db.query(ReferencefileModel).filter(
+            ReferencefileModel.referencefile_id == ref_file_id
+        ).one()
+        display_name = pdf_ref_obj.display_name
+        file_extension = pdf_ref_obj.file_extension
+
+    return {
+        "referencefile_id": ref_file_id,
+        "reference_id": ref_id,
+        "reference_curie": reference_curie,
+        "display_name": display_name,
+        "file_extension": file_extension,
+        "mod_abbreviation": mod_abbreviation
+    }, None
+
+
+def _build_workflow_error_record(  # pragma: no cover
+    db: Session,
+    reference_curie: str,
+    display_name: str,
+    file_extension: str,
+    mod_abbreviation: str,
+    error_msg: str
+) -> Dict:
+    """Build a failure record for workflow-mode error reporting."""
+    mod_cross_ref = db.query(CrossReferenceModel).join(
+        ReferenceModel, CrossReferenceModel.reference_id == ReferenceModel.reference_id
+    ).filter(
+        ReferenceModel.curie == reference_curie,
+        CrossReferenceModel.curie_prefix == mod_abbreviation
+    ).one_or_none()
+
+    return {
+        "reference_curie": reference_curie,
+        "display_name": display_name,
+        "file_extension": file_extension,
+        "mod_abbreviation": mod_abbreviation,
+        "mod_cross_ref": mod_cross_ref.curie if mod_cross_ref else "N/A",
+        "error": error_msg
+    }
+
+
+def main(  # pragma: no cover
+    prefer_nxml: bool = True,
+    process_supplements: bool = True
+):
+    """
+    Main entry point for workflow-based reference-to-Markdown conversion.
+
+    Processes references based on workflow tags (text_convert_job). For each
+    reference: prefers nXML over PDF for the main content conversion (unless
+    prefer_nxml=False) and also converts supplemental PDFs (unless
+    process_supplements=False). When prefer_nxml is True, jobs are marked
+    failed only if neither an nXML nor a main PDF is available; when
+    prefer_nxml is False, a main PDF is required.
+
+    Args:
+        prefer_nxml: Prefer nXML over PDFX for main-file conversion.
+        process_supplements: Also convert supplemental PDFs.
     """
     start_time = time.time()
 
@@ -527,6 +776,11 @@ def main():  # pragma: no cover
         limit = 1000
         offset = 0
         all_jobs = []
+
+        if not prefer_nxml:
+            logger.info("Forcing PDFX for main file (nXML preference disabled)")
+        if not process_supplements:
+            logger.info("Skipping supplemental PDFs")
 
         logger.info("Started loading all text conversion jobs.")
         seen_wf_tag_ids = set()
@@ -550,16 +804,16 @@ def main():  # pragma: no cover
             logger.error(f"Failed to obtain PDFX token: {e}")
             return
 
-        mod_abbreviation_from_mod_id = {}
+        mod_abbreviation_from_mod_id: Dict[int, str] = {}
         objects_with_errors = []
         total_count = len(all_jobs)
         success_count = 0
         failure_count = 0
         skipped_count = 0
-        pdf_times = []
+        ref_times = []
 
         for idx, job in enumerate(all_jobs, 1):
-            pdf_start_time = time.time()
+            ref_start_time = time.time()
             error_msg: Optional[str] = None
 
             ref_id = job['reference_id']
@@ -577,49 +831,26 @@ def main():  # pragma: no cover
             else:
                 mod_abbreviation = mod_abbreviation_from_mod_id[mod_id]
 
-            ref_file_id_to_convert = get_main_pdf_referencefile_id(
+            ref_file_info, resolve_error = _resolve_workflow_ref_file_info(
                 db=db,
-                curie_or_reference_id=ref_id,
-                mod_abbreviation=mod_abbreviation
+                ref_id=ref_id,
+                reference_curie=reference_curie,
+                mod_abbreviation=mod_abbreviation,
+                prefer_nxml=prefer_nxml
             )
 
-            if not ref_file_id_to_convert:
-                # No main PDF found for this reference - mark as failed and continue
+            if ref_file_info is None:
                 skipped_count += 1
-                error_msg = "No main PDF found for reference"
-                logger.warning(f"No main PDF found for {reference_curie}, marking job as failed")
+                error_msg = resolve_error or "Could not resolve reference source file"
+                logger.warning(f"{error_msg} for {reference_curie}; marking job as failed")
                 job_change_atp_code(db, reference_workflow_tag_id, "on_failed")
-
-                # Add to error list for reporting
-                mod_cross_ref = db.query(CrossReferenceModel).join(
-                    ReferenceModel, CrossReferenceModel.reference_id == ReferenceModel.reference_id
-                ).filter(
-                    ReferenceModel.curie == reference_curie,
-                    CrossReferenceModel.curie_prefix == mod_abbreviation
-                ).one_or_none()
-
-                objects_with_errors.append({
-                    "reference_curie": reference_curie,
-                    "display_name": "N/A",
-                    "file_extension": "N/A",
-                    "mod_abbreviation": mod_abbreviation,
-                    "mod_cross_ref": mod_cross_ref.curie if mod_cross_ref else "N/A",
-                    "error": error_msg
-                })
+                objects_with_errors.append(_build_workflow_error_record(
+                    db, reference_curie, "N/A", "N/A", mod_abbreviation, error_msg
+                ))
                 continue
 
-            ref_file_obj: ReferencefileModel = db.query(ReferencefileModel).filter(
-                ReferencefileModel.referencefile_id == ref_file_id_to_convert
-            ).one()
-
-            ref_file_info = {
-                "referencefile_id": ref_file_id_to_convert,
-                "reference_id": ref_id,
-                "reference_curie": reference_curie,
-                "display_name": ref_file_obj.display_name,
-                "file_extension": ref_file_obj.file_extension,
-                "mod_abbreviation": mod_abbreviation
-            }
+            display_name = ref_file_info["display_name"]
+            file_extension = ref_file_info["file_extension"]
 
             # Refresh token if needed
             try:
@@ -629,83 +860,62 @@ def main():  # pragma: no cover
                 logger.error(error_msg)
                 failure_count += 1
                 job_change_atp_code(db, reference_workflow_tag_id, "on_failed")
-
-                # Add to error list for reporting
-                mod_cross_ref = db.query(CrossReferenceModel).join(
-                    ReferenceModel, CrossReferenceModel.reference_id == ReferenceModel.reference_id
-                ).filter(
-                    ReferenceModel.curie == reference_curie,
-                    CrossReferenceModel.curie_prefix == mod_abbreviation
-                ).one_or_none()
-
-                objects_with_errors.append({
-                    "reference_curie": reference_curie,
-                    "display_name": ref_file_obj.display_name,
-                    "file_extension": ref_file_obj.file_extension,
-                    "mod_abbreviation": mod_abbreviation,
-                    "mod_cross_ref": mod_cross_ref.curie if mod_cross_ref else "N/A",
-                    "error": error_msg
-                })
+                objects_with_errors.append(_build_workflow_error_record(
+                    db, reference_curie, display_name, file_extension,
+                    mod_abbreviation, error_msg
+                ))
                 continue
 
-            success, error_msg = process_single_pdf(db, ref_file_info, token)
+            success, error_msg = process_single_reference(
+                db, ref_file_info, token,
+                prefer_nxml=prefer_nxml,
+                process_supplements=process_supplements
+            )
 
-            pdf_elapsed = time.time() - pdf_start_time
-            pdf_times.append(pdf_elapsed)
+            ref_elapsed = time.time() - ref_start_time
+            ref_times.append(ref_elapsed)
 
             if success:
                 success_count += 1
                 job_change_atp_code(db, reference_workflow_tag_id, "on_success")
-                logger.info(f"Completed {reference_curie} in {pdf_elapsed:.2f}s")
+                logger.info(f"Completed {reference_curie} in {ref_elapsed:.2f}s")
             else:
                 failure_count += 1
                 job_change_atp_code(db, reference_workflow_tag_id, "on_failed")
-                logger.error(f"Failed {reference_curie} after {pdf_elapsed:.2f}s")
-
-                mod_cross_ref = db.query(CrossReferenceModel).join(
-                    ReferenceModel, CrossReferenceModel.reference_id == ReferenceModel.reference_id
-                ).filter(
-                    ReferenceModel.curie == reference_curie,
-                    CrossReferenceModel.curie_prefix == mod_abbreviation
-                ).one_or_none()
-
-                objects_with_errors.append({
-                    "reference_curie": reference_curie,
-                    "display_name": ref_file_obj.display_name,
-                    "file_extension": ref_file_obj.file_extension,
-                    "mod_abbreviation": mod_abbreviation,
-                    "mod_cross_ref": mod_cross_ref.curie if mod_cross_ref else "N/A",
-                    "error": error_msg
-                })
+                logger.error(f"Failed {reference_curie} after {ref_elapsed:.2f}s")
+                objects_with_errors.append(_build_workflow_error_record(
+                    db, reference_curie, display_name, file_extension,
+                    mod_abbreviation, error_msg or "Unknown"
+                ))
 
         # Calculate timing statistics
         total_elapsed = time.time() - start_time
-        avg_time = sum(pdf_times) / len(pdf_times) if pdf_times else 0
-        min_time = min(pdf_times) if pdf_times else 0
-        max_time = max(pdf_times) if pdf_times else 0
+        avg_time = sum(ref_times) / len(ref_times) if ref_times else 0
+        min_time = min(ref_times) if ref_times else 0
+        max_time = max(ref_times) if ref_times else 0
 
         # Log summary
         logger.info("=" * 60)
-        logger.info("PDF to Markdown Conversion Summary (Workflow Mode)")
+        logger.info("Reference to Markdown Conversion Summary (Workflow Mode)")
         logger.info("=" * 60)
         logger.info(f"Total jobs processed: {total_count}")
         logger.info(f"Successful: {success_count}")
         logger.info(f"Failed: {failure_count}")
-        logger.info(f"Skipped (no PDF): {skipped_count}")
+        logger.info(f"Skipped (no nXML or main PDF): {skipped_count}")
         logger.info("-" * 60)
         logger.info("Timing Statistics:")
         logger.info(f"  Total time: {total_elapsed:.2f}s ({total_elapsed / 60:.2f} minutes)")
-        logger.info(f"  Average per PDF: {avg_time:.2f}s")
+        logger.info(f"  Average per reference: {avg_time:.2f}s")
         logger.info(f"  Min time: {min_time:.2f}s")
         logger.info(f"  Max time: {max_time:.2f}s")
         logger.info("=" * 60)
 
         # Send error report
         if objects_with_errors:
-            error_message = "PDF to Markdown Conversion Errors (Workflow Mode)\n\n"
+            error_message = "Reference to Markdown Conversion Errors (Workflow Mode)\n\n"
             error_message += f"Total: {total_count}, Success: {success_count}, "
             error_message += f"Failed: {failure_count}, Skipped: {skipped_count}\n\n"
-            error_message += f"Total time: {total_elapsed:.2f}s, Avg per PDF: {avg_time:.2f}s\n\n"
+            error_message += f"Total time: {total_elapsed:.2f}s, Avg per reference: {avg_time:.2f}s\n\n"
             error_message += "Failed conversions:\n"
             for error_obj in objects_with_errors:
                 error_message += f"{error_obj['mod_abbreviation']}\t{error_obj['mod_cross_ref']}\t"
@@ -728,20 +938,23 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Convert PDF files to Markdown using PDFX service.",
+        description=(
+            "Convert references to Markdown. Prefers nXML over PDF for the main "
+            "file and always processes supplemental PDFs via the PDFX service."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Process PDFs via workflow jobs (default)
+  # Process references via workflow jobs (default)
   python -m agr_literature_service.lit_processing.pdf2md.pdf2md
 
-  # Process N newest PDFs
+  # Process N newest references (enumerated by newest main PDFs)
   python -m agr_literature_service.lit_processing.pdf2md.pdf2md --newest 50
 
-  # Process all unprocessed PDFs for papers published since 2025
+  # Process all unconverted references for papers published since 2025
   python -m agr_literature_service.lit_processing.pdf2md.pdf2md --since 2025
 
-  # Process newest PDFs, skipping those with XML files
+  # Process newest references, skipping those with XML files
   python -m agr_literature_service.lit_processing.pdf2md.pdf2md --newest 50 --skip-xml
         """
     )
@@ -749,13 +962,13 @@ Examples:
         "--newest",
         type=int,
         metavar="N",
-        help="Process N newest main PDFs (regardless of processing status)"
+        help="Process N newest references (enumerated by newest main PDFs)"
     )
     parser.add_argument(
         "--since",
         type=int,
         metavar="YEAR",
-        help="Process unprocessed PDFs for papers published since YEAR (e.g., 2025)"
+        help="Process unconverted references for papers published since YEAR (e.g., 2025)"
     )
     parser.add_argument(
         "--skip-xml",
@@ -766,7 +979,22 @@ Examples:
         "--limit",
         type=int,
         metavar="N",
-        help="Limit number of PDFs to process (only applies to --since mode)"
+        help="Limit number of references to process (only applies to --since mode)"
+    )
+    parser.add_argument(
+        "--no-xml",
+        dest="prefer_nxml",
+        action="store_false",
+        help=(
+            "Always use PDFX for the main file, even when an nXML file is "
+            "available (default: prefer nXML when present)"
+        )
+    )
+    parser.add_argument(
+        "--no-supplements",
+        dest="process_supplements",
+        action="store_false",
+        help="Skip supplemental PDFs (default: process all supplemental PDFs)"
     )
 
     args = parser.parse_args()
@@ -784,21 +1012,41 @@ Examples:
         exit(1)
 
     if args.newest:
-        print(f"Processing {args.newest} newest main PDFs...")
+        print(f"Processing {args.newest} newest references...")
         if args.skip_xml:
             print("Skipping papers with existing XML/nXML files.")
-        result = process_newest_pdfs(limit=args.newest, skip_xml=args.skip_xml)
+        if not args.prefer_nxml:
+            print("Forcing PDFX for main file (--no-xml).")
+        if not args.process_supplements:
+            print("Skipping supplemental PDFs (--no-supplements).")
+        result = process_newest_references(
+            limit=args.newest,
+            skip_xml=args.skip_xml,
+            prefer_nxml=args.prefer_nxml,
+            process_supplements=args.process_supplements
+        )
         print(f"\nResults: {result}")
     elif args.since:
-        print(f"Processing unprocessed PDFs since {args.since}...")
+        print(f"Processing unconverted references since {args.since}...")
         if args.limit:
-            print(f"Limiting to {args.limit} PDFs.")
+            print(f"Limiting to {args.limit} references.")
         if args.skip_xml:
             print("Skipping papers with existing XML/nXML files.")
-        result = process_pdfs_since_year(
-            since_year=args.since, skip_xml=args.skip_xml, limit=args.limit
+        if not args.prefer_nxml:
+            print("Forcing PDFX for main file (--no-xml).")
+        if not args.process_supplements:
+            print("Skipping supplemental PDFs (--no-supplements).")
+        result = process_references_since_year(
+            since_year=args.since,
+            skip_xml=args.skip_xml,
+            limit=args.limit,
+            prefer_nxml=args.prefer_nxml,
+            process_supplements=args.process_supplements
         )
         print(f"\nResults: {result}")
     else:
         # Workflow mode (default)
-        main()
+        main(
+            prefer_nxml=args.prefer_nxml,
+            process_supplements=args.process_supplements
+        )

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -1,20 +1,27 @@
 """
-Utility functions for PDF to Markdown conversion.
+Utility functions for PDF/nXML to Markdown conversion.
 
-This module provides helper functions for processing PDFs for individual papers,
-including PDFX API integration, reference lookup by curie, and PDF file retrieval.
+This module provides helper functions for processing references for individual papers,
+including PDFX API integration, reference lookup by curie, nXML conversion, and file
+retrieval for both main and supplemental files.
 """
+import gzip
 import logging
 import os
 import time
 from io import BytesIO
 from typing import Dict, List, Literal, Optional, Tuple, TypedDict
 
+import boto3
 import requests
 from fastapi import HTTPException, UploadFile
+from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
+from agr_abc_document_parsers import convert_xml_to_markdown
+
 from agr_literature_service.api.crud.referencefile_crud import download_file, file_upload
+from agr_literature_service.api.crud.referencefile_utils import get_s3_folder_from_md5sum
 from agr_literature_service.api.crud.reference_utils import (
     normalize_reference_curie,
     get_reference,
@@ -754,3 +761,187 @@ def get_pdfs_missing_xml(  # pragma: no cover
         })
 
     return results
+
+
+def get_nxml_referencefile(  # pragma: no cover
+    db: Session,
+    reference_id: int
+) -> Optional[ReferencefileModel]:
+    """
+    Find the most recent final nXML file for a reference.
+
+    Args:
+        db: Database session.
+        reference_id: The reference ID to search.
+
+    Returns:
+        The ReferencefileModel for the nXML file, or None if not found.
+    """
+    return (
+        db.query(ReferencefileModel)
+        .filter(
+            ReferencefileModel.reference_id == reference_id,
+            ReferencefileModel.file_class == "nXML",
+            ReferencefileModel.file_publication_status == "final"
+        )
+        .order_by(desc(ReferencefileModel.referencefile_id))
+        .first()
+    )
+
+
+def download_xml_from_s3(s3_client, md5sum: str) -> bytes:  # pragma: no cover
+    """
+    Download and decompress an XML file from S3 by md5sum.
+
+    Args:
+        s3_client: boto3 S3 client.
+        md5sum: The md5sum used to locate the file in S3.
+
+    Returns:
+        The file content as bytes (decompressed if it was gzipped).
+    """
+    folder = get_s3_folder_from_md5sum(md5sum)
+    s3_key = f"{folder}/{md5sum}.gz"
+    response = s3_client.get_object(Bucket="agr-literature", Key=s3_key)
+    compressed = response["Body"].read()
+    try:
+        return gzip.decompress(compressed)
+    except (gzip.BadGzipFile, OSError):
+        return compressed
+
+
+def process_nxml_to_markdown(  # pragma: no cover
+    db: Session,
+    nxml_ref_file: ReferencefileModel,
+    reference_curie: str,
+    mod_abbreviation: Optional[str],
+    s3_client=None
+) -> Tuple[bool, Optional[str]]:
+    """
+    Convert an nXML file to Markdown and store the result.
+
+    The nXML is downloaded from S3, converted to markdown via
+    agr_abc_document_parsers.convert_xml_to_markdown (JATS format), and the
+    result is uploaded via file_upload with file_class='converted_merged_main',
+    matching the convention used by the nxml2md oneoff script.
+
+    Args:
+        db: Database session.
+        nxml_ref_file: ReferencefileModel for the nXML source file.
+        reference_curie: Reference curie for the output file metadata.
+        mod_abbreviation: Optional MOD abbreviation for the output file metadata.
+        s3_client: Optional boto3 S3 client; one is created if not provided.
+
+    Returns:
+        Tuple of (success: bool, error_message: Optional[str]).
+    """
+    try:
+        if s3_client is None:
+            s3_client = boto3.client("s3")
+
+        xml_content = download_xml_from_s3(s3_client, nxml_ref_file.md5sum)
+        if not xml_content:
+            return False, "Empty nXML content returned from S3"
+
+        markdown = convert_xml_to_markdown(xml_content, "jats")
+        md_bytes = markdown.encode("utf-8")
+
+        if len(md_bytes) < 10:
+            return False, "nXML conversion produced empty or minimal content"
+
+        output_display_name = f"{nxml_ref_file.display_name}_nxml"
+        metadata = {
+            "reference_curie": reference_curie,
+            "display_name": output_display_name,
+            "file_class": "converted_merged_main",
+            "file_publication_status": "final",
+            "file_extension": "md",
+            "pdf_type": None,
+            "is_annotation": None,
+            "mod_abbreviation": mod_abbreviation
+        }
+
+        file_upload(
+            db=db,
+            metadata=metadata,
+            file=UploadFile(
+                file=BytesIO(md_bytes),
+                filename=f"{output_display_name}.md"
+            ),
+            upload_if_already_converted=True
+        )
+
+        logger.info(
+            f"Uploaded nXML-derived markdown for {reference_curie} "
+            f"(nxml referencefile_id={nxml_ref_file.referencefile_id})"
+        )
+        return True, None
+
+    except Exception as e:
+        error_msg = f"nXML->markdown failed: {e}"
+        logger.error(f"{error_msg} (reference_curie={reference_curie})")
+        return False, error_msg
+
+
+def process_supplemental_pdfs(  # pragma: no cover
+    db: Session,
+    reference_id: int,
+    reference_curie: str,
+    token: str,
+    methods_to_extract: Optional[List[str]] = None
+) -> Tuple[int, int, List[str]]:
+    """
+    Convert all supplemental PDFs for a reference to Markdown via PDFX.
+
+    Uses the existing per-PDF helper (_process_single_pdf_file), which already
+    handles supplement file_class naming ('converted_{method}_supplement').
+
+    Args:
+        db: Database session.
+        reference_id: The reference ID whose supplements should be processed.
+        reference_curie: The reference curie for metadata/logging.
+        token: PDFX bearer token.
+        methods_to_extract: List of methods to extract (default: all).
+
+    Returns:
+        Tuple of (succeeded_count, failed_count, per_supplement_errors). Each
+        entry in per_supplement_errors is a "<display_name>: <error>" string.
+    """
+    if methods_to_extract is None:
+        methods_to_extract = list(EXTRACTION_METHODS.keys())
+
+    supplements = get_pdf_files_for_reference(db, reference_id, "supplement")
+    if not supplements:
+        return 0, 0, []
+
+    logger.info(
+        f"Processing {len(supplements)} supplemental PDF(s) for {reference_curie}"
+    )
+
+    succeeded = 0
+    failed = 0
+    errors: List[str] = []
+
+    for pdf_file in supplements:
+        try:
+            success, _methods, error = _process_single_pdf_file(
+                db=db,
+                pdf_file=pdf_file,
+                reference_curie=reference_curie,
+                token=token,
+                methods_to_extract=methods_to_extract
+            )
+            if success:
+                succeeded += 1
+            else:
+                failed += 1
+                errors.append(f"{pdf_file.display_name}: {error or 'unknown error'}")
+        except Exception as e:
+            failed += 1
+            errors.append(f"{pdf_file.display_name}: {e}")
+            logger.error(
+                f"Error processing supplemental PDF {pdf_file.display_name} "
+                f"for {reference_curie}: {e}"
+            )
+
+    return succeeded, failed, errors

--- a/tests/lit_processing/pdf2md/test_pdf2md.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md.py
@@ -4,16 +4,14 @@ Unit tests for pdf2md.py
 Tests cover:
 - get_newest_main_pdfs
 - get_unprocessed_pdfs_since_year
-- process_single_pdf
-- process_newest_pdfs
-- process_pdfs_since_year
+- process_single_reference (nXML preference, PDFX fallback, supplements)
 """
 from unittest.mock import MagicMock, patch
 
 from agr_literature_service.lit_processing.pdf2md.pdf2md import (
     get_newest_main_pdfs,
     get_unprocessed_pdfs_since_year,
-    process_single_pdf,
+    process_single_reference,
     EXTRACTION_METHODS,
 )
 
@@ -174,53 +172,11 @@ class TestGetUnprocessedPdfsSinceYear:
         assert result[0]["mod_abbreviation"] == "WB"
 
 
-class TestProcessSinglePdf:
-    """Test process_single_pdf function."""
+class TestProcessSingleReference:
+    """Test process_single_reference function covering nXML, PDFX, and supplements."""
 
-    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_pdfx_result")
-    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.poll_pdfx_status")
-    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.submit_pdf_to_pdfx")
-    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
-    def test_successful_processing(
-        self, mock_download, mock_submit, mock_poll, mock_download_result
-    ):
-        """Test successful PDF processing."""
-        mock_db = MagicMock()
-        mock_download.return_value = b"pdf_content"
-        mock_submit.return_value = "process_123"
-        mock_poll.return_value = {"status": "completed"}
-        mock_download_result.return_value = b"# Markdown content"
-
-        with patch(
-            "agr_literature_service.lit_processing.pdf2md.pdf2md.file_upload"
-        ) as mock_upload:
-            ref_file_info = {
-                "referencefile_id": 123,
-                "reference_id": 456,
-                "reference_curie": "AGRKB:101000000000001",
-                "display_name": "test_paper",
-                "file_extension": "pdf",
-                "mod_abbreviation": "WB"
-            }
-
-            success, error = process_single_pdf(
-                mock_db, ref_file_info, "test_token"
-            )
-
-            assert success is True
-            assert error is None
-            mock_submit.assert_called_once()
-            mock_poll.assert_called_once()
-            # Should upload for each extraction method
-            assert mock_upload.call_count == len(EXTRACTION_METHODS)
-
-    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
-    def test_handles_download_exception(self, mock_download):
-        """Test that exceptions during download are handled."""
-        mock_db = MagicMock()
-        mock_download.side_effect = Exception("Download failed")
-
-        ref_file_info = {
+    def _ref_file_info(self):
+        return {
             "referencefile_id": 123,
             "reference_id": 456,
             "reference_curie": "AGRKB:101000000000001",
@@ -229,51 +185,319 @@ class TestProcessSinglePdf:
             "mod_abbreviation": "WB"
         }
 
-        success, error = process_single_pdf(
-            mock_db, ref_file_info, "test_token"
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_pdfx_result")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.poll_pdfx_status")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.submit_pdf_to_pdfx")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
+    def test_nxml_preferred_pdfx_skipped(
+        self,
+        mock_download, mock_submit, mock_poll, mock_download_result,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+    ):
+        """nXML present -> convert via nXML path, skip PDFX for main."""
+        mock_db = MagicMock()
+        mock_nxml_ref = MagicMock()
+        mock_get_nxml.return_value = mock_nxml_ref
+        mock_nxml_convert.return_value = (True, None)
+        mock_process_supps.return_value = (0, 0, [])
+
+        success, error = process_single_reference(
+            mock_db, self._ref_file_info(), "test_token"
+        )
+
+        assert success is True
+        assert error is None
+        mock_nxml_convert.assert_called_once()
+        mock_submit.assert_not_called()
+        mock_poll.assert_not_called()
+        mock_download_result.assert_not_called()
+        mock_process_supps.assert_called_once()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_pdfx_result")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.poll_pdfx_status")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.submit_pdf_to_pdfx")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
+    def test_no_nxml_falls_back_to_pdfx(
+        self,
+        mock_download, mock_submit, mock_poll, mock_download_result,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+    ):
+        """No nXML -> PDFX path runs for main, supplements still processed."""
+        mock_db = MagicMock()
+        mock_get_nxml.return_value = None
+        mock_download.return_value = b"pdf_content"
+        mock_submit.return_value = "process_123"
+        mock_poll.return_value = {"status": "completed"}
+        mock_download_result.return_value = b"# Markdown content"
+        mock_process_supps.return_value = (0, 0, [])
+
+        with patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md.file_upload"
+        ) as mock_upload:
+            success, error = process_single_reference(
+                mock_db, self._ref_file_info(), "test_token"
+            )
+
+            assert success is True
+            assert error is None
+            mock_nxml_convert.assert_not_called()
+            mock_submit.assert_called_once()
+            mock_poll.assert_called_once()
+            assert mock_upload.call_count == len(EXTRACTION_METHODS)
+            mock_process_supps.assert_called_once()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_pdfx_result")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.poll_pdfx_status")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.submit_pdf_to_pdfx")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
+    def test_nxml_failure_falls_back_to_pdfx(
+        self,
+        mock_download, mock_submit, mock_poll, mock_download_result,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+    ):
+        """nXML present but conversion fails -> fall back to PDFX."""
+        mock_db = MagicMock()
+        mock_get_nxml.return_value = MagicMock()
+        mock_nxml_convert.return_value = (False, "parse error")
+        mock_download.return_value = b"pdf_content"
+        mock_submit.return_value = "process_123"
+        mock_poll.return_value = {"status": "completed"}
+        mock_download_result.return_value = b"# Markdown content"
+        mock_process_supps.return_value = (0, 0, [])
+
+        with patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md.file_upload"
+        ) as mock_upload:
+            success, error = process_single_reference(
+                mock_db, self._ref_file_info(), "test_token"
+            )
+
+            assert success is True
+            assert error is None
+            mock_nxml_convert.assert_called_once()
+            mock_submit.assert_called_once()
+            assert mock_upload.call_count == len(EXTRACTION_METHODS)
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
+    def test_handles_download_exception(
+        self, mock_download, mock_get_nxml, mock_nxml_convert, mock_process_supps
+    ):
+        """PDFX download exception -> failure returned with message."""
+        mock_db = MagicMock()
+        mock_get_nxml.return_value = None
+        mock_download.side_effect = Exception("Download failed")
+        mock_process_supps.return_value = (0, 0, [])
+
+        success, error = process_single_reference(
+            mock_db, self._ref_file_info(), "test_token"
         )
 
         assert success is False
         assert "Download failed" in error
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_pdfx_result")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.poll_pdfx_status")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.submit_pdf_to_pdfx")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
     def test_returns_failure_when_no_methods_succeed(
-        self, mock_download, mock_submit, mock_poll, mock_download_result
+        self,
+        mock_download, mock_submit, mock_poll, mock_download_result,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps,
     ):
-        """Test that failure is returned when no extraction methods succeed."""
+        """All PDFX methods empty -> failure returned."""
         mock_db = MagicMock()
+        mock_get_nxml.return_value = None
         mock_download.return_value = b"pdf_content"
         mock_submit.return_value = "process_123"
         mock_poll.return_value = {"status": "completed"}
         mock_download_result.return_value = b""  # Empty content
+        mock_process_supps.return_value = (0, 0, [])
 
-        ref_file_info = {
-            "referencefile_id": 123,
-            "reference_id": 456,
-            "reference_curie": "AGRKB:101000000000001",
-            "display_name": "test_paper",
-            "file_extension": "pdf",
-            "mod_abbreviation": "WB"
-        }
-
-        success, error = process_single_pdf(
-            mock_db, ref_file_info, "test_token"
+        success, error = process_single_reference(
+            mock_db, self._ref_file_info(), "test_token"
         )
 
         assert success is False
         assert "No methods successfully extracted" in error
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_pdfx_result")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.poll_pdfx_status")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.submit_pdf_to_pdfx")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
     def test_processes_specific_methods(
-        self, mock_download, mock_submit, mock_poll, mock_download_result
+        self,
+        mock_download, mock_submit, mock_poll, mock_download_result,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps,
     ):
-        """Test that only specified methods are processed."""
+        """Only specified methods are processed."""
+        mock_db = MagicMock()
+        mock_get_nxml.return_value = None
+        mock_download.return_value = b"pdf_content"
+        mock_submit.return_value = "process_123"
+        mock_poll.return_value = {"status": "completed"}
+        mock_download_result.return_value = b"# Markdown content"
+        mock_process_supps.return_value = (0, 0, [])
+
+        with patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md.file_upload"
+        ) as mock_upload:
+            success, error = process_single_reference(
+                mock_db,
+                self._ref_file_info(),
+                "test_token",
+                methods_to_extract=["grobid", "docling"]
+            )
+
+            assert success is True
+            # Main PDF upload x 2 methods
+            assert mock_upload.call_count == 2
+            # And supplements got the same restricted method list
+            _args, kwargs = mock_process_supps.call_args
+            assert kwargs["methods_to_extract"] == ["grobid", "docling"]
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    def test_supplement_failures_do_not_fail_reference(
+        self, mock_get_nxml, mock_nxml_convert, mock_process_supps
+    ):
+        """Supplement failures are logged but don't fail the reference."""
+        mock_db = MagicMock()
+        mock_get_nxml.return_value = MagicMock()
+        mock_nxml_convert.return_value = (True, None)
+        mock_process_supps.return_value = (1, 2, ["s1: err", "s2: err"])
+
+        success, error = process_single_reference(
+            mock_db, self._ref_file_info(), "test_token"
+        )
+
+        assert success is True
+        assert error is None
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    def test_nxml_only_no_main_pdf_succeeds(
+        self, mock_get_nxml, mock_nxml_convert, mock_process_supps
+    ):
+        """Reference with nXML but no main PDF succeeds via nXML path."""
+        mock_db = MagicMock()
+        mock_get_nxml.return_value = MagicMock()
+        mock_nxml_convert.return_value = (True, None)
+        mock_process_supps.return_value = (0, 0, [])
+
+        ref_info = self._ref_file_info()
+        ref_info["referencefile_id"] = None  # simulate no main PDF
+
+        success, error = process_single_reference(mock_db, ref_info, "test_token")
+
+        assert success is True
+        assert error is None
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    def test_no_nxml_and_no_main_pdf_fails(
+        self, mock_get_nxml, mock_nxml_convert, mock_process_supps
+    ):
+        """Reference with neither nXML nor main PDF fails."""
+        mock_db = MagicMock()
+        mock_get_nxml.return_value = None
+        mock_process_supps.return_value = (0, 0, [])
+
+        ref_info = self._ref_file_info()
+        ref_info["referencefile_id"] = None
+
+        success, error = process_single_reference(mock_db, ref_info, "test_token")
+
+        assert success is False
+        assert "no main PDF available" in error
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_pdfx_result")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.poll_pdfx_status")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.submit_pdf_to_pdfx")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
+    def test_prefer_nxml_false_forces_pdfx(
+        self,
+        mock_download, mock_submit, mock_poll, mock_download_result,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+    ):
+        """prefer_nxml=False skips nXML lookup and always uses PDFX."""
+        mock_db = MagicMock()
+        mock_download.return_value = b"pdf_content"
+        mock_submit.return_value = "process_123"
+        mock_poll.return_value = {"status": "completed"}
+        mock_download_result.return_value = b"# Markdown content"
+        mock_process_supps.return_value = (0, 0, [])
+
+        with patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md.file_upload"
+        ):
+            success, error = process_single_reference(
+                mock_db, self._ref_file_info(), "test_token",
+                prefer_nxml=False
+            )
+
+            assert success is True
+            assert error is None
+            mock_get_nxml.assert_not_called()
+            mock_nxml_convert.assert_not_called()
+            mock_submit.assert_called_once()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    def test_process_supplements_false_skips_supplements(
+        self, mock_get_nxml, mock_nxml_convert, mock_process_supps
+    ):
+        """process_supplements=False skips supplement processing entirely."""
+        mock_db = MagicMock()
+        mock_get_nxml.return_value = MagicMock()
+        mock_nxml_convert.return_value = (True, None)
+
+        success, error = process_single_reference(
+            mock_db, self._ref_file_info(), "test_token",
+            process_supplements=False
+        )
+
+        assert success is True
+        assert error is None
+        mock_process_supps.assert_not_called()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_pdfx_result")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.poll_pdfx_status")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.submit_pdf_to_pdfx")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
+    def test_both_flags_false(
+        self,
+        mock_download, mock_submit, mock_poll, mock_download_result,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+    ):
+        """Both flags False -> PDFX only on main, no supplements, no nXML lookup."""
         mock_db = MagicMock()
         mock_download.return_value = b"pdf_content"
         mock_submit.return_value = "process_123"
@@ -282,26 +506,19 @@ class TestProcessSinglePdf:
 
         with patch(
             "agr_literature_service.lit_processing.pdf2md.pdf2md.file_upload"
-        ) as mock_upload:
-            ref_file_info = {
-                "referencefile_id": 123,
-                "reference_id": 456,
-                "reference_curie": "AGRKB:101000000000001",
-                "display_name": "test_paper",
-                "file_extension": "pdf",
-                "mod_abbreviation": "WB"
-            }
-
-            success, error = process_single_pdf(
-                mock_db,
-                ref_file_info,
-                "test_token",
-                methods_to_extract=["grobid", "docling"]
+        ):
+            success, error = process_single_reference(
+                mock_db, self._ref_file_info(), "test_token",
+                prefer_nxml=False,
+                process_supplements=False
             )
 
             assert success is True
-            # Should only upload for specified methods
-            assert mock_upload.call_count == 2
+            assert error is None
+            mock_get_nxml.assert_not_called()
+            mock_nxml_convert.assert_not_called()
+            mock_process_supps.assert_not_called()
+            mock_submit.assert_called_once()
 
 
 class TestExtractionMethodsConstant:

--- a/tests/lit_processing/pdf2md/test_pdf2md_utils.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md_utils.py
@@ -25,6 +25,9 @@ from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     download_pdfx_result,
     resolve_curie_to_reference,
     get_pdf_files_for_reference,
+    get_nxml_referencefile,
+    process_nxml_to_markdown,
+    process_supplemental_pdfs,
 )
 
 
@@ -343,3 +346,201 @@ class TestGetPdfFilesForReference:
         get_pdf_files_for_reference(mock_db, 123, "both")
 
         assert mock_query.filter.called
+
+
+class TestGetNxmlReferencefile:
+    """Test get_nxml_referencefile function."""
+
+    def test_returns_nxml_when_present(self):
+        """A final nXML file is returned when present."""
+        mock_db = MagicMock()
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+
+        expected = MagicMock()
+        expected.file_class = "nXML"
+        mock_query.first.return_value = expected
+
+        result = get_nxml_referencefile(mock_db, 123)
+
+        assert result is expected
+        assert mock_query.filter.called
+        assert mock_query.order_by.called
+
+    def test_returns_none_when_absent(self):
+        """Returns None when no nXML present for the reference."""
+        mock_db = MagicMock()
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.first.return_value = None
+
+        result = get_nxml_referencefile(mock_db, 123)
+
+        assert result is None
+
+
+class TestProcessNxmlToMarkdown:
+    """Test process_nxml_to_markdown function."""
+
+    def _nxml_ref(self, md5sum="abc123", display_name="paper", ref_id=42):
+        mock_ref = MagicMock()
+        mock_ref.md5sum = md5sum
+        mock_ref.display_name = display_name
+        mock_ref.referencefile_id = ref_id
+        return mock_ref
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.convert_xml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_xml_from_s3")
+    def test_successful_conversion_and_upload(
+        self, mock_download, mock_convert, mock_upload
+    ):
+        """XML is downloaded, converted, and uploaded with correct metadata."""
+        mock_db = MagicMock()
+        mock_download.return_value = b"<xml>content</xml>"
+        mock_convert.return_value = "# Converted markdown content"
+        mock_s3 = MagicMock()
+
+        success, error = process_nxml_to_markdown(
+            db=mock_db,
+            nxml_ref_file=self._nxml_ref(),
+            reference_curie="AGRKB:101000000000001",
+            mod_abbreviation="WB",
+            s3_client=mock_s3
+        )
+
+        assert success is True
+        assert error is None
+        mock_download.assert_called_once_with(mock_s3, "abc123")
+        mock_convert.assert_called_once_with(b"<xml>content</xml>", "jats")
+        mock_upload.assert_called_once()
+        _args, kwargs = mock_upload.call_args
+        metadata = kwargs["metadata"]
+        assert metadata["file_class"] == "converted_merged_main"
+        assert metadata["file_extension"] == "md"
+        assert metadata["reference_curie"] == "AGRKB:101000000000001"
+        assert metadata["mod_abbreviation"] == "WB"
+        assert metadata["display_name"] == "paper_nxml"
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_xml_from_s3")
+    def test_empty_s3_content_returns_failure(self, mock_download):
+        """Empty S3 content produces a failure tuple."""
+        mock_download.return_value = b""
+
+        success, error = process_nxml_to_markdown(
+            db=MagicMock(),
+            nxml_ref_file=self._nxml_ref(),
+            reference_curie="AGRKB:1",
+            mod_abbreviation=None,
+            s3_client=MagicMock()
+        )
+
+        assert success is False
+        assert "Empty nXML content" in error
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.convert_xml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_xml_from_s3")
+    def test_conversion_exception_returns_failure(self, mock_download, mock_convert):
+        """Parser exceptions are caught and returned as failure."""
+        mock_download.return_value = b"<xml/>"
+        mock_convert.side_effect = ValueError("bad xml")
+
+        success, error = process_nxml_to_markdown(
+            db=MagicMock(),
+            nxml_ref_file=self._nxml_ref(),
+            reference_curie="AGRKB:1",
+            mod_abbreviation=None,
+            s3_client=MagicMock()
+        )
+
+        assert success is False
+        assert "bad xml" in error
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.convert_xml_to_markdown")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_xml_from_s3")
+    def test_minimal_markdown_returns_failure(self, mock_download, mock_convert):
+        """Conversion producing too-short content is rejected."""
+        mock_download.return_value = b"<xml/>"
+        mock_convert.return_value = "."
+
+        success, error = process_nxml_to_markdown(
+            db=MagicMock(),
+            nxml_ref_file=self._nxml_ref(),
+            reference_curie="AGRKB:1",
+            mod_abbreviation=None,
+            s3_client=MagicMock()
+        )
+
+        assert success is False
+        assert "empty or minimal" in error
+
+
+class TestProcessSupplementalPdfs:
+    """Test process_supplemental_pdfs function."""
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_no_supplements_returns_zero_counts(self, mock_get_pdfs):
+        """Zero supplements -> (0, 0, [])."""
+        mock_get_pdfs.return_value = []
+
+        succeeded, failed, errors = process_supplemental_pdfs(
+            db=MagicMock(),
+            reference_id=42,
+            reference_curie="AGRKB:1",
+            token="t"
+        )
+
+        assert succeeded == 0
+        assert failed == 0
+        assert errors == []
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils._process_single_pdf_file")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_mixed_success_and_failure(self, mock_get_pdfs, mock_process):
+        """Mix of succeeding/failing supplements counted separately."""
+        s1 = MagicMock(display_name="s1")
+        s2 = MagicMock(display_name="s2")
+        s3 = MagicMock(display_name="s3")
+        mock_get_pdfs.return_value = [s1, s2, s3]
+        mock_process.side_effect = [
+            (True, ["grobid"], None),
+            (False, [], "pdfx err"),
+            (True, ["merged"], None),
+        ]
+
+        succeeded, failed, errors = process_supplemental_pdfs(
+            db=MagicMock(),
+            reference_id=42,
+            reference_curie="AGRKB:1",
+            token="t"
+        )
+
+        assert succeeded == 2
+        assert failed == 1
+        assert len(errors) == 1
+        assert "s2" in errors[0]
+        assert "pdfx err" in errors[0]
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils._process_single_pdf_file")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_exception_in_helper_counted_as_failure(self, mock_get_pdfs, mock_process):
+        """Exceptions from the per-file helper are caught."""
+        s1 = MagicMock(display_name="s1")
+        mock_get_pdfs.return_value = [s1]
+        mock_process.side_effect = RuntimeError("boom")
+
+        succeeded, failed, errors = process_supplemental_pdfs(
+            db=MagicMock(),
+            reference_id=42,
+            reference_curie="AGRKB:1",
+            token="t"
+        )
+
+        assert succeeded == 0
+        assert failed == 1
+        assert len(errors) == 1
+        assert "boom" in errors[0]


### PR DESCRIPTION
## Summary
- Prefer publisher-provided nXML/JATS over PDFX for the main-file Markdown conversion (via `agr_abc_document_parsers.convert_xml_to_markdown`); fall back to PDFX when no nXML is present or nXML conversion fails.
- Process every supplemental PDF for the reference via PDFX, producing `converted_{method}_supplement` outputs.
- Add two CLI flags: `--no-xml` (force PDFX on main even when nXML exists) and `--no-supplements` (skip supplement processing). Threaded through `process_single_reference`, `_process_reference_list`, `process_newest_references`, `process_references_since_year`, and the workflow `main()`.
- Rename pdf-centric functions to reference-centric ones (`process_single_pdf` → `process_single_reference`, `_process_pdf_list` → `_process_reference_list`, `process_newest_pdfs` → `process_newest_references`, `process_pdfs_since_year` → `process_references_since_year`) since they now handle nXML and supplements in addition to the main PDF.
- Workflow `main()` now succeeds for references that have an nXML but no main PDF (previously marked failed). Extracted `_resolve_workflow_ref_file_info` and `_build_workflow_error_record` helpers to keep complexity in check.

## Test plan
- [x] `make run-local-flake8` — clean
- [x] `make run-local-mypy` — clean (492 files)
- [x] `pytest tests/lit_processing/pdf2md/` — 47 passed (up from 35)
- [ ] Smoke test on dev DB: reference with nXML + main PDF + ≥1 PDF supplement → verify `converted_merged_main` from nXML path and `converted_{method}_supplement` rows, no PDFX `converted_*_main` outputs for the main file
- [ ] Smoke test: reference with main PDF only → PDFX runs, all four `converted_*_main` outputs appear
- [ ] Smoke test workflow mode with nXML-only reference (no main PDF) → job transitions to `on_success`
- [ ] Smoke test `--no-xml` on a reference with nXML → forces PDFX on main regardless
- [ ] Smoke test `--no-supplements` → supplemental PDFs not touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)