### PR TITLE
feat(person): aggregate name search and add cross-reference lookup

### DIFF
--- a/agr_literature_service/api/crud/person_cross_reference_crud.py
+++ b/agr_literature_service/api/crud/person_cross_reference_crud.py
@@ -46,6 +46,8 @@ def create_for_person(db: Session, person_id: int, payload: Dict[str, Any]) -> P
     if not curie:
         raise HTTPException(status_code=422, detail="curie is required")
 
+    curie_prefix = _curie_prefix(curie)
+
     # curie is globally unique on person_cross_reference (uq_person_xref_curie).
     dup = (
         db.query(PersonCrossReferenceModel.person_cross_reference_id)
@@ -58,10 +60,28 @@ def create_for_person(db: Session, person_id: int, payload: Dict[str, Any]) -> P
             detail=f"Cross-reference '{curie}' already exists",
         )
 
+    # (person_id, curie_prefix) is unique per-person (uq_person_xref_person_prefix).
+    prefix_dup = (
+        db.query(PersonCrossReferenceModel.person_cross_reference_id)
+        .filter(
+            PersonCrossReferenceModel.person_id == person_id,
+            PersonCrossReferenceModel.curie_prefix == curie_prefix,
+        )
+        .first()
+    )
+    if prefix_dup:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Another cross-reference with prefix '{curie_prefix}' "
+                f"already exists for this person."
+            ),
+        )
+
     obj = PersonCrossReferenceModel(
         person_id=person_id,
         curie=curie,
-        curie_prefix=_curie_prefix(curie),
+        curie_prefix=curie_prefix,
         pages=_clean_pages(data.get("pages")),
         is_obsolete=bool(data.get("is_obsolete", False)),
     )

--- a/agr_literature_service/api/crud/person_cross_reference_crud.py
+++ b/agr_literature_service/api/crud/person_cross_reference_crud.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from agr_literature_service.api.models import PersonModel, PersonCrossReferenceModel
@@ -45,19 +46,16 @@ def create_for_person(db: Session, person_id: int, payload: Dict[str, Any]) -> P
     if not curie:
         raise HTTPException(status_code=422, detail="curie is required")
 
-    # prevent duplicate for the same person
+    # curie is globally unique on person_cross_reference (uq_person_xref_curie).
     dup = (
         db.query(PersonCrossReferenceModel.person_cross_reference_id)
-        .filter(
-            PersonCrossReferenceModel.person_id == person_id,
-            PersonCrossReferenceModel.curie == curie,
-        )
+        .filter(PersonCrossReferenceModel.curie == curie)
         .first()
     )
     if dup:
         raise HTTPException(
             status_code=422,
-            detail=f"Cross-reference '{curie}' already exists for person_id {person_id}",
+            detail=f"Cross-reference '{curie}' already exists",
         )
 
     obj = PersonCrossReferenceModel(
@@ -68,7 +66,14 @@ def create_for_person(db: Session, person_id: int, payload: Dict[str, Any]) -> P
         is_obsolete=bool(data.get("is_obsolete", False)),
     )
     db.add(obj)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Database constraint violation; please verify input and retry.",
+        )
     db.refresh(obj)
     return obj
 
