### PR TITLE
create SGD curies when adding papers to SGD corpus via GAF/Interaction

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/utils/alliance_paper_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/alliance_paper_utils.py
@@ -15,7 +15,9 @@ from typing import Dict, List, Set, Tuple
 
 from sqlalchemy import text
 
-from agr_literature_service.api.models import ModCorpusAssociationModel, ModModel
+from agr_literature_service.api.models import (
+    ModCorpusAssociationModel, ModModel, CrossReferenceModel
+)
 from agr_literature_service.api.schemas import ModCorpusSortSourceType
 
 logger = logging.getLogger(__name__)
@@ -104,6 +106,92 @@ def associate_papers_with_alliance(db_session, all_pmids: Set[str],
     if count > 0:
         db_session.commit()
         logger.info(f"Associated {count} paper(s) with {mod_abbr} MOD")
+
+    return count
+
+
+def create_sgd_curie_for_reference(db_session, reference_id: int) -> bool:  # pragma: no cover
+    """
+    Create an SGD curie (e.g., SGD:S100002728) for a reference if it doesn't
+    already have one.
+
+    Args:
+        db_session: Database session
+        reference_id: The reference ID to create the curie for
+
+    Returns:
+        True if a new curie was created, False if one already exists
+    """
+    # Check if reference already has an SGD cross reference
+    existing_sgd_xref = db_session.query(CrossReferenceModel).filter(
+        CrossReferenceModel.reference_id == reference_id,
+        CrossReferenceModel.curie_prefix == 'SGD',
+        CrossReferenceModel.is_obsolete.is_(False)
+    ).first()
+
+    if existing_sgd_xref:
+        return False
+
+    # Get next SGD ID from sequence
+    row = db_session.execute(text("SELECT nextval('sgd_id_seq')")).fetchone()
+    if not row:
+        logger.error(f"Failed to get next SGD ID for reference_id={reference_id}")
+        return False
+
+    sgdid_number = row[0]
+    new_sgdid = f"SGD:S{sgdid_number}"
+
+    # Create new cross reference
+    new_xref = CrossReferenceModel(
+        curie=new_sgdid,
+        curie_prefix='SGD',
+        reference_id=reference_id,
+        pages=['reference'],
+        is_obsolete=False
+    )
+    db_session.add(new_xref)
+    logger.info(f"Created SGD curie {new_sgdid} for reference_id={reference_id}")
+    return True
+
+
+def create_sgd_curies_for_references(db_session, reference_ids: Set[int]) -> int:  # pragma: no cover
+    """
+    Create SGD curies for multiple references that don't already have one.
+
+    Args:
+        db_session: Database session
+        reference_ids: Set of reference IDs to create curies for
+
+    Returns:
+        Number of curies created
+    """
+    if not reference_ids:
+        return 0
+
+    ref_ids_list = list(reference_ids)
+
+    # Get reference_ids that already have SGD cross references
+    existing_sgd_refs_query = text(
+        "SELECT DISTINCT reference_id FROM cross_reference "
+        "WHERE reference_id = ANY(:ref_ids) "
+        "AND curie_prefix = 'SGD' "
+        "AND is_obsolete = False"
+    )
+    existing_sgd_refs = db_session.execute(
+        existing_sgd_refs_query,
+        {"ref_ids": ref_ids_list}
+    ).fetchall()
+
+    refs_with_sgd = {row[0] for row in existing_sgd_refs}
+    refs_needing_sgd = reference_ids - refs_with_sgd
+
+    if not refs_needing_sgd:
+        return 0
+
+    count = 0
+    for ref_id in refs_needing_sgd:
+        if create_sgd_curie_for_reference(db_session, ref_id):
+            count += 1
 
     return count
 
@@ -238,6 +326,12 @@ def update_sgd_corpus_flag_to_true(db_session,  # pragma: no cover
     if count > 0:
         db_session.commit()
 
+        # Create SGD curies for updated papers that don't have one
+        sgd_curies_created = create_sgd_curies_for_references(db_session, updated_ref_ids)
+        if sgd_curies_created > 0:
+            db_session.commit()
+            logger.info(f"Created {sgd_curies_created} SGD curie(s) for updated papers")
+
     return count, updated_pmids
 
 
@@ -307,6 +401,7 @@ def associate_sgd_papers_with_corpus(db_session, pmids: Set[str],  # pragma: no 
     # Add mod_corpus_association for papers not yet associated with SGD
     count = 0
     pmids_added: Set[str] = set()
+    refs_added: Set[int] = set()
     for ref_id in reference_ids_in_db:
         if ref_id not in already_associated:
             mca = ModCorpusAssociationModel(
@@ -317,12 +412,19 @@ def associate_sgd_papers_with_corpus(db_session, pmids: Set[str],  # pragma: no 
             )
             db_session.add(mca)
             count += 1
+            refs_added.add(ref_id)
             if ref_id in ref_id_to_pmid:
                 pmids_added.add(ref_id_to_pmid[ref_id])
 
     if count > 0:
         db_session.commit()
         logger.info(f"Associated {count} SGD paper(s) with SGD corpus")
+
+        # Create SGD curies for newly added papers
+        sgd_curies_created = create_sgd_curies_for_references(db_session, refs_added)
+        if sgd_curies_created > 0:
+            db_session.commit()
+            logger.info(f"Created {sgd_curies_created} SGD curie(s) for newly associated papers")
 
     return count, pmids_added
 

--- a/agr_literature_service/lit_processing/oneoff_scripts/backfill_sgd_curies_for_gaf_interaction.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/backfill_sgd_curies_for_gaf_interaction.py
@@ -1,0 +1,167 @@
+"""
+backfill_sgd_curies_for_gaf_interaction.py
+==========================================
+
+This oneoff script back-populates SGD mod curies (e.g., SGD:S100002728) for
+papers in the SGD corpus that were added via GAF or Interaction loading
+but are missing SGD curies.
+
+Target papers:
+- mod_id = SGD (4)
+- corpus = True
+- mod_corpus_sort_source IN ('Gaf', 'Interaction')
+- No existing SGD cross reference (curie_prefix = 'SGD', is_obsolete = False)
+
+Usage:
+    python backfill_sgd_curies_for_gaf_interaction.py [--dry-run]
+
+Options:
+    --dry-run    Report what would be done without making changes
+"""
+import argparse
+import logging.config
+from os import path
+
+from sqlalchemy import text
+
+from agr_literature_service.lit_processing.utils.sqlalchemy_utils import create_postgres_session
+from agr_literature_service.api.models import CrossReferenceModel, ModModel
+from agr_literature_service.api.user import set_global_user_id
+
+log_file_path = path.join(path.dirname(path.abspath(__file__)), '../../../logging.conf')
+logging.config.fileConfig(log_file_path)
+logger = logging.getLogger('literature logger')
+
+
+def get_sgd_mod_id(db_session):
+    """Get the mod_id for SGD."""
+    sgd_mod = db_session.query(ModModel).filter(
+        ModModel.abbreviation == 'SGD'
+    ).first()
+    if not sgd_mod:
+        logger.error("SGD MOD not found in database")
+        return None
+    return sgd_mod.mod_id
+
+
+def get_references_missing_sgd_curie(db_session, sgd_mod_id):
+    """
+    Get reference_ids in SGD corpus (Gaf or Interaction source) that are
+    missing SGD curies.
+
+    Returns:
+        List of tuples: (reference_id, reference_curie, mod_corpus_sort_source)
+    """
+    query = text("""
+        SELECT mca.reference_id, r.curie, mca.mod_corpus_sort_source
+        FROM mod_corpus_association mca
+        JOIN reference r ON r.reference_id = mca.reference_id
+        WHERE mca.mod_id = :sgd_mod_id
+          AND mca.corpus = True
+          AND mca.mod_corpus_sort_source IN ('Gaf', 'Interaction')
+          AND NOT EXISTS (
+              SELECT 1 FROM cross_reference cr
+              WHERE cr.reference_id = mca.reference_id
+                AND cr.curie_prefix = 'SGD'
+                AND cr.is_obsolete = False
+          )
+        ORDER BY mca.reference_id
+    """)
+
+    rows = db_session.execute(query, {"sgd_mod_id": sgd_mod_id}).fetchall()
+    return [(row[0], row[1], row[2]) for row in rows]
+
+
+def create_sgd_curie(db_session, reference_id):
+    """Create an SGD curie for the given reference_id."""
+    # Get next SGD ID from sequence
+    row = db_session.execute(text("SELECT nextval('sgd_id_seq')")).fetchone()
+    if not row:
+        logger.error(f"Failed to get next SGD ID for reference_id={reference_id}")
+        return None
+
+    sgdid_number = row[0]
+    new_sgdid = f"SGD:S{sgdid_number}"
+
+    # Create new cross reference
+    new_xref = CrossReferenceModel(
+        curie=new_sgdid,
+        curie_prefix='SGD',
+        reference_id=reference_id,
+        pages=['reference'],
+        is_obsolete=False
+    )
+    db_session.add(new_xref)
+    return new_sgdid
+
+
+def backfill_sgd_curies(dry_run=False):
+    """Main function to back-populate SGD curies."""
+    db_session = create_postgres_session(False)
+
+    # Set script user for audit tracking
+    script_name = path.basename(__file__).replace(".py", "")
+    set_global_user_id(db_session, script_name)
+
+    # Get SGD mod_id
+    sgd_mod_id = get_sgd_mod_id(db_session)
+    if sgd_mod_id is None:
+        db_session.close()
+        return
+
+    logger.info(f"SGD mod_id: {sgd_mod_id}")
+
+    # Get references missing SGD curies
+    refs_missing_curies = get_references_missing_sgd_curie(db_session, sgd_mod_id)
+    logger.info(f"Found {len(refs_missing_curies)} reference(s) missing SGD curies")
+
+    if not refs_missing_curies:
+        logger.info("No references need SGD curie backfill")
+        db_session.close()
+        return
+
+    # Group by source for reporting
+    gaf_count = sum(1 for r in refs_missing_curies if r[2] == 'Gaf')
+    interaction_count = sum(1 for r in refs_missing_curies if r[2] == 'Interaction')
+    logger.info(f"  - Gaf source: {gaf_count}")
+    logger.info(f"  - Interaction source: {interaction_count}")
+
+    if dry_run:
+        logger.info("DRY RUN - No changes will be made")
+        logger.info("References that would be updated:")
+        for ref_id, ref_curie, source in refs_missing_curies:
+            logger.info(f"  reference_id={ref_id}, curie={ref_curie}, source={source}")
+        db_session.close()
+        return
+
+    # Create SGD curies
+    created_count = 0
+    for ref_id, ref_curie, source in refs_missing_curies:
+        new_curie = create_sgd_curie(db_session, ref_id)
+        if new_curie:
+            logger.info(f"Created {new_curie} for reference_id={ref_id} ({ref_curie}), source={source}")
+            created_count += 1
+        else:
+            logger.error(f"Failed to create SGD curie for reference_id={ref_id}")
+
+    if created_count > 0:
+        db_session.commit()
+        logger.info(f"Successfully created {created_count} SGD curie(s)")
+    else:
+        logger.info("No SGD curies were created")
+
+    db_session.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Back-populate SGD curies for GAF and Interaction papers"
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help="Report what would be done without making changes"
+    )
+    args = parser.parse_args()
+
+    backfill_sgd_curies(dry_run=args.dry_run)


### PR DESCRIPTION
The load_interaction_papers.py and load_mod_gaf_papers.py scripts were adding papers to SGD corpus but not creating SGD mod curies (e.g., SGD:S100002728) in the cross_reference table.

Changes:
- Add create_sgd_curie_for_reference() and create_sgd_curies_for_references() helper functions to alliance_paper_utils.py
- Modify associate_sgd_papers_with_corpus() to create SGD curies for newly associated papers
- Modify update_sgd_corpus_flag_to_true() to create SGD curies for papers updated to be in corpus
- Add oneoff script backfill_sgd_curies_for_gaf_interaction.py to back-populate missing SGD curies for existing GAF/Interaction papers