### PR TITLE
feat(api): on-demand file conversion endpoint (SCRUM-5795)

### DIFF
--- a/agr_literature_service/api/crud/file_conversion_crud.py
+++ b/agr_literature_service/api/crud/file_conversion_crud.py
@@ -1,0 +1,600 @@
+"""
+Orchestrator for the on-demand file-conversion endpoint.
+
+Decides, for a given reference, whether a converted Markdown file already
+exists and, if not, triggers a conversion. NXML sources convert
+synchronously (fast). PDFs go to PDFX in a background task unless the caller
+sets ``wait=true``.
+
+The endpoint reports ONLY conversion status (plus per-file progress from the
+most recent job). Callers that want the resulting file listing should call the
+existing ``GET /reference/referencefile/show_all/`` endpoint once the status
+flips to ``converted``.
+
+All actual conversion work is delegated to the batch primitives in
+``agr_literature_service.lit_processing.pdf2md.pdf2md_utils``.
+"""
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import BackgroundTasks, HTTPException, status
+from sqlalchemy.orm import Session
+
+from agr_cognito_py import MOD_ACCESS_ABBR, ModAccess
+from agr_literature_service.api.crud.reference_utils import get_reference
+from agr_literature_service.api.crud.referencefile_utils import remove_from_s3_and_db
+from agr_literature_service.api.models import ReferenceModel, ReferencefileModel
+from agr_literature_service.api.utils.conversion_job_manager import ConversionJob, conversion_manager
+from agr_literature_service.api.utils.conversion_processor import run_conversion_job
+from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+    get_nxml_referencefile,
+    get_pdf_files_for_reference,
+    process_nxml_to_markdown,
+)
+
+logger = logging.getLogger(__name__)
+
+STATUS_CONVERTED = "converted"
+STATUS_RUNNING = "running"
+STATUS_FAILED = "failed"
+STATUS_NO_SOURCES = "no_sources"
+
+
+def _check_permission(reference: ReferenceModel, mod_access: Any) -> None:
+    """
+    Raise 403 if the caller cannot read this reference's files.
+
+    Mirrors the permission logic in ``referencefile_crud.download_file``:
+    open_access references are readable by anyone; otherwise the caller
+    needs ALL_ACCESS or a MOD match against one of the referencefile mods.
+    ``mod_access`` may be an empty list (unauthenticated), in which case
+    only open_access references are readable.
+    """
+    if reference.copyright_license and reference.copyright_license.open_access:
+        return
+    if not isinstance(mod_access, ModAccess):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Reference is not open access and caller has no MOD access.",
+        )
+    if mod_access == ModAccess.ALL_ACCESS:
+        return
+    if mod_access == ModAccess.NO_ACCESS:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Reference is not open access and caller has no MOD access.",
+        )
+    caller_mod = MOD_ACCESS_ABBR.get(mod_access)
+    for ref_file in reference.referencefiles or []:
+        for ref_file_mod in ref_file.referencefile_mods:
+            if ref_file_mod.mod is None:
+                return
+            if caller_mod and ref_file_mod.mod.abbreviation == caller_mod:
+                return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Reference is not open access and caller's MOD does not match any referencefile.",
+    )
+
+
+def _assess_reference(db: Session, reference: ReferenceModel,
+                      overwrite_tei_md: bool = False) -> Dict[str, Any]:
+    """
+    Inspect a reference's files and sources. Return a dict with:
+        - main_cached: bool — a converted_merged_main row exists
+        - supp_cached: bool — any converted_merged_supplement row exists
+        - nxml_source: ReferencefileModel | None
+        - main_pdfs: list[ReferencefileModel] of eligible main PDFs
+        - supp_pdfs: list[ReferencefileModel] of eligible supplement PDFs
+        - main_pdf_available: bool
+        - supp_pdf_available: bool
+        - main_missing: bool — needs conversion AND has a source
+        - supp_missing: bool — needs conversion AND has a source
+        - needs_async: bool — at least one missing class needs PDFX
+        - mod_abbreviation: str | None — first available mod abbrev for metadata
+
+    When ``overwrite_tei_md`` is True, converted rows whose display_name ends
+    with ``_tei`` (produced by the legacy TEI→MD batch job) are NOT counted as
+    cached — so the endpoint will re-convert from nXML or PDF and the
+    higher-quality output supersedes the TEI-derived fallback.
+    """
+    main_cached = False
+    supp_cached = False
+    mod_abbreviation: Optional[str] = None
+    for ref_file in reference.referencefiles or []:
+        is_tei_md = (
+            (ref_file.display_name or "").endswith("_tei")
+            and ref_file.file_extension == "md"
+        )
+        if (
+            ref_file.file_class == "converted_merged_main"
+            and ref_file.file_extension == "md"
+            and ref_file.file_publication_status == "final"
+            and not (overwrite_tei_md and is_tei_md)
+        ):
+            main_cached = True
+        if (
+            ref_file.file_class == "converted_merged_supplement"
+            and ref_file.file_extension == "md"
+            and ref_file.file_publication_status == "final"
+            and not (overwrite_tei_md and is_tei_md)
+        ):
+            supp_cached = True
+        for ref_file_mod in ref_file.referencefile_mods:
+            if mod_abbreviation is None and ref_file_mod.mod is not None:
+                mod_abbreviation = ref_file_mod.mod.abbreviation
+
+    nxml_source = None if main_cached else get_nxml_referencefile(db, reference.reference_id)
+    main_pdfs = [] if main_cached else get_pdf_files_for_reference(db, reference.reference_id, "main")
+    supp_pdfs = [] if supp_cached else get_pdf_files_for_reference(db, reference.reference_id, "supplement")
+
+    main_pdf_available = bool(main_pdfs)
+    supp_pdf_available = bool(supp_pdfs)
+
+    main_missing = (not main_cached) and (nxml_source is not None or main_pdf_available)
+    supp_missing = (not supp_cached) and supp_pdf_available
+
+    main_needs_pdf = main_missing and nxml_source is None and main_pdf_available
+    supp_needs_pdf = supp_missing and supp_pdf_available
+    needs_async = main_needs_pdf or supp_needs_pdf
+
+    return {
+        "main_cached": main_cached,
+        "supp_cached": supp_cached,
+        "nxml_source": nxml_source,
+        "main_pdfs": main_pdfs,
+        "supp_pdfs": supp_pdfs,
+        "main_pdf_available": main_pdf_available,
+        "supp_pdf_available": supp_pdf_available,
+        "main_missing": main_missing,
+        "supp_missing": supp_missing,
+        "needs_async": needs_async,
+        "mod_abbreviation": mod_abbreviation,
+    }
+
+
+def _expected_source_files_from_assessment(
+    assessment: Dict[str, Any],
+) -> List[Dict[str, Optional[str]]]:
+    """Build the list of eligible source files for the upcoming conversion job.
+
+    Used to seed ``per_file_progress`` with ``pending`` entries so callers
+    polling while a job runs can see the full list of files in flight, not
+    only the ones already finished.
+    """
+    expected: List[Dict[str, Optional[str]]] = []
+
+    if assessment.get("main_missing"):
+        nxml_source = assessment.get("nxml_source")
+        if nxml_source is not None:
+            expected.append({
+                "source_display_name": nxml_source.display_name,
+                "source_file_class": "nXML",
+                "source_referencefile_id": nxml_source.referencefile_id,
+                "expected_converted_display_name": f"{nxml_source.display_name}_nxml",
+                "expected_converted_file_class": "converted_merged_main",
+            })
+        else:
+            for pdf in assessment.get("main_pdfs") or []:
+                expected.append({
+                    "source_display_name": pdf.display_name,
+                    "source_file_class": "main",
+                    "source_referencefile_id": pdf.referencefile_id,
+                    "expected_converted_display_name": f"{pdf.display_name}_merged",
+                    "expected_converted_file_class": "converted_merged_main",
+                })
+
+    if assessment.get("supp_missing"):
+        for pdf in assessment.get("supp_pdfs") or []:
+            expected.append({
+                "source_display_name": pdf.display_name,
+                "source_file_class": "supplement",
+                "source_referencefile_id": pdf.referencefile_id,
+                "expected_converted_display_name": f"{pdf.display_name}_merged",
+                "expected_converted_file_class": "converted_merged_supplement",
+            })
+
+    return expected
+
+
+def _job_progress_payload(job: Optional[ConversionJob]) -> List[Dict[str, Any]]:
+    if job is None:
+        return []
+    out: List[Dict[str, Any]] = []
+    for p in job.per_file_progress:
+        converted_info: Optional[Dict[str, Any]] = None
+        if p.converted_display_name and p.converted_file_class:
+            converted_info = {
+                "display_name": p.converted_display_name,
+                "file_class": p.converted_file_class,
+                "referencefile_id": p.converted_referencefile_id,
+            }
+        out.append({
+            "source": {
+                "display_name": p.source_display_name,
+                "file_class": p.source_file_class,
+                "referencefile_id": p.source_referencefile_id,
+            },
+            "converted": converted_info,
+            "status": p.status,
+            "error": p.error,
+        })
+    return out
+
+
+_SUFFIX_TO_SOURCE_CLASS: Dict[str, str] = {
+    # Direct mappings: suffix → source file_class.
+    "_nxml": "nXML",
+    "_tei": "tei",
+}
+
+# PDFX method suffixes — the source file_class depends on whether the
+# converted row is main or supplement (resolved at lookup time).
+_PDFX_METHOD_SUFFIXES = ("_merged", "_grobid", "_docling", "_marker")
+
+
+def _infer_source_info(reference: ReferenceModel,
+                       converted_display_name: str,
+                       converted_file_class: str) -> Optional[Dict[str, Any]]:
+    """Best-effort lookup of the source referencefile that produced a given
+    converted Markdown row, based on the display_name suffix convention used
+    by pdf2md_utils and the legacy TEI→MD batch. Returns the source info
+    dict or None if the source can't be identified."""
+    base_name: Optional[str] = None
+    source_class: Optional[str] = None
+    for suffix, src_class in _SUFFIX_TO_SOURCE_CLASS.items():
+        if converted_display_name.endswith(suffix):
+            base_name = converted_display_name[: -len(suffix)]
+            source_class = src_class
+            break
+    if source_class is None:
+        for method_suffix in _PDFX_METHOD_SUFFIXES:
+            if converted_display_name.endswith(method_suffix):
+                base_name = converted_display_name[: -len(method_suffix)]
+                if converted_file_class == "converted_merged_main":
+                    source_class = "main"
+                elif converted_file_class == "converted_merged_supplement":
+                    source_class = "supplement"
+                break
+    if base_name is None or source_class is None:
+        return None
+    for rf in reference.referencefiles or []:
+        if rf.file_class == source_class and rf.display_name == base_name:
+            return {
+                "display_name": rf.display_name,
+                "file_class": rf.file_class,
+                "referencefile_id": int(rf.referencefile_id),
+            }
+    return None
+
+
+def _db_derived_progress(reference: ReferenceModel) -> List[Dict[str, Any]]:
+    """Produce per_file_progress entries for every converted Markdown row
+    currently in the DB for this reference. Used to surface referencefile_ids
+    even when no job ran in this process (e.g. the reference was converted in
+    a prior session and the manager's in-memory state has since been lost).
+    Source info is inferred from the display_name suffix convention."""
+    out: List[Dict[str, Any]] = []
+    for ref_file in reference.referencefiles or []:
+        if ref_file.file_class not in ("converted_merged_main",
+                                       "converted_merged_supplement"):
+            continue
+        if ref_file.file_extension != "md":
+            continue
+        if ref_file.file_publication_status != "final":
+            continue
+        out.append({
+            "source": _infer_source_info(
+                reference, ref_file.display_name or "", ref_file.file_class,
+            ),
+            "converted": {
+                "display_name": ref_file.display_name,
+                "file_class": ref_file.file_class,
+                "referencefile_id": int(ref_file.referencefile_id),
+            },
+            "status": "success",
+            "error": None,
+        })
+    return out
+
+
+def _merge_progress(job_progress: List[Dict[str, Any]],
+                    db_progress: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Merge job-recorded progress with DB-synthesized entries. Dedupes by
+    the converted file's (display_name, file_class) — job entries win because
+    they carry source info and accurate status (incl. pending/failed)."""
+    seen: set = set()
+    for entry in job_progress:
+        conv = entry.get("converted") or {}
+        if conv.get("display_name") and conv.get("file_class"):
+            seen.add((conv["display_name"], conv["file_class"]))
+    merged = list(job_progress)
+    for db_entry in db_progress:
+        conv = db_entry.get("converted") or {}
+        key = (conv.get("display_name"), conv.get("file_class"))
+        if key not in seen:
+            merged.append(db_entry)
+    return merged
+
+
+def _converted_classes_from_assessment(assessment: Dict[str, Any]) -> List[str]:
+    """List the converted file_class values currently present in the DB for
+    this reference — regardless of whether they were produced in this call or
+    written by a prior run."""
+    out: List[str] = []
+    if assessment.get("main_cached"):
+        out.append("converted_merged_main")
+    if assessment.get("supp_cached"):
+        out.append("converted_merged_supplement")
+    return out
+
+
+def _status_payload(reference: ReferenceModel, *, status_str: str,
+                    converted_classes: List[str],
+                    job: Optional[ConversionJob] = None,
+                    error_message: Optional[str] = None,
+                    started_at: Optional[str] = None,
+                    completed_at: Optional[str] = None) -> Dict[str, Any]:
+    """Build the endpoint response. ``job`` is the most recent job for the
+    reference, if any — its id, timestamps, and per-file progress are surfaced.
+    Per-file progress is merged with synthesized DB entries so converted rows
+    produced in prior sessions still surface their referencefile_ids."""
+    progress = _merge_progress(
+        _job_progress_payload(job),
+        _db_derived_progress(reference),
+    )
+    payload: Dict[str, Any] = {
+        "reference_curie": reference.curie,
+        "status": status_str,
+        "job_id": job.job_id if job else None,
+        "error_message": error_message,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "converted_classes": converted_classes,
+        "per_file_progress": progress,
+    }
+    if job is not None and payload["started_at"] is None:
+        payload["started_at"] = job.started_at.isoformat()
+    if job is not None and payload["completed_at"] is None and job.completed_at is not None:
+        payload["completed_at"] = job.completed_at.isoformat()
+    if job is not None and payload["error_message"] is None and job.error_message:
+        payload["error_message"] = job.error_message
+    return payload
+
+
+def _execute_sync_nxml(db: Session, reference: ReferenceModel,
+                       assessment: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
+    """Run the NXML-only conversion inline. Returns (success, error_message)."""
+    nxml_source = assessment["nxml_source"]
+    if nxml_source is None:
+        return False, "No nXML source available"
+    success, error = process_nxml_to_markdown(
+        db=db,
+        nxml_ref_file=nxml_source,
+        reference_curie=reference.curie,
+        mod_abbreviation=assessment["mod_abbreviation"],
+    )
+    return success, error
+
+
+def find_converted_referencefile_id(db: Session, reference_id: int,
+                                    display_name: str,
+                                    file_class: str) -> Optional[int]:
+    """Look up a newly-uploaded converted Markdown row by its expected
+    display_name + file_class. Returns the referencefile_id of the most
+    recently created matching row, or None if not found."""
+    row = (
+        db.query(ReferencefileModel)
+        .filter(
+            ReferencefileModel.reference_id == reference_id,
+            ReferencefileModel.display_name == display_name,
+            ReferencefileModel.file_class == file_class,
+            ReferencefileModel.file_extension == "md",
+            ReferencefileModel.file_publication_status == "final",
+        )
+        .order_by(ReferencefileModel.date_created.desc())
+        .first()
+    )
+    return int(row.referencefile_id) if row else None
+
+
+def delete_tei_derived_md_rows(db: Session, reference: ReferenceModel,
+                               file_classes: List[str]) -> int:
+    """Remove converted Markdown rows produced by the legacy TEI→MD batch.
+    Identified as rows with the given file_class(es), file_extension == 'md',
+    and display_name ending with '_tei'. Returns the number of rows deleted."""
+    removed = 0
+    for ref_file in list(reference.referencefiles or []):
+        if ref_file.file_class not in file_classes:
+            continue
+        if ref_file.file_extension != "md":
+            continue
+        if not (ref_file.display_name or "").endswith("_tei"):
+            continue
+        try:
+            remove_from_s3_and_db(db, ref_file)
+            removed += 1
+        except Exception:
+            logger.exception(
+                f"Failed to delete TEI-derived MD row "
+                f"referencefile_id={ref_file.referencefile_id} for "
+                f"reference {reference.curie}"
+            )
+    if removed:
+        logger.info(
+            f"Deleted {removed} TEI-derived MD row(s) for reference {reference.curie}"
+        )
+    return removed
+
+
+def handle_conversion_request(db: Session, curie_or_reference_id: str, wait: bool,
+                              background_tasks: BackgroundTasks, mod_access: ModAccess,
+                              user_id: str,
+                              overwrite_tei_md: bool = False
+                              ) -> Tuple[int, Dict[str, Any]]:
+    """
+    Orchestrator for
+    ``GET /reference/referencefile/conversion_request/{curie_or_reference_id}``.
+
+    Returns a ``(status_code, response_dict)`` tuple so the router can set the
+    HTTP status to 200 or 202 as appropriate. The response reports conversion
+    state plus the per-file progress of the most recent job (if any); callers
+    use ``show_all`` to fetch the file listing once status is ``converted``.
+
+    ``overwrite_tei_md`` — when True, converted Markdown rows produced by the
+    legacy TEI→MD batch (display_name ends in ``_tei``) are ignored when
+    deciding whether the reference is already converted, so a fresh nXML /
+    PDFX conversion runs. After a successful new conversion, the TEI-derived
+    rows are deleted.
+    """
+    reference = get_reference(db=db, curie_or_reference_id=curie_or_reference_id,
+                              load_referencefiles=True)
+    _check_permission(reference, mod_access)
+
+    assessment = _assess_reference(db, reference, overwrite_tei_md=overwrite_tei_md)
+    now_iso = datetime.utcnow().isoformat()
+    recent_job = conversion_manager.get_last_job_for_reference(reference.reference_id)
+
+    # If a job is still running for this reference, always report "running" —
+    # even if the DB already reflects completed work. This closes the race
+    # between file_upload committing a new row and the processor calling
+    # record_file_progress, so callers only see status="converted" once every
+    # per_file_progress entry (with referencefile_id) is finalized.
+    existing = conversion_manager.get_active_job_for_reference(reference.reference_id)
+    if existing is not None:
+        return status.HTTP_202_ACCEPTED, _status_payload(
+            reference, status_str=STATUS_RUNNING,
+            converted_classes=_converted_classes_from_assessment(assessment),
+            started_at=existing.started_at.isoformat(), job=existing,
+        )
+
+    nothing_missing = not assessment["main_missing"] and not assessment["supp_missing"]
+    nothing_cached = not assessment["main_cached"] and not assessment["supp_cached"]
+    no_sources = (
+        not assessment["nxml_source"]
+        and not assessment["main_pdf_available"]
+        and not assessment["supp_pdf_available"]
+    )
+
+    if nothing_missing:
+        if nothing_cached and no_sources:
+            return status.HTTP_200_OK, _status_payload(
+                reference, status_str=STATUS_NO_SOURCES,
+                converted_classes=_converted_classes_from_assessment(assessment),
+                job=recent_job,
+            )
+        return status.HTTP_200_OK, _status_payload(
+            reference, status_str=STATUS_CONVERTED,
+            converted_classes=_converted_classes_from_assessment(assessment),
+            completed_at=now_iso, job=recent_job,
+        )
+
+    nxml_only = (
+        assessment["main_missing"]
+        and assessment["nxml_source"] is not None
+        and not assessment["supp_missing"]
+    )
+    if nxml_only:
+        success, error = _execute_sync_nxml(db, reference, assessment)
+        if not success:
+            return status.HTTP_200_OK, _status_payload(
+                reference, status_str=STATUS_FAILED,
+                converted_classes=_converted_classes_from_assessment(assessment),
+                error_message=error or "nXML conversion failed",
+                completed_at=now_iso, job=recent_job,
+            )
+        if overwrite_tei_md:
+            delete_tei_derived_md_rows(
+                db, reference,
+                ["converted_merged_main", "converted_merged_supplement"],
+            )
+        db.expire(reference)
+        reference = get_reference(db=db, curie_or_reference_id=curie_or_reference_id,
+                                  load_referencefiles=True)
+        post_assessment = _assess_reference(db, reference)
+        return status.HTTP_200_OK, _status_payload(
+            reference, status_str=STATUS_CONVERTED,
+            converted_classes=_converted_classes_from_assessment(post_assessment),
+            started_at=now_iso, completed_at=now_iso, job=recent_job,
+        )
+
+    if wait:
+        job = conversion_manager.create_or_get_job(
+            reference_id=reference.reference_id,
+            reference_curie=reference.curie,
+            user_id=user_id,
+            expected_source_files=_expected_source_files_from_assessment(assessment),
+        )
+        run_conversion_job(
+            job_id=job.job_id,
+            reference_id=reference.reference_id,
+            reference_curie=reference.curie,
+            overwrite_tei_md=overwrite_tei_md,
+        )
+        db.expire(reference)
+        reference = get_reference(db=db, curie_or_reference_id=curie_or_reference_id,
+                                  load_referencefiles=True)
+        post_assessment = _assess_reference(db, reference, overwrite_tei_md=overwrite_tei_md)
+        final_job = conversion_manager.get_job(job.job_id)
+        failed = (
+            post_assessment["main_missing"]
+            or post_assessment["supp_missing"]
+            or (final_job is not None and final_job.status == "failed")
+        )
+        if failed:
+            error_detail = ""
+            if final_job is not None:
+                if final_job.error_message:
+                    error_detail = final_job.error_message
+                per_file_errors = [
+                    f"{p.source_display_name}: {p.error}"
+                    for p in final_job.per_file_progress
+                    if p.status == "failed" and p.error
+                ]
+                if per_file_errors:
+                    error_detail = (error_detail + "; " if error_detail else "") \
+                        + "; ".join(per_file_errors)
+            if not error_detail:
+                error_detail = "Conversion completed but some files are still missing."
+            completed_at = (final_job.completed_at.isoformat()
+                            if final_job and final_job.completed_at
+                            else now_iso)
+            return status.HTTP_200_OK, _status_payload(
+                reference, status_str=STATUS_FAILED,
+                converted_classes=_converted_classes_from_assessment(post_assessment),
+                error_message=error_detail,
+                started_at=job.started_at.isoformat(),
+                completed_at=completed_at, job=final_job,
+            )
+        return status.HTTP_200_OK, _status_payload(
+            reference, status_str=STATUS_CONVERTED,
+            converted_classes=_converted_classes_from_assessment(post_assessment),
+            started_at=job.started_at.isoformat(),
+            completed_at=datetime.utcnow().isoformat(), job=final_job,
+        )
+
+    job = conversion_manager.create_or_get_job(
+        reference_id=reference.reference_id,
+        reference_curie=reference.curie,
+        user_id=user_id,
+        expected_source_files=_expected_source_files_from_assessment(assessment),
+    )
+    background_tasks.add_task(
+        run_conversion_job,
+        job.job_id,
+        reference.reference_id,
+        reference.curie,
+        overwrite_tei_md,
+    )
+    return status.HTTP_202_ACCEPTED, _status_payload(
+        reference, status_str=STATUS_RUNNING,
+        converted_classes=_converted_classes_from_assessment(assessment),
+        started_at=job.started_at.isoformat(), job=job,
+    )
+
+
+__all__ = [
+    "_assess_reference",
+    "handle_conversion_request",
+]

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -331,15 +331,23 @@ def check_if_paper_in_corpus(db, reference_curie, mod_abbr):
 
 def file_upload(db: Session, metadata: dict, file: UploadFile, upload_if_already_converted: bool = False):  # pragma: no cover
     metadata["reference_curie"] = normalize_reference_curie(db, metadata["reference_curie"])
+    # TRANSIENT (remove with SCRUM-5867): converted Markdown outputs (file_class
+    # starting with 'converted_') bypass the is_file_upload_blocked guardrail.
+    # Rationale: during the TEI→Markdown migration, pipelines that run while
+    # extraction/classification are in progress still need to write out their
+    # converted_* rows without clashing with the safeguard intended for original
+    # source files. Remove this bypass when pdf2tei is decommissioned.
+    is_converted_output = str(metadata.get("file_class") or "").startswith("converted_")
     if metadata["mod_abbreviation"]:
         inCorpus = check_if_paper_in_corpus(db, metadata["reference_curie"], metadata["mod_abbreviation"])
         if not inCorpus:
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                                 detail=f"This paper ({metadata['reference_curie']}) is not in {metadata['mod_abbreviation']}.")
-        job_type = is_file_upload_blocked(db, metadata["reference_curie"], metadata["mod_abbreviation"])
-        if job_type:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                                detail=f"The {job_type} for reference {metadata['reference_curie']} is currently in progress. Please wait until the {job_type} process is complete before uploading any files for this paper.")
+        if not is_converted_output:
+            job_type = is_file_upload_blocked(db, metadata["reference_curie"], metadata["mod_abbreviation"])
+            if job_type:
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                    detail=f"The {job_type} for reference {metadata['reference_curie']} is currently in progress. Please wait until the {job_type} process is complete before uploading any files for this paper.")
 
     if (
         metadata["file_class"] == 'main'

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -4,17 +4,19 @@ import logging
 from json import JSONDecodeError
 from typing import Union, List, Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, Security, status, File, UploadFile, \
+from fastapi import APIRouter, Depends, Response, Security, status, File, UploadFile, \
     BackgroundTasks, HTTPException
 from fastapi.responses import PlainTextResponse
 
 from sqlalchemy.orm import Session
 
 from agr_literature_service.api import database
-from agr_literature_service.api.crud import referencefile_crud
+from agr_literature_service.api.crud import file_conversion_crud, referencefile_crud
 from agr_literature_service.api.deps import s3_auth
 from agr_cognito_py import get_mod_access
 from agr_literature_service.api.schemas import ResponseMessageSchema
+from agr_literature_service.api.schemas.file_conversion_schemas import \
+    ConversionStatusResponseSchema
 from agr_literature_service.api.schemas.referencefile_schemas import ReferencefileSchemaShow, \
     ReferencefileSchemaUpdate, ReferencefileSchemaRelated, ReferenceFileAllMainPDFIdsSchemaPost
 from agr_literature_service.api.utils.bulk_upload_utils import validate_archive_structure
@@ -165,6 +167,80 @@ def show_all(curie_or_reference_id: str,
              user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
              db: Session = db_session):
     return referencefile_crud.show_all(db, curie_or_reference_id)
+
+
+@router.get('/conversion_request/{curie_or_reference_id}',
+            responses={
+                status.HTTP_200_OK: {"model": ConversionStatusResponseSchema},
+                status.HTTP_202_ACCEPTED: {"model": ConversionStatusResponseSchema},
+            })
+def get_converted(curie_or_reference_id: str,
+                  response: Response,
+                  background_tasks: BackgroundTasks,
+                  wait: bool = False,
+                  overwrite_tei_md: bool = False,
+                  user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+                  db: Session = db_session):
+    """
+    Request on-demand conversion of a reference's files to Markdown and report
+    the conversion state. Returns status only — use the existing endpoint
+    ``GET /reference/referencefile/show_all/{curie_or_reference_id}`` to fetch
+    the resulting file listing once the status is ``converted``.
+
+    Re-calling this endpoint acts as a poll: the response surfaces the current
+    conversion state plus ``per_file_progress`` for the most recent job. There
+    is no separate status endpoint — poll this URL for updates.
+
+    Status values returned in the response body:
+    - ``converted``: every convertible source has a converted Markdown row
+      in the DB (whether produced by this call or a prior one). HTTP 200.
+    - ``running``: a background conversion job is in progress. HTTP 202.
+      Re-call this URL to poll; ``converted_classes`` already lists any rows
+      that are done so partial results can be consumed without waiting.
+    - ``failed``: the most recent conversion attempt failed. See
+      ``error_message`` and ``per_file_progress`` for details. HTTP 200.
+    - ``no_sources``: the reference has nothing to convert (no nXML, no main
+      PDF, no supplement PDFs). HTTP 200.
+
+    Behavior:
+    - If everything convertible already has a converted row, returns 200
+      immediately with status=``converted`` and no job is started.
+    - If only an nXML source is missing its Markdown, the conversion is run
+      synchronously and 200 with status=``converted`` is returned.
+    - If PDF conversion is needed, the default returns 202 with
+      status=``running`` and a ``job_id``. Re-call the same URL to poll.
+    - Pass ``wait=true`` to block until PDF conversion finishes (can take
+      minutes; may hit HTTP/gateway timeouts).
+    - Pass ``overwrite_tei_md=true`` to ignore legacy TEI-derived Markdown
+      rows (display_name ending in ``_tei``) when checking cache, forcing a
+      fresh higher-quality nXML/PDFX conversion. On success, the legacy
+      TEI-derived rows are deleted so the new output replaces them.
+
+    The response includes ``converted_classes`` — the list of converted
+    file_class values currently present in the DB. Clients can act on
+    partial results (for example, fetching ``converted_merged_main`` as soon
+    as it appears, while a longer-running supplement conversion is still in
+    progress). ``per_file_progress`` reports, for each file the most recent
+    job attempted, the source file info and the resulting converted file
+    info (or null on failure).
+
+    Idempotent: concurrent calls for the same reference share a job_id.
+    """
+    mod_access = get_mod_access(user) if user else []
+    user_id = "unknown"
+    if user:
+        user_id = str(user.get("cognito:username") or user.get("sub", "unknown"))
+    status_code, payload = file_conversion_crud.handle_conversion_request(
+        db=db,
+        curie_or_reference_id=curie_or_reference_id,
+        wait=wait,
+        background_tasks=background_tasks,
+        mod_access=mod_access,
+        user_id=user_id,
+        overwrite_tei_md=overwrite_tei_md,
+    )
+    response.status_code = status_code
+    return payload
 
 
 @router.post('/show_main_pdf_ids_for_curies',

--- a/agr_literature_service/api/schemas/file_conversion_schemas.py
+++ b/agr_literature_service/api/schemas/file_conversion_schemas.py
@@ -1,0 +1,63 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ConversionFileInfo(BaseModel):
+    model_config = ConfigDict(extra='forbid', from_attributes=True)
+
+    display_name: str
+    file_class: str
+    referencefile_id: Optional[int] = None
+
+
+class ConversionPerFileProgressSchema(BaseModel):
+    """One entry per source file eligible for conversion on the most recent
+    job, plus one entry per converted Markdown row currently in the DB for
+    which no job entry exists. ``status`` is ``pending`` (not yet attempted),
+    ``success``, or ``failed``. For ``pending`` and ``success`` entries,
+    ``converted`` contains the (expected or actual) output file's
+    display_name and file_class; for ``failed`` entries ``converted`` is
+    null and ``error`` is populated. ``source`` may be null for entries
+    derived purely from the DB — call ``show_all`` if you need the original
+    source file info for those."""
+    model_config = ConfigDict(extra='forbid', from_attributes=True)
+
+    source: Optional[ConversionFileInfo] = None
+    converted: Optional[ConversionFileInfo] = None
+    status: str
+    error: Optional[str] = None
+
+
+class ConversionStatusResponseSchema(BaseModel):
+    """
+    Response for GET /reference/referencefile/conversion_request/{curie_or_reference_id}.
+
+    Reports the conversion state for a reference and includes per-file progress
+    for the most recent job (if any). Callers use the existing
+    GET /reference/referencefile/show_all/{curie_or_reference_id} to retrieve
+    the file listing once ``status`` is ``converted``.
+
+    Possible ``status`` values:
+        - ``converted`` — every convertible source has a converted Markdown
+          row in the DB (whether produced by this call or a prior one).
+        - ``running``   — a conversion job is currently in progress.
+        - ``failed``    — the most recent conversion failed; see
+          ``error_message`` and ``per_file_progress``.
+        - ``no_sources``— the reference has nothing to convert.
+
+    ``converted_classes`` lists the converted file_class values currently
+    present in the DB for this reference. Clients can act on partial results
+    (fetching ``converted_merged_main`` as soon as it appears, for example,
+    without waiting for longer-running supplement conversions to finish).
+    """
+    model_config = ConfigDict(extra='forbid', from_attributes=True)
+
+    reference_curie: str
+    status: str
+    job_id: Optional[str] = None
+    error_message: Optional[str] = None
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    converted_classes: List[str] = []
+    per_file_progress: List[ConversionPerFileProgressSchema] = []

--- a/agr_literature_service/api/utils/conversion_job_manager.py
+++ b/agr_literature_service/api/utils/conversion_job_manager.py
@@ -1,0 +1,249 @@
+"""
+Thread-safe in-memory manager for on-demand file-conversion jobs.
+
+Mirrors BulkUploadManager but is keyed by reference_id for idempotency:
+two concurrent requests to convert the same reference share a single job
+rather than launching duplicate PDFX runs.
+
+Job state is per-process and lost on restart (same tradeoff as
+BulkUploadManager). Under multi-worker uvicorn the worst case is one
+duplicate job per worker; acceptable for the current use case.
+"""
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PerFileProgress:
+    source_display_name: str
+    source_file_class: str
+    # Per-file status: "pending" (not yet attempted), "success", or "failed".
+    status: str = "pending"
+    error: Optional[str] = None
+    source_referencefile_id: Optional[int] = None
+    converted_display_name: Optional[str] = None
+    converted_file_class: Optional[str] = None
+    converted_referencefile_id: Optional[int] = None
+
+
+@dataclass
+class ConversionJob:
+    job_id: str
+    reference_id: int
+    reference_curie: str
+    user_id: str
+    status: str  # 'running', 'completed', 'failed'
+    started_at: datetime = field(default_factory=datetime.utcnow)
+    completed_at: Optional[datetime] = None
+    last_update: datetime = field(default_factory=datetime.utcnow)
+    error_message: str = ""
+    per_file_progress: List[PerFileProgress] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "reference_id": self.reference_id,
+            "reference_curie": self.reference_curie,
+            "status": self.status,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "duration_seconds": self.duration_seconds,
+            "error_message": self.error_message,
+            "per_file_progress": [
+                {
+                    "source_display_name": p.source_display_name,
+                    "source_file_class": p.source_file_class,
+                    "source_referencefile_id": p.source_referencefile_id,
+                    "converted_display_name": p.converted_display_name,
+                    "converted_file_class": p.converted_file_class,
+                    "converted_referencefile_id": p.converted_referencefile_id,
+                    "status": p.status,
+                    "error": p.error,
+                }
+                for p in self.per_file_progress
+            ],
+        }
+
+    @property
+    def duration_seconds(self) -> float:
+        end = self.completed_at or datetime.utcnow()
+        return (end - self.started_at).total_seconds()
+
+
+class ConversionJobManager:
+    """Thread-safe in-memory manager for file-conversion jobs."""
+
+    def __init__(self) -> None:
+        self._jobs: Dict[str, ConversionJob] = {}
+        self._active_by_reference: Dict[int, str] = {}
+        self._last_by_reference: Dict[int, str] = {}
+        self._lock = Lock()
+
+    def create_or_get_job(self, reference_id: int, reference_curie: str, user_id: str,
+                          expected_source_files: Optional[List[Dict[str, Optional[str]]]] = None) -> ConversionJob:
+        """
+        Atomically return the existing running job for the reference or create a new one.
+
+        This is the idempotency primitive: two concurrent callers asking for the
+        same reference both receive the same job.
+
+        ``expected_source_files`` — when creating a new job, seeds the job's
+        ``per_file_progress`` with a ``pending`` entry for each eligible source.
+        Each dict may include ``source_display_name``, ``source_file_class``,
+        ``expected_converted_display_name``, ``expected_converted_file_class``.
+        Seeding is skipped when an existing running job is returned.
+        """
+        with self._lock:
+            existing_job_id = self._active_by_reference.get(reference_id)
+            if existing_job_id:
+                existing = self._jobs.get(existing_job_id)
+                if existing and existing.status == "running":
+                    return existing
+                # Stale entry (job was completed/failed but not cleaned up) — fall through.
+                self._active_by_reference.pop(reference_id, None)
+
+            job_id = str(uuid.uuid4())
+            job = ConversionJob(
+                job_id=job_id,
+                reference_id=reference_id,
+                reference_curie=reference_curie,
+                user_id=user_id,
+                status="running",
+            )
+            if expected_source_files:
+                for ef in expected_source_files:
+                    source_id = ef.get("source_referencefile_id")
+                    source_id_int = int(source_id) if source_id is not None else None
+                    job.per_file_progress.append(
+                        PerFileProgress(
+                            source_display_name=str(ef["source_display_name"]),
+                            source_file_class=str(ef["source_file_class"]),
+                            source_referencefile_id=source_id_int,
+                            converted_display_name=ef.get("expected_converted_display_name"),
+                            converted_file_class=ef.get("expected_converted_file_class"),
+                            status="pending",
+                        )
+                    )
+            self._jobs[job_id] = job
+            self._active_by_reference[reference_id] = job_id
+            self._last_by_reference[reference_id] = job_id
+        logger.info(
+            f"Created conversion job {job_id} for reference_id={reference_id} "
+            f"(curie={reference_curie}, user={user_id})"
+        )
+        return job
+
+    def get_job(self, job_id: str) -> Optional[ConversionJob]:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def get_active_job_for_reference(self, reference_id: int) -> Optional[ConversionJob]:
+        with self._lock:
+            job_id = self._active_by_reference.get(reference_id)
+            if not job_id:
+                return None
+            job = self._jobs.get(job_id)
+            if job and job.status == "running":
+                return job
+            return None
+
+    def get_last_job_for_reference(self, reference_id: int) -> Optional[ConversionJob]:
+        """Return the most recent job for this reference, regardless of status."""
+        with self._lock:
+            job_id = self._last_by_reference.get(reference_id)
+            if not job_id:
+                return None
+            return self._jobs.get(job_id)
+
+    def record_file_progress(self, job_id: str, *,
+                             source_display_name: str,
+                             source_file_class: str,
+                             success: bool,
+                             error: Optional[str] = None,
+                             source_referencefile_id: Optional[int] = None,
+                             converted_display_name: Optional[str] = None,
+                             converted_file_class: Optional[str] = None,
+                             converted_referencefile_id: Optional[int] = None) -> None:
+        """Update the pending entry for this source (matched by
+        ``source_display_name`` + ``source_file_class``). If no pending entry
+        was seeded, a new entry is appended (defensive)."""
+        new_status = "success" if success else "failed"
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+            existing: Optional[PerFileProgress] = None
+            for p in job.per_file_progress:
+                if (p.source_display_name == source_display_name
+                        and p.source_file_class == source_file_class):
+                    existing = p
+                    break
+            if existing is not None:
+                existing.status = new_status
+                existing.error = error
+                if source_referencefile_id is not None:
+                    existing.source_referencefile_id = source_referencefile_id
+                if success:
+                    if converted_display_name is not None:
+                        existing.converted_display_name = converted_display_name
+                    if converted_file_class is not None:
+                        existing.converted_file_class = converted_file_class
+                    if converted_referencefile_id is not None:
+                        existing.converted_referencefile_id = converted_referencefile_id
+                else:
+                    existing.converted_display_name = None
+                    existing.converted_file_class = None
+                    existing.converted_referencefile_id = None
+            else:
+                job.per_file_progress.append(
+                    PerFileProgress(
+                        source_display_name=source_display_name,
+                        source_file_class=source_file_class,
+                        source_referencefile_id=source_referencefile_id,
+                        converted_display_name=converted_display_name if success else None,
+                        converted_file_class=converted_file_class if success else None,
+                        converted_referencefile_id=converted_referencefile_id if success else None,
+                        status=new_status,
+                        error=error,
+                    )
+                )
+            job.last_update = datetime.utcnow()
+
+    def complete_job(self, job_id: str, success: bool, error: str = "") -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+            job.status = "completed" if success else "failed"
+            job.completed_at = datetime.utcnow()
+            job.last_update = job.completed_at
+            if error:
+                job.error_message = error
+            self._active_by_reference.pop(job.reference_id, None)
+        logger.info(f"Conversion job {job_id} {job.status} (reference_id={job.reference_id})")
+
+    def cleanup_old_jobs(self, max_age_hours: int = 24) -> int:
+        cutoff = datetime.utcnow() - timedelta(hours=max_age_hours)
+        removed = 0
+        with self._lock:
+            to_remove = [
+                jid for jid, job in self._jobs.items()
+                if job.status != "running" and job.started_at < cutoff
+            ]
+            for jid in to_remove:
+                job = self._jobs.pop(jid)
+                if self._last_by_reference.get(job.reference_id) == jid:
+                    self._last_by_reference.pop(job.reference_id, None)
+                removed += 1
+        if removed:
+            logger.info(f"Cleaned up {removed} old conversion jobs")
+        return removed
+
+
+conversion_manager = ConversionJobManager()

--- a/agr_literature_service/api/utils/conversion_processor.py
+++ b/agr_literature_service/api/utils/conversion_processor.py
@@ -6,7 +6,7 @@ Dispatches to the existing batch conversion primitives in
 re-implementing any conversion logic here.
 """
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from agr_literature_service.api.database.main import SessionLocal
 from agr_literature_service.api.utils.conversion_job_manager import conversion_manager

--- a/agr_literature_service/api/utils/conversion_processor.py
+++ b/agr_literature_service/api/utils/conversion_processor.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 def _record_pdf_details(db: Any, job_id: str, reference_id: int,
-                        details: List[Dict[str, Any]], output_file_class: str) -> None:
+                        details: List[Any], output_file_class: str) -> None:
     """Translate process_pdf_for_reference per-PDF details into job progress entries.
     Each source PDF produces one entry; if the 'merged' method succeeded, the
     converted side points at the merged output row for that PDF."""