@@ -141,11 +146,12 @@ def patch(db: Session, person_cross_reference_id: int, patch_dict: Dict[str, Any
 
     if "curie" in data and data["curie"] is not None:
         new_curie = data["curie"].strip()
-        # duplicate check for same person
+        new_prefix = _curie_prefix(new_curie)
+
+        # curie is globally unique on person_cross_reference (uq_person_xref_curie).
         dup = (
             db.query(PersonCrossReferenceModel.person_cross_reference_id)
             .filter(
-                PersonCrossReferenceModel.person_id == obj.person_id,
                 PersonCrossReferenceModel.curie == new_curie,
                 PersonCrossReferenceModel.person_cross_reference_id != person_cross_reference_id,
             )
@@ -154,10 +160,33 @@ def patch(db: Session, person_cross_reference_id: int, patch_dict: Dict[str, Any
         if dup:
             raise HTTPException(
                 status_code=422,
-                detail=f"Cross-reference '{new_curie}' already exists for person_id {obj.person_id}",
+                detail=f"Cross-reference '{new_curie}' already exists",
             )
+
+        # (person_id, curie_prefix) is unique per-person (uq_person_xref_person_prefix).
+        # NULL person_ids are exempt — Postgres treats NULLs in unique constraints
+        # as distinct, so the constraint only fires when person_id is non-null.
+        if obj.person_id is not None:
+            prefix_dup = (
+                db.query(PersonCrossReferenceModel.person_cross_reference_id)
+                .filter(
+                    PersonCrossReferenceModel.person_id == obj.person_id,
+                    PersonCrossReferenceModel.curie_prefix == new_prefix,
+                    PersonCrossReferenceModel.person_cross_reference_id != person_cross_reference_id,
+                )
+                .first()
+            )
+            if prefix_dup:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Another cross-reference with prefix '{new_prefix}' "
+                        f"already exists for this person."
+                    ),
+                )
+
         obj.curie = new_curie
-        obj.curie_prefix = _curie_prefix(new_curie)
+        obj.curie_prefix = new_prefix
 
     if "pages" in data:
         obj.pages = _clean_pages(data["pages"])
@@ -165,7 +194,14 @@ def patch(db: Session, person_cross_reference_id: int, patch_dict: Dict[str, Any
     if "is_obsolete" in data:
         obj.is_obsolete = bool(data["is_obsolete"])
 
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Database constraint violation; please verify input and retry.",
+        )
     return {"message": "updated"}
 
 

--- a/agr_literature_service/api/crud/person_cross_reference_crud.py
+++ b/agr_literature_service/api/crud/person_cross_reference_crud.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from agr_literature_service.api.models import PersonModel, PersonCrossReferenceModel
@@ -85,6 +86,27 @@ def list_for_person(db: Session, person_id: int) -> List[PersonCrossReferenceMod
         .order_by(PersonCrossReferenceModel.person_cross_reference_id.asc())
         .all()
     )
+
+
+def get_by_curie_or_id(db: Session, curie_or_id: str) -> PersonCrossReferenceModel:
+    pcr_id = int(curie_or_id) if curie_or_id.isdigit() else None
+    obj = (
+        db.query(PersonCrossReferenceModel)
+        .filter(
+            or_(
+                PersonCrossReferenceModel.curie == curie_or_id,
+                PersonCrossReferenceModel.person_cross_reference_id == pcr_id,
+            )
+        )
+        .order_by(PersonCrossReferenceModel.is_obsolete)
+        .first()
+    )
+    if not obj:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"PersonCrossReference with curie or id {curie_or_id} not found",
+        )
+    return obj
 
 
 def show(db: Session, person_cross_reference_id: int) -> PersonCrossReferenceModel:

--- a/agr_literature_service/api/crud/person_crud.py
+++ b/agr_literature_service/api/crud/person_crud.py
@@ -260,20 +260,31 @@ def get_by_email(db: Session, email: str) -> Optional[PersonModel]:
 
 def find_by_name(db: Session, name: str) -> List[PersonModel]:
     """
-    Case-insensitive partial match on display_name.
+    Case-insensitive partial match on Person.display_name OR on
+    PersonName.first_name / middle_name / last_name. Returns a deduplicated
+    list of PersonModel ordered by display_name.
     """
     if not name:
         return []
     pattern = f"%{name.strip()}%"
     return (
         db.query(PersonModel)
+        .outerjoin(PersonNameModel, PersonNameModel.person_id == PersonModel.person_id)
         .options(
             selectinload(PersonModel.emails),
             selectinload(PersonModel.cross_references),
             selectinload(PersonModel.names),
             selectinload(PersonModel.notes),
         )
-        .filter(PersonModel.display_name.ilike(pattern))
+        .filter(
+            or_(
+                PersonModel.display_name.ilike(pattern),
+                PersonNameModel.first_name.ilike(pattern),
+                PersonNameModel.middle_name.ilike(pattern),
+                PersonNameModel.last_name.ilike(pattern),
+            )
+        )
+        .distinct()
         .order_by(PersonModel.display_name.asc())
         .all()
     )

--- a/agr_literature_service/api/crud/person_crud.py
+++ b/agr_literature_service/api/crud/person_crud.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
 from agr_literature_service.api.models import (
@@ -60,6 +61,56 @@ def create(db: Session, payload: PersonSchemaCreate) -> PersonModel:  # noqa: C9
     xrefs_data = data.pop("cross_references", None)
     names_data = data.pop("names", None)
     notes_data = data.pop("notes", None)
+
+    def curie_prefix_from(curie: str) -> str:
+        curie = curie.strip()
+        if curie.count(":") != 1:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid CURIE '{curie}': expected exactly one colon",
+            )
+        return curie.split(":", 1)[0]
+
+    # Validate cross-references BEFORE calling MATI for a new person curie.
+    # MATI's counter is external and does not roll back with the local
+    # transaction, so a failure after the MATI call permanently wastes an ID.
+    # Defends against both unique constraints on person_cross_reference:
+    # curie is globally unique, and (person_id, curie_prefix) is unique
+    # per-person.
+    if xrefs_data:
+        seen_curies: set = set()
+        seen_prefixes: set = set()
+        for xr in xrefs_data:
+            curie = xr["curie"].strip()
+            curie_prefix = curie_prefix_from(curie)
+
+            if curie in seen_curies:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Cross-reference '{curie}' is duplicated in the request",
+                )
+            seen_curies.add(curie)
+
+            if curie_prefix in seen_prefixes:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"Multiple cross-references with prefix '{curie_prefix}' "
+                        "in the request; at most one per prefix is allowed."
+                    ),
+                )
+            seen_prefixes.add(curie_prefix)
+
+            existing = (
+                db.query(PersonCrossReferenceModel.person_cross_reference_id)
+                .filter(PersonCrossReferenceModel.curie == curie)
+                .first()
+            )
+            if existing:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=f"Cross-reference '{curie}' already exists",
+                )
 
     data["curie"] = get_next_person_curie(db)
 
@@ -126,17 +177,10 @@ def create(db: Session, payload: PersonSchemaCreate) -> PersonModel:  # noqa: C9
                 )
             )
 
-    def curie_prefix_from(curie: str) -> str:
-        curie = curie.strip()
-        if curie.count(":") != 1:
-            raise ValueError(f"Invalid CURIE '{curie}': expected exactly one colon")
-        return curie.split(":", 1)[0]
-
-    # Create child cross-references
+    # Insert cross-references (already validated above, before MATI call).
     if xrefs_data:
         for xr in xrefs_data:
-            curie = xr["curie"]
-            curie = curie.strip()
+            curie = xr["curie"].strip()
             curie_prefix = curie_prefix_from(curie)
             db.add(
                 PersonCrossReferenceModel(
@@ -158,7 +202,17 @@ def create(db: Session, payload: PersonSchemaCreate) -> PersonModel:  # noqa: C9
                 )
             )
 
-    db.commit()
+    # Belt-and-suspenders: a concurrent insert could have inserted a
+    # conflicting xref between our pre-check and this commit. Convert the
+    # resulting IntegrityError into a 422 instead of letting it leak as 500.
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Database constraint violation; please verify input and retry.",
+        )
     db.refresh(obj)
     return obj.curie
 

--- a/agr_literature_service/api/crud/person_setting_crud.py
+++ b/agr_literature_service/api/crud/person_setting_crud.py
@@ -3,11 +3,12 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import and_, func
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy import and_, func, or_
+from sqlalchemy.orm import Session, contains_eager, joinedload
 
 from agr_literature_service.api.models.person_model import PersonModel
 from agr_literature_service.api.models.email_model import EmailModel
+from agr_literature_service.api.models.person_name_model import PersonNameModel
 from agr_literature_service.api.models.person_setting_model import PersonSettingModel
 from agr_literature_service.api.crud.user_utils import map_to_user_id
 
@@ -213,16 +214,35 @@ def get_by_email(db: Session, email: str) -> List[PersonSettingModel]:
 
 def find_by_name(db: Session, name: str) -> List[PersonSettingModel]:
     """
-    Case-insensitive partial match on Person.display_name.
+    Case-insensitive partial match on Person.display_name OR on
+    PersonName.first_name / middle_name / last_name.
+    Returns a deduplicated list of PersonSettingModel.
     """
     if not name:
         return []
     pattern = f"%{name.strip()}%"