--- a/agr_literature_service/api/utils/conversion_processor.py
+++ b/agr_literature_service/api/utils/conversion_processor.py
@@ -1,0 +1,162 @@
+"""
+Background task for on-demand file conversion.
+
+Dispatches to the existing batch conversion primitives in
+``agr_literature_service.lit_processing.pdf2md.pdf2md_utils`` rather than
+re-implementing any conversion logic here.
+"""
+import logging
+from typing import Any, Dict, List, Optional
+
+from agr_literature_service.api.database.main import SessionLocal
+from agr_literature_service.api.utils.conversion_job_manager import conversion_manager
+
+logger = logging.getLogger(__name__)
+
+
+def _record_pdf_details(db: Any, job_id: str, reference_id: int,
+                        details: List[Dict[str, Any]], output_file_class: str) -> None:
+    """Translate process_pdf_for_reference per-PDF details into job progress entries.
+    Each source PDF produces one entry; if the 'merged' method succeeded, the
+    converted side points at the merged output row for that PDF."""
+    from agr_literature_service.api.crud.file_conversion_crud import find_converted_referencefile_id
+    for detail in details:
+        merged_uploaded = "merged" in (detail.get("methods_uploaded") or [])
+        source_display_name = detail["display_name"]
+        converted_display_name = f"{source_display_name}_merged" if merged_uploaded else None
+        converted_rf_id: Optional[int] = None
+        if merged_uploaded and converted_display_name is not None:
+            converted_rf_id = find_converted_referencefile_id(
+                db, reference_id, converted_display_name, output_file_class,
+            )
+        conversion_manager.record_file_progress(
+            job_id=job_id,
+            source_display_name=source_display_name,
+            source_file_class=detail["file_class"],
+            source_referencefile_id=detail.get("referencefile_id"),
+            converted_display_name=converted_display_name,
+            converted_file_class=output_file_class if merged_uploaded else None,
+            converted_referencefile_id=converted_rf_id,
+            success=detail["success"],
+            error=detail.get("error"),
+        )
+
+
+def run_conversion_job(job_id: str, reference_id: int, reference_curie: str,
+                       overwrite_tei_md: bool = False) -> None:
+    """
+    Execute a pending conversion job.
+
+    Opens its own SessionLocal (the request's DB session has closed by the time
+    the BackgroundTasks runner invokes this). Figures out what's missing for
+    the reference and dispatches NXML or PDFX conversions to the batch
+    primitives. Reports progress to ``conversion_manager`` and marks the job
+    completed or failed before returning.
+
+    ``overwrite_tei_md`` — when True, TEI-derived converted Markdown rows
+    (display_name ending in ``_tei``) are not counted as cached, so the job
+    will re-run the conversion. On success, the legacy TEI-derived rows are
+    deleted so the new higher-quality output replaces them.
+
+    Never raises: any exception is captured on the job.
+    """
+    from agr_literature_service.api.crud.file_conversion_crud import (
+        _assess_reference,
+        delete_tei_derived_md_rows,
+        find_converted_referencefile_id,
+    )
+    from agr_literature_service.api.crud.reference_utils import get_reference
+    from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+        process_nxml_to_markdown,
+        process_pdf_for_reference,
+    )
+
+    db = SessionLocal()
+    try:
+        reference = get_reference(db, str(reference_id), load_referencefiles=True)
+        assessment = _assess_reference(db, reference, overwrite_tei_md=overwrite_tei_md)
+
+        any_failure = False
+        failure_messages = []
+
+        # Main: prefer NXML (sync, fast) if available; else fall back to PDFX.
+        if assessment["main_missing"]:
+            if assessment["nxml_source"] is not None:
+                nxml_source = assessment["nxml_source"]
+                success, error = process_nxml_to_markdown(
+                    db=db,
+                    nxml_ref_file=nxml_source,
+                    reference_curie=reference_curie,
+                    mod_abbreviation=assessment["mod_abbreviation"],
+                )
+                converted_display_name = f"{nxml_source.display_name}_nxml" if success else None
+                converted_rf_id: Optional[int] = None
+                if success and converted_display_name is not None:
+                    converted_rf_id = find_converted_referencefile_id(
+                        db, reference_id, converted_display_name, "converted_merged_main",
+                    )
+                conversion_manager.record_file_progress(
+                    job_id=job_id,
+                    source_display_name=nxml_source.display_name,
+                    source_file_class="nXML",
+                    source_referencefile_id=nxml_source.referencefile_id,
+                    converted_display_name=converted_display_name,
+                    converted_file_class="converted_merged_main" if success else None,
+                    converted_referencefile_id=converted_rf_id,
+                    success=success,
+                    error=error,
+                )
+                if not success:
+                    any_failure = True
+                    if error:
+                        failure_messages.append(f"nXML main: {error}")
+            elif assessment["main_pdf_available"]:
+                result = process_pdf_for_reference(
+                    db=db,
+                    curie=reference_curie,
+                    pdf_type="main",
+                )
+                _record_pdf_details(db, job_id, reference_id,
+                                    result.get("details", []), "converted_merged_main")
+                if not result.get("success"):
+                    any_failure = True
+                    err = result.get("error")
+                    if err:
+                        failure_messages.append(f"PDF main: {err}")
+
+        # Supplements: always PDFX when any supplement PDFs exist.
+        if assessment["supp_missing"] and assessment["supp_pdf_available"]:
+            result = process_pdf_for_reference(
+                db=db,
+                curie=reference_curie,
+                pdf_type="supplement",
+            )
+            _record_pdf_details(db, job_id, reference_id,
+                                result.get("details", []), "converted_merged_supplement")
+            if not result.get("success"):
+                any_failure = True
+                err = result.get("error")
+                if err:
+                    failure_messages.append(f"PDF supplements: {err}")
+
+        overall_success = not any_failure
+        if overwrite_tei_md and overall_success:
+            # Re-query the reference so the freshly-uploaded converted rows
+            # are visible, then drop any legacy TEI-derived MD rows.
+            db.expire_all()
+            reference = get_reference(db, str(reference_id), load_referencefiles=True)
+            delete_tei_derived_md_rows(
+                db, reference,
+                ["converted_merged_main", "converted_merged_supplement"],
+            )
+        conversion_manager.complete_job(
+            job_id=job_id,
+            success=overall_success,
+            error="; ".join(failure_messages) if failure_messages else "",
+        )
+
+    except Exception as exc:
+        logger.exception(f"Conversion job {job_id} failed with unexpected error")
+        conversion_manager.complete_job(job_id=job_id, success=False, error=str(exc))
+    finally:
+        db.close()

--- a/tests/api/test_file_conversion.py
+++ b/tests/api/test_file_conversion.py
@@ -309,7 +309,7 @@ class TestConvertedEndpoint:
                             "main", "pdf", "md5_pdf_wait", pdf_type="pdf")
         ref_curie = test_reference.new_ref_curie
 
-        def fake_sync_job(job_id, reference_id, reference_curie):
+        def fake_sync_job(job_id, reference_id, reference_curie, overwrite_tei_md=False):
             create_metadata(
                 db,
                 ReferencefileSchemaPost(

--- a/tests/api/test_file_conversion.py
+++ b/tests/api/test_file_conversion.py
@@ -1,0 +1,472 @@
+"""
+Tests for the on-demand conversion API (SCRUM-5795).
+
+Covers:
+- Unit tests for ConversionJobManager (no DB).
+- Integration tests for GET /reference/referencefile/conversion_request/{curie_or_reference_id}
+  and GET /reference/referencefile/conversion_status/{job_id}.
+
+The new endpoint reports only conversion status — callers use the existing
+/reference/referencefile/show_all/{curie_or_reference_id} endpoint to fetch
+the resulting file listing.
+
+Conversion primitives (process_nxml_to_markdown / process_pdf_for_reference) are
+mocked — the real ones would call PDFX and S3.
+"""
+import pytest
+from unittest.mock import patch
+
+from fastapi import status
+from starlette.testclient import TestClient
+
+from agr_literature_service.api.main import app
+from agr_literature_service.api.schemas import ReferencefileSchemaPost
+from agr_literature_service.api.crud.referencefile_crud import create_metadata
+from agr_literature_service.api.utils.conversion_job_manager import (
+    ConversionJob,
+    ConversionJobManager,
+    conversion_manager,
+)
+
+from .test_reference import test_reference  # noqa: F401
+from ..fixtures import db  # noqa: F401
+from .fixtures import auth_headers  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for ConversionJobManager (no DB, no HTTP)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def clear_global_manager():
+    """Reset the module-level singleton between tests."""
+    conversion_manager._jobs.clear()
+    conversion_manager._active_by_reference.clear()
+    yield
+    conversion_manager._jobs.clear()
+    conversion_manager._active_by_reference.clear()
+
+
+@pytest.fixture
+def manager():
+    return ConversionJobManager()
+
+
+class TestConversionJob:
+    def test_to_dict_serializes_timestamps(self):
+        job = ConversionJob(
+            job_id="j1",
+            reference_id=42,
+            reference_curie="AGRKB:1",
+            user_id="u1",
+            status="running",
+        )
+        d = job.to_dict()
+        assert d["job_id"] == "j1"
+        assert d["reference_id"] == 42
+        assert d["status"] == "running"
+        assert isinstance(d["started_at"], str)
+        assert d["completed_at"] is None
+        assert d["per_file_progress"] == []
+
+    def test_duration_seconds_before_completion(self):
+        job = ConversionJob(
+            job_id="j2",
+            reference_id=1,
+            reference_curie="AGRKB:2",
+            user_id="u",
+            status="running",
+        )
+        assert job.duration_seconds >= 0.0
+
+
+class TestConversionJobManager:
+    def test_create_new_job(self, manager):
+        job = manager.create_or_get_job(reference_id=10, reference_curie="AGRKB:X",
+                                        user_id="u1")
+        assert job.status == "running"
+        assert manager.get_job(job.job_id) is job
+        assert manager.get_active_job_for_reference(10).job_id == job.job_id
+
+    def test_create_or_get_returns_existing_running(self, manager):
+        first = manager.create_or_get_job(reference_id=11, reference_curie="AGRKB:Y",
+                                          user_id="u")
+        second = manager.create_or_get_job(reference_id=11, reference_curie="AGRKB:Y",
+                                           user_id="u")
+        assert first.job_id == second.job_id
+
+    def test_new_job_after_completion(self, manager):
+        first = manager.create_or_get_job(reference_id=12, reference_curie="AGRKB:Z",
+                                          user_id="u")
+        manager.complete_job(first.job_id, success=True)
+        assert manager.get_active_job_for_reference(12) is None
+        second = manager.create_or_get_job(reference_id=12, reference_curie="AGRKB:Z",
+                                           user_id="u")
+        assert second.job_id != first.job_id
+        assert second.status == "running"
+
+    def test_record_progress_and_complete(self, manager):
+        job = manager.create_or_get_job(reference_id=13, reference_curie="AGRKB:Q",
+                                        user_id="u")
+        manager.record_file_progress(
+            job.job_id,
+            source_display_name="file.pdf",
+            source_file_class="main",
+            converted_display_name="file.pdf_merged",
+            converted_file_class="converted_merged_main",
+            success=True,
+        )
+        manager.complete_job(job.job_id, success=True)
+        final = manager.get_job(job.job_id)
+        assert final.status == "completed"
+        assert final.completed_at is not None
+        assert len(final.per_file_progress) == 1
+        entry = final.per_file_progress[0]
+        assert entry.source_display_name == "file.pdf"
+        assert entry.source_file_class == "main"
+        assert entry.converted_file_class == "converted_merged_main"
+        assert entry.status == "success"
+
+    def test_complete_job_with_failure(self, manager):
+        job = manager.create_or_get_job(reference_id=14, reference_curie="AGRKB:R",
+                                        user_id="u")
+        manager.complete_job(job.job_id, success=False, error="boom")
+        final = manager.get_job(job.job_id)
+        assert final.status == "failed"
+        assert final.error_message == "boom"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for the /converted and /conversion_status endpoints
+# ---------------------------------------------------------------------------
+
+def _make_referencefile(db, reference_curie, display_name, file_class,  # noqa: F811
+                        file_extension, md5sum, pdf_type=None):
+    payload = {
+        "display_name": display_name,
+        "reference_curie": reference_curie,
+        "file_class": file_class,
+        "file_publication_status": "final",
+        "file_extension": file_extension,
+        "pdf_type": pdf_type,
+        "md5sum": md5sum,
+    }
+    return create_metadata(db, ReferencefileSchemaPost(**payload))
+
+
+class TestConvertedEndpoint:
+
+    def test_no_sources_returns_no_sources_status(self, db, test_reference, auth_headers):  # noqa: F811
+        """A reference with no files and no sources reports no_sources."""
+        with TestClient(app) as client:
+            response = client.get(
+                url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                headers=auth_headers,
+            )
+            assert response.status_code == status.HTTP_200_OK
+            body = response.json()
+            assert body["reference_curie"] == test_reference.new_ref_curie
+            assert body["status"] == "no_sources"
+            assert body["job_id"] is None
+            assert "files" not in body
+
+    def test_cached_main_and_supplement(self, db, test_reference, auth_headers):  # noqa: F811
+        """With converted_merged_main + converted_merged_supplement present → cached."""
+        _make_referencefile(db, test_reference.new_ref_curie, "pdf_main",
+                            "main", "pdf", "md5_main_pdf", pdf_type="pdf")
+        _make_referencefile(db, test_reference.new_ref_curie, "pdf_main_merged",
+                            "converted_merged_main", "md", "md5_main_md")
+        _make_referencefile(db, test_reference.new_ref_curie, "pdf_supp",
+                            "supplement", "pdf", "md5_supp_pdf")
+        _make_referencefile(db, test_reference.new_ref_curie, "pdf_supp_merged",
+                            "converted_merged_supplement", "md", "md5_supp_md")
+
+        with TestClient(app) as client:
+            response = client.get(
+                url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                headers=auth_headers,
+            )
+            assert response.status_code == status.HTTP_200_OK
+            body = response.json()
+            assert body["status"] == "converted"
+            assert sorted(body["converted_classes"]) == [
+                "converted_merged_main", "converted_merged_supplement"
+            ]
+
+    def test_nxml_sync_path_completes(self, db, test_reference, auth_headers):  # noqa: F811
+        """nXML source but no converted row → sync conversion, 200 with status=completed."""
+        _make_referencefile(db, test_reference.new_ref_curie, "nxml_source",
+                            "nXML", "xml", "md5_nxml")
+
+        def fake_process_nxml(*, db, nxml_ref_file, reference_curie, mod_abbreviation,
+                              s3_client=None):
+            create_metadata(
+                db,
+                ReferencefileSchemaPost(
+                    reference_curie=reference_curie,
+                    display_name=f"{nxml_ref_file.display_name}_nxml",
+                    file_class="converted_merged_main",
+                    file_publication_status="final",
+                    file_extension="md",
+                    md5sum="md5_generated_nxml",
+                ),
+            )
+            return True, None
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud.process_nxml_to_markdown",
+            side_effect=fake_process_nxml,
+        ):
+            with TestClient(app) as client:
+                response = client.get(
+                    url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                    headers=auth_headers,
+                )
+                assert response.status_code == status.HTTP_200_OK
+                body = response.json()
+                assert body["status"] == "converted"
+
+    def test_pdf_async_default_returns_202(self, db, test_reference, auth_headers):  # noqa: F811
+        """Main PDF with no nXML → 202 with job_id, background task scheduled, and
+        a pending per_file_progress entry seeded for the main PDF."""
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_pdf_main", pdf_type="pdf")
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud.run_conversion_job",
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                response = client.get(
+                    url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                    headers=auth_headers,
+                )
+                assert response.status_code == status.HTTP_202_ACCEPTED
+                body = response.json()
+                assert body["status"] == "running"
+                assert body["job_id"] is not None
+                # The main PDF should appear as a pending entry.
+                assert len(body["per_file_progress"]) == 1
+                entry = body["per_file_progress"][0]
+                assert entry["source"]["display_name"] == "paper"
+                assert entry["source"]["file_class"] == "main"
+                assert entry["source"]["referencefile_id"] is not None
+                assert entry["status"] == "pending"
+                assert entry["converted"]["display_name"] == "paper_merged"
+                assert entry["converted"]["file_class"] == "converted_merged_main"
+                # Converted row doesn't exist yet — id is None until processing finishes.
+                assert entry["converted"]["referencefile_id"] is None
+
+    def test_pdf_idempotency_same_job_id(self, db, test_reference, auth_headers):  # noqa: F811
+        """Two consecutive calls while a job is running share the same job_id."""
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_pdf_idem", pdf_type="pdf")
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud.run_conversion_job",
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                r1 = client.get(
+                    url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                    headers=auth_headers,
+                )
+                r2 = client.get(
+                    url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                    headers=auth_headers,
+                )
+                assert r1.status_code == status.HTTP_202_ACCEPTED
+                assert r2.status_code == status.HTTP_202_ACCEPTED
+                assert r1.json()["job_id"] == r2.json()["job_id"]
+
+    def test_converted_classes_reflects_partial_state(self, db, test_reference, auth_headers):  # noqa: F811
+        """converted_classes lists already-cached rows even while a job is still running."""
+        # Already-cached main from a prior run:
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_main_merged",
+                            "converted_merged_main", "md", "md5_partial_main_md")
+        # A supplement PDF that still needs converting:
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_supp",
+                            "supplement", "pdf", "md5_partial_supp_pdf")
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud.run_conversion_job",
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                response = client.get(
+                    url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                    headers=auth_headers,
+                )
+                assert response.status_code == status.HTTP_202_ACCEPTED
+                body = response.json()
+                assert body["status"] == "running"
+                # Main was already cached, supp conversion in progress:
+                assert body["converted_classes"] == ["converted_merged_main"]
+
+    def test_pdf_wait_true_blocks(self, db, test_reference, auth_headers):  # noqa: F811
+        """wait=true should block and return 200 when the mocked job creates the row."""
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_pdf_wait", pdf_type="pdf")
+        ref_curie = test_reference.new_ref_curie
+
+        def fake_sync_job(job_id, reference_id, reference_curie):
+            create_metadata(
+                db,
+                ReferencefileSchemaPost(
+                    reference_curie=reference_curie,
+                    display_name="paper_merged",
+                    file_class="converted_merged_main",
+                    file_publication_status="final",
+                    file_extension="md",
+                    md5sum="md5_wait_generated",
+                ),
+            )
+            conversion_manager.complete_job(job_id, success=True)
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud.run_conversion_job",
+            side_effect=fake_sync_job,
+        ):
+            with TestClient(app) as client:
+                response = client.get(
+                    url=f"/reference/referencefile/conversion_request/{ref_curie}?wait=true",
+                    headers=auth_headers,
+                )
+                assert response.status_code == status.HTTP_200_OK
+                body = response.json()
+                assert body["status"] == "converted"
+
+    def test_reference_not_found(self, db, auth_headers):  # noqa: F811
+        """Unknown curie → 404."""
+        with TestClient(app) as client:
+            response = client.get(
+                url="/reference/referencefile/conversion_request/AGRKB:999999999999999",
+                headers=auth_headers,
+            )
+            assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_per_file_progress_surfaces_in_response(self, db, test_reference, auth_headers):  # noqa: F811
+        """After a job records per-file progress, subsequent polls of the same
+        endpoint surface it in `per_file_progress`."""
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_pdf_progress", pdf_type="pdf")
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud.run_conversion_job",
+            return_value=None,
+        ):
+            with TestClient(app) as client:
+                r1 = client.get(
+                    url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                    headers=auth_headers,
+                )
+                assert r1.status_code == status.HTTP_202_ACCEPTED
+                job_id = r1.json()["job_id"]
+
+                conversion_manager.record_file_progress(
+                    job_id,
+                    source_display_name="paper",
+                    source_file_class="main",
+                    success=False,
+                    error="pdfx 500",
+                )
+
+                r2 = client.get(
+                    url=f"/reference/referencefile/conversion_request/{test_reference.new_ref_curie}",
+                    headers=auth_headers,
+                )
+                body = r2.json()
+                assert body["job_id"] == job_id
+                assert len(body["per_file_progress"]) == 1
+                entry = body["per_file_progress"][0]
+                assert entry["source"]["display_name"] == "paper"
+                assert entry["source"]["file_class"] == "main"
+                assert entry["source"]["referencefile_id"] is not None
+                assert entry["converted"] is None
+                assert entry["status"] == "failed"
+                assert entry["error"] == "pdfx 500"
+
+
+# ---------------------------------------------------------------------------
+# Unit test for _assess_reference (uses DB but not the HTTP layer)
+# ---------------------------------------------------------------------------
+
+class TestAssessReference:
+
+    def test_detects_cached_and_missing(self, db, test_reference, auth_headers):  # noqa: F811
+        from agr_literature_service.api.crud.file_conversion_crud import _assess_reference
+        from agr_literature_service.api.crud.reference_utils import get_reference
+
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_assess_main", pdf_type="pdf")
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_merged",
+                            "converted_merged_main", "md", "md5_assess_md")
+
+        reference = get_reference(db=db,
+                                  curie_or_reference_id=test_reference.new_ref_curie,
+                                  load_referencefiles=True)
+        assessment = _assess_reference(db, reference)
+
+        assert assessment["main_cached"] is True
+        assert assessment["main_missing"] is False
+        assert assessment["supp_cached"] is False
+        assert assessment["supp_missing"] is False
+        assert assessment["needs_async"] is False
+
+    def test_detects_main_needs_pdf_conversion(self, db, test_reference, auth_headers):  # noqa: F811
+        from agr_literature_service.api.crud.file_conversion_crud import _assess_reference
+        from agr_literature_service.api.crud.reference_utils import get_reference
+
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_assess_pdf", pdf_type="pdf")
+
+        reference = get_reference(db=db,
+                                  curie_or_reference_id=test_reference.new_ref_curie,
+                                  load_referencefiles=True)
+        assessment = _assess_reference(db, reference)
+
+        assert assessment["main_cached"] is False
+        assert assessment["main_pdf_available"] is True
+        assert assessment["main_missing"] is True
+        assert assessment["nxml_source"] is None
+        assert assessment["needs_async"] is True
+
+    def test_detects_main_needs_nxml_conversion(self, db, test_reference, auth_headers):  # noqa: F811
+        from agr_literature_service.api.crud.file_conversion_crud import _assess_reference
+        from agr_literature_service.api.crud.reference_utils import get_reference
+
+        _make_referencefile(db, test_reference.new_ref_curie, "nxml_only",
+                            "nXML", "xml", "md5_assess_nxml")
+
+        reference = get_reference(db=db,
+                                  curie_or_reference_id=test_reference.new_ref_curie,
+                                  load_referencefiles=True)
+        assessment = _assess_reference(db, reference)
+
+        assert assessment["main_cached"] is False
+        assert assessment["main_missing"] is True
+        assert assessment["nxml_source"] is not None
+        assert assessment["needs_async"] is False
+
+    def test_overwrite_tei_md_ignores_tei_derived_rows(self, db, test_reference, auth_headers):  # noqa: F811
+        """A _tei-suffixed converted_merged_main counts as cached by default,
+        but with overwrite_tei_md=True it's ignored so the endpoint re-runs."""
+        from agr_literature_service.api.crud.file_conversion_crud import _assess_reference
+        from agr_literature_service.api.crud.reference_utils import get_reference
+
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_tei_main_pdf", pdf_type="pdf")
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_tei",
+                            "converted_merged_main", "md", "md5_tei_main_md")
+
+        reference = get_reference(db=db,
+                                  curie_or_reference_id=test_reference.new_ref_curie,
+                                  load_referencefiles=True)
+
+        default_assessment = _assess_reference(db, reference)
+        assert default_assessment["main_cached"] is True
+        assert default_assessment["main_missing"] is False
+
+        overwrite_assessment = _assess_reference(db, reference, overwrite_tei_md=True)
+        assert overwrite_assessment["main_cached"] is False
+        assert overwrite_assessment["main_missing"] is True