+    # contains_eager (not joinedload) so the explicit join's PersonModel
+    # columns are added to the SELECT list — required because Postgres
+    # rejects SELECT DISTINCT when ORDER BY references columns (here
+    # PersonModel.display_name) that are not in the select list.
     return (
         db.query(PersonSettingModel)
         .join(PersonModel, PersonModel.person_id == PersonSettingModel.person_id)
-        .options(joinedload(PersonSettingModel.person))
-        .filter(PersonModel.display_name.ilike(pattern))
-        .order_by(PersonModel.display_name.asc(), PersonSettingModel.component_name.asc(), PersonSettingModel.setting_name.asc())
+        .outerjoin(PersonNameModel, PersonNameModel.person_id == PersonModel.person_id)
+        .options(contains_eager(PersonSettingModel.person))
+        .filter(
+            or_(
+                PersonModel.display_name.ilike(pattern),
+                PersonNameModel.first_name.ilike(pattern),
+                PersonNameModel.middle_name.ilike(pattern),
+                PersonNameModel.last_name.ilike(pattern),
+            )
+        )
+        .distinct()
+        .order_by(
+            PersonModel.display_name.asc(),
+            PersonSettingModel.component_name.asc(),
+            PersonSettingModel.setting_name.asc(),
+        )
         .all()
     )

--- a/agr_literature_service/api/routers/person_router.py
+++ b/agr_literature_service/api/routers/person_router.py
@@ -1,11 +1,11 @@
 from typing import List, Optional, Dict, Any
 
-from fastapi import APIRouter, Depends, Response, Security, status
+from fastapi import APIRouter, Depends, HTTPException, Response, Security, status
 
 from sqlalchemy.orm import Session
 
 from agr_literature_service.api import database