### PR DESCRIPTION
## Summary
- Adds `GET /reference/referencefile/conversion_request/{curie_or_reference_id}` — one endpoint to request conversion + poll progress. nXML runs synchronously (200); PDF conversions go through PDFX in a BackgroundTask and return 202 with a `job_id` (or `?wait=true` to block). Idempotent by `reference_id`.
- Response exposes `status` (`converted` / `running` / `failed` / `no_sources`), `converted_classes` (file_class values currently present in DB), and `per_file_progress` — each entry carries source + converted info including `referencefile_id`, so callers can download directly via the existing `/download_file/{id}` without a separate `/show_all` round-trip. Per-file state is seeded at job creation and updated in place (`pending` → `success`/`failed`). DB-derived entries are merged in so already-converted rows surface even when no job ran in this process.
- Adds `overwrite_tei_md=true` flag to ignore legacy TEI-derived Markdown (display_name ending in `_tei`) as cache and delete it after a higher-quality conversion succeeds. Uses existing `referencefile_utils.remove_from_s3_and_db` for DB + S3 cleanup.
- **Transient**: `file_upload()` now bypasses `is_file_upload_blocked` for `converted_*` file classes so automated pipelines don't collide with entity/classification-in-progress guardrails during the TEI→Markdown migration. Tracked in [SCRUM-5867](https://agr-jira.atlassian.net/browse/SCRUM-5867) for removal when pdf2tei is decommissioned.

All conversion work delegates to existing `pdf2md_utils` primitives — no conversion logic is re-implemented. Async job tracking follows the `BulkUploadManager` pattern (in-memory, per-process, 24h cleanup).

## Out of scope (tracked elsewhere)
- Workflow-status transition for `ATP:0000163` ("file converted to text") — still lives in `pdf2tei.py`. Documented as a prerequisite on [SCRUM-5867](https://agr-jira.atlassian.net/browse/SCRUM-5867) before pdf2tei can be retired.
- UI handling of the new endpoint — the UI (SCRUM-5871, already deployed) already recognises `_nxml`/`_tei` suffixes on converted files and renders them correctly via `show_all`.

## Test plan
- [ ] `make run-local-flake8 && make run-local-mypy` — clean locally.
- [ ] `make run-test-bash` — full test suite (requires Cognito creds + DB in the test container).
- [ ] Unit tests in `tests/api/test_file_conversion.py` (14 total; 7 `ConversionJobManager` unit tests pass locally without DB).
- [ ] Manual smoke test on dev with the reference shapes exercised during implementation:
  - nXML, no supplements (sync path, 200)
  - nXML + supplements (sync main, async supp)
  - PDF only, no supplements (async main)
  - PDF + supplements (async main + supp)
  - Already-converted reference (no job; response still lists converted rows with `referencefile_id`s)
  - `overwrite_tei_md=true` on a reference whose only converted row is TEI-derived

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-5867]: https://agr-jira.atlassian.net/browse/SCRUM-5867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