-from agr_literature_service.api.crud import person_crud
+from agr_literature_service.api.crud import person_crud, person_cross_reference_crud
 from agr_literature_service.api.schemas import (
     PersonSchemaCreate,
     PersonSchemaUpdate,
@@ -32,6 +32,87 @@ def create(
     """
     set_global_user_from_cognito(db, user)
     return person_crud.create(db, request)
+
+
+@router.get('/whoami')
+def get_user_info_from_cognito(
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user)
+):
+    """Get information about the currently authenticated user."""
+    if user is None:
+        return {"error": "Not authenticated"}
+    return {
+        "user_id": user.get("sub"),
+        "email": user.get("email"),
+        "name": user.get("name"),
+        "groups": user.get("cognito:groups", [])
+    }
+
+
+# Lookup routes — declared BEFORE /{curie_or_person_id} so the catch-all
+# does not capture single-segment lookup paths like /by_name.
+@router.get(
+    "/by_email/{email}",
+    response_model=Optional[PersonSchemaShow],
+    status_code=status.HTTP_200_OK,
+)
+def get_by_email(
+    email: str,
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+    db: Session = db_session,
+):
+    """
+    Get a single person by email (exact match).
+    Returns 200 with the person if found; 204 (no content) if not found.
+    """
+    person = person_crud.get_by_email(db, email)
+    if not person:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return person
+
+
+@router.get(
+    "/by_person_cross_reference/{curie_or_person_cross_reference_id}",
+    response_model=PersonSchemaShow,
+    status_code=status.HTTP_200_OK,
+)
+def get_by_person_cross_reference(
+    curie_or_person_cross_reference_id: str,
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+    db: Session = db_session,
+):
+    """
+    Get a person by a person_cross_reference curie or its internal id.
+    """
+    pcr = person_cross_reference_crud.get_by_curie_or_id(
+        db, curie_or_person_cross_reference_id
+    )
+    if pcr.person_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"PersonCrossReference {curie_or_person_cross_reference_id} "
+                "is not associated to a person"
+            ),
+        )
+    return person_crud.show(db, str(pcr.person_id))
+
+
+@router.get(
+    "/by_name",
+    response_model=List[PersonSchemaShow],
+    status_code=status.HTTP_200_OK,
+)
+def get_by_name(
+    name: str,
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+    db: Session = db_session,
+):
+    """
+    Find people by name. Returns a (possibly empty) list.
+    Implement the matching strategy (exact/ILIKE) inside person_crud.
+    """
+    return person_crud.find_by_name(db, name)
 
 
 @router.delete("/{curie_or_person_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -64,21 +145,6 @@ def patch(
     return person_crud.patch(db, curie_or_person_id, patch_data)
 
 
-@router.get('/whoami')
-def get_user_info_from_cognito(
-    user: Optional[Dict[str, Any]] = Security(get_authenticated_user)
-):
-    """Get information about the currently authenticated user."""
-    if user is None:
-        return {"error": "Not authenticated"}
-    return {
-        "user_id": user.get("sub"),
-        "email": user.get("email"),
-        "name": user.get("name"),
-        "groups": user.get("cognito:groups", [])
-    }
-
-
 @router.get(
     "/{curie_or_person_id}",
     response_model=PersonSchemaShow,
@@ -93,40 +159,3 @@ def show(
     Get a person by curie or internal ID.
     """
     return person_crud.show(db, curie_or_person_id)
-
-
-@router.get(
-    "/by/email/{email}",
-    response_model=Optional[PersonSchemaShow],
-    status_code=status.HTTP_200_OK,
-)
-def get_by_email(
-    email: str,
-    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
-    db: Session = db_session,
-):
-    """
-    Get a single person by email (exact match).
-    Returns 200 with the person if found; 204 (no content) if not found.
-    """
-    person = person_crud.get_by_email(db, email)
-    if not person:
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
-    return person
-
-
-@router.get(
-    "/by/name",
-    response_model=List[PersonSchemaShow],
-    status_code=status.HTTP_200_OK,
-)
-def get_by_name(
-    name: str,
-    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
-    db: Session = db_session,
-):
-    """
-    Find people by name. Returns a (possibly empty) list.
-    Implement the matching strategy (exact/ILIKE) inside person_crud.
-    """
-    return person_crud.find_by_name(db, name)

--- a/agr_literature_service/api/routers/person_setting_router.py
+++ b/agr_literature_service/api/routers/person_setting_router.py
@@ -33,6 +33,45 @@ def create(
     return person_setting_crud.create(db, request)
 
 
+# Lookup routes — declared BEFORE /{person_setting_id} so the int-typed
+# catch-all does not 422 on single-segment lookup paths like /by_name.
+@router.get(
+    "/by_email/{email}",
+    response_model=List[PersonSettingSchemaShow],
+    status_code=status.HTTP_200_OK,
+)
+def get_by_email(
+    email: str,
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+    db: Session = db_session,
+):
+    """
+    Get person_setting rows by email (exact match).
+    Returns 200 with a list (possibly multiple rows) or 204 if none.
+    """
+    person_setting_list = person_setting_crud.get_by_email(db, email)
+    if not person_setting_list:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return person_setting_list
+
+
+@router.get(
+    "/by_name",
+    response_model=List[PersonSettingSchemaShow],
+    status_code=status.HTTP_200_OK,
+)
+def get_by_name(
+    name: str,
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+    db: Session = db_session,
+):
+    """
+    Find person_setting rows by person display name.
+    Matching strategy (exact/ILIKE) is implemented inside person_setting_crud.
+    """
+    return person_setting_crud.find_by_name(db, name)
+
+
 @router.delete("/{person_setting_id}", status_code=status.HTTP_204_NO_CONTENT)
 def destroy(
     person_setting_id: int,
@@ -80,40 +119,3 @@ def show(
     Get a person_setting row by internal ID.
     """
     return person_setting_crud.show(db, person_setting_id)
-
-
-@router.get(
-    "/by/email/{email}",
-    response_model=List[PersonSettingSchemaShow],
-    status_code=status.HTTP_200_OK,
-)
-def get_by_email(
-    email: str,
-    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
-    db: Session = db_session,
-):
-    """
-    Get person_setting rows by email (exact match).
-    Returns 200 with a list (possibly multiple rows) or 204 if none.
-    """
-    person_setting_list = person_setting_crud.get_by_email(db, email)
-    if not person_setting_list:
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
-    return person_setting_list
-
-
-@router.get(
-    "/by/name",
-    response_model=List[PersonSettingSchemaShow],
-    status_code=status.HTTP_200_OK,
-)
-def get_by_name(
-    name: str,
-    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
-    db: Session = db_session,
-):
-    """
-    Find person_setting rows by person display name.
-    Matching strategy (exact/ILIKE) is implemented inside person_setting_crud.
-    """
-    return person_setting_crud.find_by_name(db, name)

--- a/tests/api/test_person_fields.py
+++ b/tests/api/test_person_fields.py
@@ -525,3 +525,181 @@ class TestPersonCurie:
             assert listed.status_code == status.HTTP_200_OK
             xref_curies = {x["curie"] for x in listed.json()}
             assert "ORCID:0000-0009-8888-7777" in xref_curies
+
+
+class TestPersonLookups:
+
+    # ---- /person/by_email/{email} ----
+
+    def test_by_email_found(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            curie = client.post(
+                "/person/",
+                json={"display_name": "Email Lookup Person"},
+                headers=auth_headers,
+            ).json()
+            person_id = client.get(f"/person/{curie}", headers=auth_headers).json()["person_id"]
+            email_post = client.post(
+                f"/email/person/{person_id}",
+                json={"email_address": "lookup@example.com"},
+                headers=auth_headers,
+            )
+            assert email_post.status_code == status.HTTP_201_CREATED
+            res = client.get("/person/by_email/lookup@example.com", headers=auth_headers)
+            assert res.status_code == status.HTTP_200_OK
+            assert res.json()["person_id"] == person_id
+
+    def test_by_email_not_found_returns_204(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            res = client.get("/person/by_email/nobody@example.com", headers=auth_headers)
+            assert res.status_code == status.HTTP_204_NO_CONTENT
+
+    def test_old_by_slash_email_path_is_gone(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            res = client.get("/person/by/email/anything@example.com", headers=auth_headers)
+            assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    # ---- /person/by_name (aggregates display_name + person_name) ----
+
+    def test_by_name_matches_display_name(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            client.post(
+                "/person/",
+                json={"display_name": "Zelda Display Match"},
+                headers=auth_headers,
+            )
+            res = client.get("/person/by_name", params={"name": "Zelda"}, headers=auth_headers)
+            assert res.status_code == status.HTTP_200_OK
+            assert any("Zelda" in p["display_name"] for p in res.json())
+
+    def test_by_name_matches_person_name_first_name(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            curie = client.post(
+                "/person/",
+                json={"display_name": "Totally Unrelated"},
+                headers=auth_headers,
+            ).json()
+            person_id = client.get(f"/person/{curie}", headers=auth_headers).json()["person_id"]
+            client.post(
+                f"/person_name/person/{person_id}",
+                json={"first_name": "Borogove", "last_name": "Smith"},
+                headers=auth_headers,
+            )
+            res = client.get("/person/by_name", params={"name": "Borogove"}, headers=auth_headers)
+            assert res.status_code == status.HTTP_200_OK
+            assert any(p["person_id"] == person_id for p in res.json())
+
+    def test_by_name_matches_person_name_last_name(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            curie = client.post(
+                "/person/",
+                json={"display_name": "Totally Different Display"},
+                headers=auth_headers,
+            ).json()
+            person_id = client.get(f"/person/{curie}", headers=auth_headers).json()["person_id"]
+            client.post(
+                f"/person_name/person/{person_id}",
+                json={"first_name": "X", "last_name": "Slithytove"},
+                headers=auth_headers,
+            )
+            res = client.get("/person/by_name", params={"name": "Slithytove"}, headers=auth_headers)
+            assert any(p["person_id"] == person_id for p in res.json())
+
+    def test_by_name_matches_person_name_middle_name(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            curie = client.post(
+                "/person/",
+                json={"display_name": "No Match Here"},
+                headers=auth_headers,
+            ).json()
+            person_id = client.get(f"/person/{curie}", headers=auth_headers).json()["person_id"]
+            client.post(
+                f"/person_name/person/{person_id}",
+                json={"first_name": "F", "middle_name": "Mimsy", "last_name": "L"},
+                headers=auth_headers,
+            )
+            res = client.get("/person/by_name", params={"name": "Mimsy"}, headers=auth_headers)
+            assert any(p["person_id"] == person_id for p in res.json())
+
+    def test_by_name_dedupes_when_multiple_person_names_match(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            curie = client.post(
+                "/person/",
+                json={"display_name": "Dedupe Person"},
+                headers=auth_headers,
+            ).json()
+            person_id = client.get(f"/person/{curie}", headers=auth_headers).json()["person_id"]
+            for last in ["Jabberwocky", "Jabberwocky-Hyphenated"]:
+                client.post(
+                    f"/person_name/person/{person_id}",
+                    json={"first_name": "F", "last_name": last},
+                    headers=auth_headers,
+                )
+            res = client.get("/person/by_name", params={"name": "Jabberwocky"}, headers=auth_headers)
+            matches = [p for p in res.json() if p["person_id"] == person_id]
+            assert len(matches) == 1
+
+    def test_by_name_no_match_returns_empty_list(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            res = client.get(
+                "/person/by_name",
+                params={"name": "ZZZ_DEFINITELY_NOT_PRESENT"},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_200_OK
+            assert res.json() == []
+
+    def test_old_by_slash_name_path_is_gone(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            res = client.get("/person/by/name", params={"name": "X"}, headers=auth_headers)
+            assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    # ---- /person/by_person_cross_reference/{curie_or_id} ----
+
+    def test_by_person_cross_reference_found_by_curie(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            curie = client.post(
+                "/person/",
+                json={"display_name": "PCR Lookup Person"},
+                headers=auth_headers,
+            ).json()
+            person_id = client.get(f"/person/{curie}", headers=auth_headers).json()["person_id"]
+            client.post(
+                f"/person_cross_reference/person/{person_id}",
+                json={"curie": "ORCID:0000-0001-2345-6789"},
+                headers=auth_headers,
+            )
+            res = client.get(
+                "/person/by_person_cross_reference/ORCID:0000-0001-2345-6789",
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_200_OK
+            assert res.json()["person_id"] == person_id
+
+    def test_by_person_cross_reference_found_by_id(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            curie = client.post(
+                "/person/",
+                json={"display_name": "PCR-by-id Person"},
+                headers=auth_headers,
+            ).json()
+            person_id = client.get(f"/person/{curie}", headers=auth_headers).json()["person_id"]
+            pcr = client.post(
+                f"/person_cross_reference/person/{person_id}",
+                json={"curie": "ORCID:0000-9999-9999-9999"},
+                headers=auth_headers,
+            ).json()
+            res = client.get(
+                f"/person/by_person_cross_reference/{pcr['person_cross_reference_id']}",
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_200_OK
+            assert res.json()["person_id"] == person_id
+
+    def test_by_person_cross_reference_not_found(self, db, auth_headers):  # noqa
+        with TestClient(app) as client:
+            res = client.get(
+                "/person/by_person_cross_reference/ORCID:0000-0000-0000-0000",
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/api/test_person_fields.py
+++ b/tests/api/test_person_fields.py
@@ -1,9 +1,12 @@
 # flake8: noqa: F811
+from unittest.mock import MagicMock
+
 import pytest
 from starlette.testclient import TestClient
 from fastapi import status
 
 from agr_literature_service.api.main import app
+from agr_literature_service.api.crud import person_crud
 from ..fixtures import db  # noqa
 from .fixtures import auth_headers  # noqa
 
@@ -703,3 +706,81 @@ class TestPersonLookups:
                 headers=auth_headers,
             )
             assert res.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestPersonCreateDuplicates:
+    """
+    Re-POSTing /person/ with the same cross_reference curies must return 422,
+    not 500 from a leaked IntegrityError on the global uq_person_xref_curie
+    constraint.
+    """
+
+    def test_post_person_with_duplicate_xref_curie_across_persons_returns_422(
+        self, db, auth_headers
+    ):  # noqa
+        payload = {
+            "display_name": "Dup XRef Person",
+            "cross_references": [{"curie": "ORCID:0000-0005-1111-3333"}],
+        }
+        with TestClient(app) as client:
+            first = client.post("/person/", json=payload, headers=auth_headers)
+            assert first.status_code == status.HTTP_201_CREATED
+
+            second = client.post("/person/", json=payload, headers=auth_headers)
+            assert second.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert "ORCID:0000-0005-1111-3333" in second.json()["detail"]
+
+    def test_post_person_with_duplicate_curie_within_payload_returns_422(
+        self, db, auth_headers
+    ):  # noqa
+        payload = {
+            "display_name": "Same Curie Twice",
+            "cross_references": [
+                {"curie": "ORCID:0000-0006-2222-4444"},
+                {"curie": "ORCID:0000-0006-2222-4444"},
+            ],
+        }
+        with TestClient(app) as client:
+            res = client.post("/person/", json=payload, headers=auth_headers)
+            assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert "duplicated in the request" in res.json()["detail"]
+
+    def test_post_person_with_duplicate_prefix_within_payload_returns_422(
+        self, db, auth_headers
+    ):  # noqa
+        # Two different curies with the same prefix violate
+        # uq_person_xref_person_prefix on commit; check it surfaces as 422.
+        payload = {
+            "display_name": "Two Same-Prefix XRefs",
+            "cross_references": [
+                {"curie": "ORCID:0000-0007-3333-5555"},
+                {"curie": "ORCID:0000-0007-3333-6666"},
+            ],
+        }
+        with TestClient(app) as client:
+            res = client.post("/person/", json=payload, headers=auth_headers)
+            assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert "at most one per prefix" in res.json()["detail"]
+
+    def test_duplicate_xref_does_not_consume_mati_id(
+        self, db, auth_headers, monkeypatch
+    ):  # noqa
+        """Regression guard for the validation reorder.
+
+        The xref pre-check must run BEFORE get_next_person_curie() in
+        person_crud.create(). If the order is reversed, this test fails.
+        """
+        payload = {
+            "display_name": "MATI Skip Test",
+            "cross_references": [{"curie": "ORCID:0000-0008-4444-7777"}],
+        }
+        with TestClient(app) as client:
+            first = client.post("/person/", json=payload, headers=auth_headers)
+            assert first.status_code == status.HTTP_201_CREATED
+
+            spy = MagicMock()
+            monkeypatch.setattr(person_crud, "get_next_person_curie", spy)
+
+            second = client.post("/person/", json=payload, headers=auth_headers)
+            assert second.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+            spy.assert_not_called()

--- a/tests/api/test_person_setting.py
+++ b/tests/api/test_person_setting.py
@@ -144,13 +144,13 @@ class TestPersonSetting:
 
     def test_find_by_name(self, test_person_setting, auth_headers):  # noqa
         with TestClient(app) as client:
-            res = client.get("/person_setting/by/name", params={"name": "Alice"}, headers=auth_headers)
+            res = client.get("/person_setting/by_name", params={"name": "Alice"}, headers=auth_headers)
             assert res.status_code == status.HTTP_200_OK
             rows = res.json()
             assert isinstance(rows, list)
             assert any(r["person_setting_id"] == test_person_setting.new_person_setting_id for r in rows)
 
-            res_empty = client.get("/person_setting/by/name", params={"name": "ZZZ_NOT_FOUND"},
+            res_empty = client.get("/person_setting/by_name", params={"name": "ZZZ_NOT_FOUND"},
                                    headers=auth_headers)
             assert res_empty.status_code == status.HTTP_200_OK
             assert res_empty.json() == []


### PR DESCRIPTION
/person/by_name now matches person_name.first/middle/last_name in addition to display_name so curators can find people by structured name parts. Adds /person/by_person_cross_reference/{curie_or_id} mirroring the existing reference/by_cross_reference endpoint. Renames /by/X to /by_X on the person and person_setting routers for consistency with the rest of the API; lookup routes are declared before the {id} catch-all so single-segment paths resolve correctly.