### PR TITLE
SCRUM-5772: extract and upload PDF figures via PDFX

### DIFF
--- a/agr_literature_service/api/crud/file_conversion_crud.py
+++ b/agr_literature_service/api/crud/file_conversion_crud.py
@@ -30,6 +30,7 @@ from agr_literature_service.api.utils.conversion_processor import run_conversion
 from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     get_nxml_referencefile,
     get_pdf_files_for_reference,
+    is_eligible_for_supplement_conversion,
     process_nxml_to_markdown,
 )
 
@@ -127,7 +128,16 @@ def _assess_reference(db: Session, reference: ReferenceModel,
 
     nxml_source = None if main_cached else get_nxml_referencefile(db, reference.reference_id)
     main_pdfs = [] if main_cached else get_pdf_files_for_reference(db, reference.reference_id, "main")
-    supp_pdfs = [] if supp_cached else get_pdf_files_for_reference(db, reference.reference_id, "supplement")
+
+    # Supplement conversion is restricted to references in corpus for WB/ZFIN/FB
+    # (SCRUM-6026). Treat ineligible references as if they have no supplement
+    # PDFs so the endpoint reports "converted" cleanly once main is done and
+    # never schedules supplement work.
+    supp_eligible = is_eligible_for_supplement_conversion(db, reference.reference_id)
+    if supp_cached or not supp_eligible:
+        supp_pdfs: List[Any] = []
+    else:
+        supp_pdfs = get_pdf_files_for_reference(db, reference.reference_id, "supplement")
 
     main_pdf_available = bool(main_pdfs)
     supp_pdf_available = bool(supp_pdfs)

--- a/agr_literature_service/api/crud/file_conversion_crud.py
+++ b/agr_literature_service/api/crud/file_conversion_crud.py
@@ -35,6 +35,7 @@ from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     pending_main_sources,
     pending_supplement_sources,
     process_nxml_to_markdown,
+    sync_converted_file_mods_to_sources,
 )
 
 logger = logging.getLogger(__name__)
@@ -186,6 +187,98 @@ def _assess_reference(db: Session, reference: ReferenceModel,
         "needs_async": needs_async,
         "mod_abbreviation": mod_abbreviation,
     }
+
+
+def per_mod_pending_status(
+    db: Session,
+    reference: ReferenceModel,
+    overwrite_tei_md: bool = False,
+) -> List[Dict[str, Any]]:
+    """
+    Return per-MOD conversion status for every MOD that currently has a
+    ``text_convert_job`` workflow tag for this reference.
+
+    Each entry: ``{mod_abbreviation, reference_workflow_tag_id,
+    pending_main_count, pending_supplement_count, all_converted}``.
+    ``all_converted`` is True iff that MOD has no pending main or
+    supplement sources — i.e., that MOD's conversion is complete.
+    """
+    from agr_literature_service.api.crud.workflow_tag_crud import get_jobs
+    from agr_literature_service.api.models import ModModel
+
+    jobs = get_jobs(db, "text_convert_job", reference=reference.curie)
+    out: List[Dict[str, Any]] = []
+    for job in jobs:
+        mod_id = job["mod_id"]
+        mod_abbr_row = (
+            db.query(ModModel.abbreviation)
+            .filter(ModModel.mod_id == mod_id)
+            .one_or_none()
+        )
+        if not mod_abbr_row:
+            continue
+        mod_abbreviation = mod_abbr_row.abbreviation
+        pending_main = pending_main_sources(
+            db, reference.reference_id,
+            prefer_nxml=True, ignore_tei_derived=overwrite_tei_md,
+            mod_abbreviation=mod_abbreviation,
+        )
+        # Only count supplements when the reference is supplement-eligible
+        # (SCRUM-6026: WB/ZFIN/FB only). Otherwise this MOD has nothing to
+        # do on the supplement side regardless of what supplement PDFs exist.
+        if is_eligible_for_supplement_conversion(db, reference.reference_id):
+            pending_supplements = pending_supplement_sources(
+                db, reference.reference_id,
+                ignore_tei_derived=overwrite_tei_md,
+                mod_abbreviation=mod_abbreviation,
+            )
+        else:
+            pending_supplements = []
+        out.append({
+            "mod_abbreviation": mod_abbreviation,
+            "reference_workflow_tag_id": job["reference_workflow_tag_id"],
+            "pending_main_count": len(pending_main),
+            "pending_supplement_count": len(pending_supplements),
+            "all_converted": (
+                len(pending_main) == 0 and len(pending_supplements) == 0
+            ),
+        })
+    return out
+
+
+def transition_completed_text_convert_tags(
+    db: Session,
+    reference: ReferenceModel,
+    overwrite_tei_md: bool = False,
+) -> int:
+    """
+    For each ``text_convert_job`` "needed" tag on this reference, transition
+    to ``on_success`` when no source files remain pending for that MOD.
+
+    Returns the number of tags transitioned.
+
+    Used by the on-demand endpoint to land all eligible MODs' workflow
+    tags after conversion + mod-association sync. Only transitions tags
+    whose MOD genuinely has nothing left to do — MODs with pending
+    sources stay in their current state.
+    """
+    from agr_literature_service.api.crud.workflow_tag_crud import job_change_atp_code
+
+    transitioned = 0
+    for entry in per_mod_pending_status(db, reference, overwrite_tei_md):
+        if entry["all_converted"]:
+            try:
+                job_change_atp_code(
+                    db, entry["reference_workflow_tag_id"], "on_success"
+                )
+                transitioned += 1
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to transition text_convert_job tag "
+                    f"{entry['reference_workflow_tag_id']} for "
+                    f"{entry['mod_abbreviation']} on {reference.curie}: {exc}"
+                )
+    return transitioned
 
 
 def _expected_source_files_from_assessment(
@@ -423,21 +516,37 @@ def _converted_classes_from_assessment(assessment: Dict[str, Any]) -> List[str]:
     return out
 
 
-def _status_payload(reference: ReferenceModel, *, status_str: str,
+def _status_payload(db: Session, reference: ReferenceModel, *, status_str: str,
                     converted_classes: List[str],
                     job: Optional[ConversionJob] = None,
                     error_message: Optional[str] = None,
                     started_at: Optional[str] = None,
-                    completed_at: Optional[str] = None) -> Dict[str, Any]:
+                    completed_at: Optional[str] = None,
+                    overwrite_tei_md: bool = False) -> Dict[str, Any]:
     """Build the endpoint response. ``job`` is the most recent job for the
     reference, if any — its id, timestamps, and per-file progress are surfaced.
     Per-file progress is merged with synthesized DB entries so converted rows
-    produced in prior sessions still surface their referencefile_ids."""
+    produced in prior sessions still surface their referencefile_ids.
+
+    ``per_mod_status`` lists every MOD with a text_convert_job tag for this
+    reference and that MOD's conversion state (pending counts +
+    all_converted boolean). Best-effort: any error computing per-MOD
+    status returns an empty list rather than failing the whole response.
+    """
     progress = _merge_progress(
         _job_progress_payload(job),
         _db_derived_progress(reference),
     )
     _attach_figures(reference, progress)
+    try:
+        per_mod = per_mod_pending_status(
+            db, reference, overwrite_tei_md=overwrite_tei_md
+        )
+    except Exception:
+        logger.exception(
+            f"Failed to compute per-MOD status for {reference.curie}"
+        )
+        per_mod = []
     payload: Dict[str, Any] = {
         "reference_curie": reference.curie,
         "status": status_str,
@@ -447,6 +556,7 @@ def _status_payload(reference: ReferenceModel, *, status_str: str,
         "completed_at": completed_at,
         "converted_classes": converted_classes,
         "per_file_progress": progress,
+        "per_mod_status": per_mod,
     }
     if job is not None and payload["started_at"] is None:
         payload["started_at"] = job.started_at.isoformat()
@@ -558,7 +668,7 @@ def handle_conversion_request(db: Session, curie_or_reference_id: str, wait: boo
     existing = conversion_manager.get_active_job_for_reference(reference.reference_id)
     if existing is not None:
         return status.HTTP_202_ACCEPTED, _status_payload(
-            reference, status_str=STATUS_RUNNING,
+            db, reference, status_str=STATUS_RUNNING,
             converted_classes=_converted_classes_from_assessment(assessment),
             started_at=existing.started_at.isoformat(), job=existing,
         )
@@ -574,12 +684,29 @@ def handle_conversion_request(db: Session, curie_or_reference_id: str, wait: boo
     if nothing_missing:
         if nothing_cached and no_sources:
             return status.HTTP_200_OK, _status_payload(
-                reference, status_str=STATUS_NO_SOURCES,
+                db, reference, status_str=STATUS_NO_SOURCES,
                 converted_classes=_converted_classes_from_assessment(assessment),
                 job=recent_job,
             )
+        # SCRUM-6041: nothing to convert, but still reconcile mod
+        # associations on existing converted rows and transition any
+        # text_convert_job tags whose MODs are now fully converted.
+        # This is the "already converted by an earlier MOD-specific run,
+        # need to fan out the result to other MODs" case.
+        try:
+            sync_converted_file_mods_to_sources(db, reference)
+            transition_completed_text_convert_tags(
+                db, reference, overwrite_tei_md=overwrite_tei_md
+            )
+            db.expire(reference)
+            reference = get_reference(db=db, curie_or_reference_id=curie_or_reference_id,
+                                      load_referencefiles=True)
+        except Exception:
+            logger.exception(
+                f"Post-conversion sync/transition failed for {reference.curie}"
+            )
         return status.HTTP_200_OK, _status_payload(
-            reference, status_str=STATUS_CONVERTED,
+            db, reference, status_str=STATUS_CONVERTED,
             converted_classes=_converted_classes_from_assessment(assessment),
             completed_at=now_iso, job=recent_job,
         )
@@ -597,7 +724,7 @@ def handle_conversion_request(db: Session, curie_or_reference_id: str, wait: boo
         success, error = _execute_sync_nxml(db, reference, assessment)
         if not success:
             return status.HTTP_200_OK, _status_payload(
-                reference, status_str=STATUS_FAILED,
+                db, reference, status_str=STATUS_FAILED,
                 converted_classes=_converted_classes_from_assessment(assessment),
                 error_message=error or "nXML conversion failed",
                 completed_at=now_iso, job=recent_job,
@@ -612,7 +739,7 @@ def handle_conversion_request(db: Session, curie_or_reference_id: str, wait: boo
                                   load_referencefiles=True)
         post_assessment = _assess_reference(db, reference)
         return status.HTTP_200_OK, _status_payload(
-            reference, status_str=STATUS_CONVERTED,
+            db, reference, status_str=STATUS_CONVERTED,
             converted_classes=_converted_classes_from_assessment(post_assessment),
             started_at=now_iso, completed_at=now_iso, job=recent_job,
         )
@@ -659,14 +786,14 @@ def handle_conversion_request(db: Session, curie_or_reference_id: str, wait: boo
                             if final_job and final_job.completed_at
                             else now_iso)
             return status.HTTP_200_OK, _status_payload(
-                reference, status_str=STATUS_FAILED,
+                db, reference, status_str=STATUS_FAILED,
                 converted_classes=_converted_classes_from_assessment(post_assessment),
                 error_message=error_detail,
                 started_at=job.started_at.isoformat(),
                 completed_at=completed_at, job=final_job,
             )
         return status.HTTP_200_OK, _status_payload(
-            reference, status_str=STATUS_CONVERTED,
+            db, reference, status_str=STATUS_CONVERTED,
             converted_classes=_converted_classes_from_assessment(post_assessment),
             started_at=job.started_at.isoformat(),
             completed_at=datetime.utcnow().isoformat(), job=final_job,
@@ -686,7 +813,7 @@ def handle_conversion_request(db: Session, curie_or_reference_id: str, wait: boo
         overwrite_tei_md,
     )
     return status.HTTP_202_ACCEPTED, _status_payload(
-        reference, status_str=STATUS_RUNNING,
+        db, reference, status_str=STATUS_RUNNING,
         converted_classes=_converted_classes_from_assessment(assessment),
         started_at=job.started_at.isoformat(), job=job,
     )

--- a/agr_literature_service/api/crud/file_conversion_crud.py
+++ b/agr_literature_service/api/crud/file_conversion_crud.py
@@ -217,6 +217,7 @@ def _job_progress_payload(job: Optional[ConversionJob]) -> List[Dict[str, Any]]:
                 "referencefile_id": p.source_referencefile_id,
             },
             "converted": converted_info,
+            "figures": [],
             "status": p.status,
             "error": p.error,
         })
@@ -293,10 +294,67 @@ def _db_derived_progress(reference: ReferenceModel) -> List[Dict[str, Any]]:
                 "file_class": ref_file.file_class,
                 "referencefile_id": int(ref_file.referencefile_id),
             },
+            "figures": [],
             "status": "success",
             "error": None,
         })
     return out
+
+
+# Mapping from source PDF file_class to the figure file_class that
+# process_extracted_images uploads. Kept in sync with FIGURE_FILE_CLASSES
+# in pdf2md_utils — duplicated here to avoid an inter-module dependency.
+_FIGURE_FILE_CLASS_FOR_SOURCE: Dict[str, str] = {
+    "main": "converted_main_figure",
+    "supplement": "converted_supplement_figure",
+}
+
+
+def _figures_for_source(reference: ReferenceModel,
+                        source_display_name: Optional[str],
+                        source_file_class: Optional[str]) -> List[Dict[str, Any]]:
+    """Return ConversionFileInfo dicts for every extracted-figure row in the
+    DB whose source PDF matches ``(source_display_name, source_file_class)``.
+
+    Figures uploaded by ``pdf2md_utils.process_extracted_images`` use the
+    ``{source_display_name}_image_{idx:03d}`` convention and one of the
+    ``converted_main_figure`` / ``converted_supplement_figure`` file_classes,
+    so we match on display_name prefix + the corresponding figure file_class.
+    """
+    if not source_display_name or not source_file_class:
+        return []
+    figure_file_class = _FIGURE_FILE_CLASS_FOR_SOURCE.get(source_file_class)
+    if figure_file_class is None:
+        return []
+    prefix = f"{source_display_name}_image_"
+    figures: List[Dict[str, Any]] = []
+    for ref_file in reference.referencefiles or []:
+        if ref_file.file_class != figure_file_class:
+            continue
+        if ref_file.file_publication_status != "final":
+            continue
+        if not (ref_file.display_name or "").startswith(prefix):
+            continue
+        figures.append({
+            "display_name": ref_file.display_name,
+            "file_class": ref_file.file_class,
+            "referencefile_id": int(ref_file.referencefile_id),
+        })
+    figures.sort(key=lambda f: f["display_name"] or "")
+    return figures
+
+
+def _attach_figures(reference: ReferenceModel,
+                    progress: List[Dict[str, Any]]) -> None:
+    """Mutate ``progress`` in place: set each entry's ``figures`` list to the
+    extracted-figure rows currently in the DB for that source PDF."""
+    for entry in progress:
+        source = entry.get("source") or {}
+        entry["figures"] = _figures_for_source(
+            reference,
+            source.get("display_name"),
+            source.get("file_class"),
+        )
 
 
 def _merge_progress(job_progress: List[Dict[str, Any]],
@@ -344,6 +402,7 @@ def _status_payload(reference: ReferenceModel, *, status_str: str,
         _job_progress_payload(job),
         _db_derived_progress(reference),
     )
+    _attach_figures(reference, progress)
     payload: Dict[str, Any] = {
         "reference_curie": reference.curie,
         "status": status_str,

--- a/agr_literature_service/api/crud/file_conversion_crud.py
+++ b/agr_literature_service/api/crud/file_conversion_crud.py
@@ -28,9 +28,12 @@ from agr_literature_service.api.models import ReferenceModel, ReferencefileModel
 from agr_literature_service.api.utils.conversion_job_manager import ConversionJob, conversion_manager
 from agr_literature_service.api.utils.conversion_processor import run_conversion_job
 from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+    PendingMainSource,
     get_nxml_referencefile,
     get_pdf_files_for_reference,
     is_eligible_for_supplement_conversion,
+    pending_main_sources,
+    pending_supplement_sources,
     process_nxml_to_markdown,
 )
 
@@ -83,21 +86,32 @@ def _assess_reference(db: Session, reference: ReferenceModel,
                       overwrite_tei_md: bool = False) -> Dict[str, Any]:
     """
     Inspect a reference's files and sources. Return a dict with:
-        - main_cached: bool — a converted_merged_main row exists
-        - supp_cached: bool — any converted_merged_supplement row exists
+        - main_cached: bool — at least one converted_merged_main row exists
+        - supp_cached: bool — at least one converted_merged_supplement row exists
         - nxml_source: ReferencefileModel | None
-        - main_pdfs: list[ReferencefileModel] of eligible main PDFs
-        - supp_pdfs: list[ReferencefileModel] of eligible supplement PDFs
+        - main_pdfs: list[ReferencefileModel] of all main PDFs
+        - supp_pdfs: list[ReferencefileModel] of all supplement PDFs
         - main_pdf_available: bool
         - supp_pdf_available: bool
-        - main_missing: bool — needs conversion AND has a source
-        - supp_missing: bool — needs conversion AND has a source
-        - needs_async: bool — at least one missing class needs PDFX
+        - pending_main: list[PendingMainSource] — main-side sources still
+            needing conversion (per-source dedup; nXML preferred over PDF)
+        - pending_supplements: list[ReferencefileModel] — supplement PDFs
+            still needing conversion (per-source dedup)
+        - main_missing: bool — pending_main is non-empty
+        - supp_missing: bool — pending_supplements is non-empty
+        - needs_async: bool — at least one pending source needs PDFX
         - mod_abbreviation: str | None — first available mod abbrev for metadata
 
-    When ``overwrite_tei_md`` is True, converted rows whose display_name ends
-    with ``_tei`` (produced by the legacy TEI→MD batch job) are NOT counted as
-    cached — so the endpoint will re-convert from nXML or PDF and the
+    Per-source dedup: a source is "already converted" iff a
+    ``converted_merged_*`` row exists with the matching ``_nxml`` / ``_merged``
+    display_name suffix (and ``_tei`` for legacy TEI-derived rows unless
+    ``overwrite_tei_md`` is True). This means a later batch tick (or a later
+    MOD's "conversion needed" tag) only processes sources that haven't been
+    converted yet — supplements MOD A processed earlier are skipped while
+    supplements MOD B added later are picked up.
+
+    When ``overwrite_tei_md`` is True, ``_tei``-suffixed rows are NOT
+    counted, so the endpoint re-converts from nXML or PDF and the
     higher-quality output supersedes the TEI-derived fallback.
     """
     main_cached = False
@@ -126,28 +140,36 @@ def _assess_reference(db: Session, reference: ReferenceModel,
             if mod_abbreviation is None and ref_file_mod.mod is not None:
                 mod_abbreviation = ref_file_mod.mod.abbreviation
 
-    nxml_source = None if main_cached else get_nxml_referencefile(db, reference.reference_id)
-    main_pdfs = [] if main_cached else get_pdf_files_for_reference(db, reference.reference_id, "main")
+    nxml_source = get_nxml_referencefile(db, reference.reference_id)
+    main_pdfs = get_pdf_files_for_reference(db, reference.reference_id, "main")
+    supp_pdfs = get_pdf_files_for_reference(db, reference.reference_id, "supplement")
+
+    pending_main: List[PendingMainSource] = pending_main_sources(
+        db, reference.reference_id,
+        prefer_nxml=True, ignore_tei_derived=overwrite_tei_md,
+    )
 
     # Supplement conversion is restricted to references in corpus for WB/ZFIN/FB
-    # (SCRUM-6026). Treat ineligible references as if they have no supplement
-    # PDFs so the endpoint reports "converted" cleanly once main is done and
-    # never schedules supplement work.
+    # (SCRUM-6026). Treat ineligible references as if they have no pending
+    # supplements so the endpoint reports "converted" cleanly once main is
+    # done and never schedules supplement work.
     supp_eligible = is_eligible_for_supplement_conversion(db, reference.reference_id)
-    if supp_cached or not supp_eligible:
-        supp_pdfs: List[Any] = []
+    if supp_eligible:
+        pending_supplements: List[Any] = pending_supplement_sources(
+            db, reference.reference_id, ignore_tei_derived=overwrite_tei_md,
+        )
     else:
-        supp_pdfs = get_pdf_files_for_reference(db, reference.reference_id, "supplement")
+        pending_supplements = []
 
     main_pdf_available = bool(main_pdfs)
     supp_pdf_available = bool(supp_pdfs)
 
-    main_missing = (not main_cached) and (nxml_source is not None or main_pdf_available)
-    supp_missing = (not supp_cached) and supp_pdf_available
+    main_missing = bool(pending_main)
+    supp_missing = bool(pending_supplements)
 
-    main_needs_pdf = main_missing and nxml_source is None and main_pdf_available
-    supp_needs_pdf = supp_missing and supp_pdf_available
-    needs_async = main_needs_pdf or supp_needs_pdf
+    # PDF-only pending sources need the async PDFX path; nXML can be done sync.
+    main_needs_pdf = any(p["kind"] == "pdf" for p in pending_main)
+    needs_async = main_needs_pdf or supp_missing
 
     return {
         "main_cached": main_cached,
@@ -157,6 +179,8 @@ def _assess_reference(db: Session, reference: ReferenceModel,
         "supp_pdfs": supp_pdfs,
         "main_pdf_available": main_pdf_available,
         "supp_pdf_available": supp_pdf_available,
+        "pending_main": pending_main,
+        "pending_supplements": pending_supplements,
         "main_missing": main_missing,
         "supp_missing": supp_missing,
         "needs_async": needs_async,
@@ -167,43 +191,44 @@ def _assess_reference(db: Session, reference: ReferenceModel,
 def _expected_source_files_from_assessment(
     assessment: Dict[str, Any],
 ) -> List[Dict[str, Optional[str]]]:
-    """Build the list of eligible source files for the upcoming conversion job.
+    """Build the list of eligible source files for the upcoming conversion job
+    from the assessment's per-source pending lists.
 
     Used to seed ``per_file_progress`` with ``pending`` entries so callers
     polling while a job runs can see the full list of files in flight, not
-    only the ones already finished.
+    only the ones already finished. Each entry corresponds to a source file
+    that genuinely still needs conversion — sources that were already
+    converted in a prior run are not seeded here.
     """
     expected: List[Dict[str, Optional[str]]] = []
 
-    if assessment.get("main_missing"):
-        nxml_source = assessment.get("nxml_source")
-        if nxml_source is not None:
+    for entry in assessment.get("pending_main") or []:
+        ref_file = entry["ref_file"]
+        if entry["kind"] == "nxml":
             expected.append({
-                "source_display_name": nxml_source.display_name,
+                "source_display_name": ref_file.display_name,
                 "source_file_class": "nXML",
-                "source_referencefile_id": nxml_source.referencefile_id,
-                "expected_converted_display_name": f"{nxml_source.display_name}_nxml",
+                "source_referencefile_id": ref_file.referencefile_id,
+                "expected_converted_display_name": f"{ref_file.display_name}_nxml",
                 "expected_converted_file_class": "converted_merged_main",
             })
         else:
-            for pdf in assessment.get("main_pdfs") or []:
-                expected.append({
-                    "source_display_name": pdf.display_name,
-                    "source_file_class": "main",
-                    "source_referencefile_id": pdf.referencefile_id,
-                    "expected_converted_display_name": f"{pdf.display_name}_merged",
-                    "expected_converted_file_class": "converted_merged_main",
-                })
-
-    if assessment.get("supp_missing"):
-        for pdf in assessment.get("supp_pdfs") or []:
             expected.append({
-                "source_display_name": pdf.display_name,
-                "source_file_class": "supplement",
-                "source_referencefile_id": pdf.referencefile_id,
-                "expected_converted_display_name": f"{pdf.display_name}_merged",
-                "expected_converted_file_class": "converted_merged_supplement",
+                "source_display_name": ref_file.display_name,
+                "source_file_class": "main",
+                "source_referencefile_id": ref_file.referencefile_id,
+                "expected_converted_display_name": f"{ref_file.display_name}_merged",
+                "expected_converted_file_class": "converted_merged_main",
             })
+
+    for ref_file in assessment.get("pending_supplements") or []:
+        expected.append({
+            "source_display_name": ref_file.display_name,
+            "source_file_class": "supplement",
+            "source_referencefile_id": ref_file.referencefile_id,
+            "expected_converted_display_name": f"{ref_file.display_name}_merged",
+            "expected_converted_file_class": "converted_merged_supplement",
+        })
 
     return expected
 
@@ -559,9 +584,13 @@ def handle_conversion_request(db: Session, curie_or_reference_id: str, wait: boo
             completed_at=now_iso, job=recent_job,
         )
 
+    # Sync-nxml shortcut applies when the only pending main source is the
+    # nXML and there are no pending supplements — the nXML conversion is
+    # fast enough to run inline.
+    pending_main = assessment.get("pending_main") or []
     nxml_only = (
-        assessment["main_missing"]
-        and assessment["nxml_source"] is not None
+        bool(pending_main)
+        and all(p["kind"] == "nxml" for p in pending_main)
         and not assessment["supp_missing"]
     )
     if nxml_only:

--- a/agr_literature_service/api/schemas/file_conversion_schemas.py
+++ b/agr_literature_service/api/schemas/file_conversion_schemas.py
@@ -11,6 +11,23 @@ class ConversionFileInfo(BaseModel):
     referencefile_id: Optional[int] = None
 
 
+class ConversionModStatusSchema(BaseModel):
+    """Per-MOD conversion status for a reference.
+
+    Reports the conversion state from each MOD's perspective. Returned for
+    every MOD that currently has a ``text_convert_job`` workflow tag
+    pointing at this reference. ``all_converted`` is True iff that MOD has
+    no main / supplement source files left to convert (taking into account
+    SCRUM-6026 supplement eligibility for non-WB/ZFIN/FB references).
+    """
+    model_config = ConfigDict(extra='forbid', from_attributes=True)
+
+    mod_abbreviation: str
+    pending_main_count: int
+    pending_supplement_count: int
+    all_converted: bool
+
+
 class ConversionPerFileProgressSchema(BaseModel):
     """One entry per source file eligible for conversion on the most recent
     job, plus one entry per converted Markdown row currently in the DB for
@@ -68,3 +85,4 @@ class ConversionStatusResponseSchema(BaseModel):
     completed_at: Optional[str] = None
     converted_classes: List[str] = []
     per_file_progress: List[ConversionPerFileProgressSchema] = []
+    per_mod_status: List[ConversionModStatusSchema] = []

--- a/agr_literature_service/api/schemas/file_conversion_schemas.py
+++ b/agr_literature_service/api/schemas/file_conversion_schemas.py
@@ -20,11 +20,18 @@ class ConversionPerFileProgressSchema(BaseModel):
     display_name and file_class; for ``failed`` entries ``converted`` is
     null and ``error`` is populated. ``source`` may be null for entries
     derived purely from the DB — call ``show_all`` if you need the original
-    source file info for those."""
+    source file info for those.
+
+    ``figures`` lists every ``converted_main_figure`` /
+    ``converted_supplement_figure`` row currently in the DB that was
+    extracted from this entry's source PDF (matched by display_name prefix).
+    Empty when image extraction was not run, returned no figures, or the
+    source isn't a PDF."""
     model_config = ConfigDict(extra='forbid', from_attributes=True)
 
     source: Optional[ConversionFileInfo] = None
     converted: Optional[ConversionFileInfo] = None
+    figures: List[ConversionFileInfo] = []
     status: str
     error: Optional[str] = None
 

--- a/agr_literature_service/api/utils/conversion_processor.py
+++ b/agr_literature_service/api/utils/conversion_processor.py
@@ -208,8 +208,12 @@ def run_conversion_job(job_id: str, reference_id: int, reference_curie: str,
     from agr_literature_service.api.crud.file_conversion_crud import (
         _assess_reference,
         delete_tei_derived_md_rows,
+        transition_completed_text_convert_tags,
     )
     from agr_literature_service.api.crud.reference_utils import get_reference
+    from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+        sync_converted_file_mods_to_sources,
+    )
 
     db = SessionLocal()
     try:
@@ -247,6 +251,26 @@ def run_conversion_job(job_id: str, reference_id: int, reference_curie: str,
                 db, reference,
                 ["converted_merged_main", "converted_merged_supplement"],
             )
+
+        # SCRUM-6041: on-demand path always reconciles converted-file mod
+        # associations with their sources and transitions every fully-
+        # converted MOD's text_convert_job tag — even when no new
+        # conversion ran in this call (the reference may already be
+        # converted but missing some MOD associations / pending tag
+        # transitions from prior MOD-specific batch runs).
+        try:
+            db.expire_all()
+            reference = get_reference(db, str(reference_id), load_referencefiles=True)
+            sync_converted_file_mods_to_sources(db, reference)
+            transition_completed_text_convert_tags(
+                db, reference, overwrite_tei_md=overwrite_tei_md
+            )
+        except Exception:
+            logger.exception(
+                f"Conversion job {job_id}: post-conversion sync/transition failed "
+                f"for reference_id={reference_id}"
+            )
+
         conversion_manager.complete_job(
             job_id=job_id,
             success=overall_success,

--- a/agr_literature_service/api/utils/conversion_processor.py
+++ b/agr_literature_service/api/utils/conversion_processor.py
@@ -3,10 +3,14 @@ Background task for on-demand file conversion.
 
 Dispatches to the existing batch conversion primitives in
 ``agr_literature_service.lit_processing.pdf2md.pdf2md_utils`` rather than
-re-implementing any conversion logic here.
+re-implementing any conversion logic here. Per-source dedup (SCRUM-6041):
+the assessment's ``pending_main`` / ``pending_supplements`` lists drive
+conversion, so already-converted source files are never re-processed —
+even when a later workflow tag (added by a different MOD or after new
+files were uploaded) re-triggers the job for the same reference.
 """
 import logging
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from agr_literature_service.api.database.main import SessionLocal
 from agr_literature_service.api.utils.conversion_job_manager import conversion_manager
@@ -14,32 +18,171 @@ from agr_literature_service.api.utils.conversion_job_manager import conversion_m
 logger = logging.getLogger(__name__)
 
 
-def _record_pdf_details(db: Any, job_id: str, reference_id: int,
-                        details: List[Any], output_file_class: str) -> None:
-    """Translate process_pdf_for_reference per-PDF details into job progress entries.
-    Each source PDF produces one entry; if the 'merged' method succeeded, the
-    converted side points at the merged output row for that PDF."""
-    from agr_literature_service.api.crud.file_conversion_crud import find_converted_referencefile_id
-    for detail in details:
-        merged_uploaded = "merged" in (detail.get("methods_uploaded") or [])
-        source_display_name = detail["display_name"]
-        converted_display_name = f"{source_display_name}_merged" if merged_uploaded else None
-        converted_rf_id: Optional[int] = None
-        if merged_uploaded and converted_display_name is not None:
-            converted_rf_id = find_converted_referencefile_id(
-                db, reference_id, converted_display_name, output_file_class,
-            )
-        conversion_manager.record_file_progress(
-            job_id=job_id,
-            source_display_name=source_display_name,
-            source_file_class=detail["file_class"],
-            source_referencefile_id=detail.get("referencefile_id"),
-            converted_display_name=converted_display_name,
-            converted_file_class=output_file_class if merged_uploaded else None,
-            converted_referencefile_id=converted_rf_id,
-            success=detail["success"],
-            error=detail.get("error"),
+def _all_extraction_methods() -> List[str]:
+    from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+        EXTRACTION_METHODS,
+    )
+    return list(EXTRACTION_METHODS.keys())
+
+
+def _record_single_pdf(
+    db: Any,
+    job_id: str,
+    reference_id: int,
+    pdf_file: Any,
+    success: bool,
+    methods_uploaded: Any,
+    error: Optional[str],
+    output_file_class: str,
+) -> None:
+    """Record one per-source progress entry for a PDF that was just processed.
+
+    The converted side points at the merged output row when the merged method
+    succeeded; otherwise it's left null so the on-demand response surfaces the
+    failure cleanly.
+    """
+    from agr_literature_service.api.crud.file_conversion_crud import (
+        find_converted_referencefile_id,
+    )
+    merged_uploaded = "merged" in (methods_uploaded or [])
+    source_display_name = pdf_file.display_name
+    converted_display_name = (
+        f"{source_display_name}_merged" if merged_uploaded else None
+    )
+    converted_rf_id: Optional[int] = None
+    if merged_uploaded and converted_display_name is not None:
+        converted_rf_id = find_converted_referencefile_id(
+            db, reference_id, converted_display_name, output_file_class,
         )
+    conversion_manager.record_file_progress(
+        job_id=job_id,
+        source_display_name=source_display_name,
+        source_file_class=pdf_file.file_class,
+        source_referencefile_id=int(pdf_file.referencefile_id),
+        converted_display_name=converted_display_name,
+        converted_file_class=output_file_class if merged_uploaded else None,
+        converted_referencefile_id=converted_rf_id,
+        success=success,
+        error=error,
+    )
+
+
+def _convert_pending_nxml(
+    db: Any, job_id: str, reference_id: int, reference_curie: str,
+    nxml_ref_file: Any, mod_abbreviation: Optional[str],
+) -> Tuple[bool, Optional[str]]:
+    """Run nXML→MD conversion for a single pending nXML source."""
+    from agr_literature_service.api.crud.file_conversion_crud import (
+        find_converted_referencefile_id,
+    )
+    from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+        process_nxml_to_markdown,
+    )
+    success, error = process_nxml_to_markdown(
+        db=db,
+        nxml_ref_file=nxml_ref_file,
+        reference_curie=reference_curie,
+        mod_abbreviation=mod_abbreviation,
+    )
+    converted_display_name = (
+        f"{nxml_ref_file.display_name}_nxml" if success else None
+    )
+    converted_rf_id: Optional[int] = None
+    if success and converted_display_name is not None:
+        converted_rf_id = find_converted_referencefile_id(
+            db, reference_id, converted_display_name, "converted_merged_main",
+        )
+    conversion_manager.record_file_progress(
+        job_id=job_id,
+        source_display_name=nxml_ref_file.display_name,
+        source_file_class="nXML",
+        source_referencefile_id=int(nxml_ref_file.referencefile_id),
+        converted_display_name=converted_display_name,
+        converted_file_class=(
+            "converted_merged_main" if success else None
+        ),
+        converted_referencefile_id=converted_rf_id,
+        success=success,
+        error=error,
+    )
+    return success, error
+
+
+def _convert_pending_pdf(
+    db: Any, job_id: str, reference_id: int, reference_curie: str,
+    pdf_file: Any, output_file_class: str, token: str,
+) -> Tuple[bool, Optional[str]]:
+    """Run PDFX→MD conversion for a single pending main or supplement PDF."""
+    from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+        _process_single_pdf_file,
+    )
+    try:
+        success, methods_uploaded, error = _process_single_pdf_file(
+            db=db,
+            pdf_file=pdf_file,
+            reference_curie=reference_curie,
+            token=token,
+            methods_to_extract=_all_extraction_methods(),
+        )
+    except Exception as exc:
+        success, methods_uploaded, error = False, [], str(exc)
+    _record_single_pdf(
+        db, job_id, reference_id, pdf_file,
+        success, methods_uploaded, error,
+        output_file_class,
+    )
+    return success, error
+
+
+def _convert_pending_main(
+    db: Any, job_id: str, reference_id: int, reference_curie: str,
+    assessment: Dict[str, Any], get_token,
+) -> Tuple[bool, List[str]]:
+    """Convert each entry in assessment['pending_main']. Returns
+    (any_failure, failure_messages)."""
+    any_failure = False
+    failure_messages: List[str] = []
+    for entry in assessment.get("pending_main") or []:
+        ref_file = entry["ref_file"]
+        if entry["kind"] == "nxml":
+            success, error = _convert_pending_nxml(
+                db, job_id, reference_id, reference_curie,
+                ref_file, assessment["mod_abbreviation"],
+            )
+            tag = "nXML main"
+        else:
+            success, error = _convert_pending_pdf(
+                db, job_id, reference_id, reference_curie,
+                ref_file, "converted_merged_main", get_token(),
+            )
+            tag = f"PDF main '{ref_file.display_name}'"
+        if not success:
+            any_failure = True
+            if error:
+                failure_messages.append(f"{tag}: {error}")
+    return any_failure, failure_messages
+
+
+def _convert_pending_supplements(
+    db: Any, job_id: str, reference_id: int, reference_curie: str,
+    assessment: Dict[str, Any], get_token,
+) -> Tuple[bool, List[str]]:
+    """Convert each entry in assessment['pending_supplements']. Returns
+    (any_failure, failure_messages)."""
+    any_failure = False
+    failure_messages: List[str] = []
+    for ref_file in assessment.get("pending_supplements") or []:
+        success, error = _convert_pending_pdf(
+            db, job_id, reference_id, reference_curie,
+            ref_file, "converted_merged_supplement", get_token(),
+        )
+        if not success:
+            any_failure = True
+            if error:
+                failure_messages.append(
+                    f"PDF supplement '{ref_file.display_name}': {error}"
+                )
+    return any_failure, failure_messages
 
 
 def run_conversion_job(job_id: str, reference_id: int, reference_curie: str,
@@ -48,10 +191,12 @@ def run_conversion_job(job_id: str, reference_id: int, reference_curie: str,
     Execute a pending conversion job.
 
     Opens its own SessionLocal (the request's DB session has closed by the time
-    the BackgroundTasks runner invokes this). Figures out what's missing for
-    the reference and dispatches NXML or PDFX conversions to the batch
-    primitives. Reports progress to ``conversion_manager`` and marks the job
-    completed or failed before returning.
+    the BackgroundTasks runner invokes this). The assessment's
+    ``pending_main`` / ``pending_supplements`` lists tell us exactly which
+    source files still need conversion; we run NXML or PDFX once per pending
+    source, skip everything that's already been converted, and report
+    progress to ``conversion_manager`` before marking the job completed
+    or failed.
 
     ``overwrite_tei_md`` — when True, TEI-derived converted Markdown rows
     (display_name ending in ``_tei``) are not counted as cached, so the job
@@ -63,81 +208,34 @@ def run_conversion_job(job_id: str, reference_id: int, reference_curie: str,
     from agr_literature_service.api.crud.file_conversion_crud import (
         _assess_reference,
         delete_tei_derived_md_rows,
-        find_converted_referencefile_id,
     )
     from agr_literature_service.api.crud.reference_utils import get_reference
-    from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
-        process_nxml_to_markdown,
-        process_pdf_for_reference,
-    )
 
     db = SessionLocal()
     try:
         reference = get_reference(db, str(reference_id), load_referencefiles=True)
         assessment = _assess_reference(db, reference, overwrite_tei_md=overwrite_tei_md)
 
-        any_failure = False
-        failure_messages = []
+        # Lazily fetch the PDFX token: we only need it when there's at
+        # least one pending PDF source (main or supplement). nXML-only
+        # conversions skip this.
+        cached_token: Dict[str, str] = {}
 
-        # Main: prefer NXML (sync, fast) if available; else fall back to PDFX.
-        if assessment["main_missing"]:
-            if assessment["nxml_source"] is not None:
-                nxml_source = assessment["nxml_source"]
-                success, error = process_nxml_to_markdown(
-                    db=db,
-                    nxml_ref_file=nxml_source,
-                    reference_curie=reference_curie,
-                    mod_abbreviation=assessment["mod_abbreviation"],
-                )
-                converted_display_name = f"{nxml_source.display_name}_nxml" if success else None
-                converted_rf_id: Optional[int] = None
-                if success and converted_display_name is not None:
-                    converted_rf_id = find_converted_referencefile_id(
-                        db, reference_id, converted_display_name, "converted_merged_main",
-                    )
-                conversion_manager.record_file_progress(
-                    job_id=job_id,
-                    source_display_name=nxml_source.display_name,
-                    source_file_class="nXML",
-                    source_referencefile_id=nxml_source.referencefile_id,
-                    converted_display_name=converted_display_name,
-                    converted_file_class="converted_merged_main" if success else None,
-                    converted_referencefile_id=converted_rf_id,
-                    success=success,
-                    error=error,
-                )
-                if not success:
-                    any_failure = True
-                    if error:
-                        failure_messages.append(f"nXML main: {error}")
-            elif assessment["main_pdf_available"]:
-                result = process_pdf_for_reference(
-                    db=db,
-                    curie=reference_curie,
-                    pdf_type="main",
-                )
-                _record_pdf_details(db, job_id, reference_id,
-                                    result.get("details", []), "converted_merged_main")
-                if not result.get("success"):
-                    any_failure = True
-                    err = result.get("error")
-                    if err:
-                        failure_messages.append(f"PDF main: {err}")
+        def get_token() -> str:
+            if "token" not in cached_token:
+                from agr_cognito_py import get_admin_token
+                cached_token["token"] = get_admin_token()
+            return cached_token["token"]
 
-        # Supplements: always PDFX when any supplement PDFs exist.
-        if assessment["supp_missing"] and assessment["supp_pdf_available"]:
-            result = process_pdf_for_reference(
-                db=db,
-                curie=reference_curie,
-                pdf_type="supplement",
-            )
-            _record_pdf_details(db, job_id, reference_id,
-                                result.get("details", []), "converted_merged_supplement")
-            if not result.get("success"):
-                any_failure = True
-                err = result.get("error")
-                if err:
-                    failure_messages.append(f"PDF supplements: {err}")
+        main_failure, main_errors = _convert_pending_main(
+            db, job_id, reference_id, reference_curie, assessment, get_token,
+        )
+        supp_failure, supp_errors = _convert_pending_supplements(
+            db, job_id, reference_id, reference_curie, assessment, get_token,
+        )
+
+        any_failure = main_failure or supp_failure
+        failure_messages = main_errors + supp_errors
 
         overall_success = not any_failure
         if overwrite_tei_md and overall_success:

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md.py
@@ -627,7 +627,10 @@ def process_single_reference(  # pragma: no cover
             else:
                 main_error = pdfx_error
 
-    # 3. Optionally convert supplemental PDFs regardless of main path used
+    # 3. Optionally convert supplemental PDFs regardless of main path used.
+    # When called from the workflow batch (mod_abbreviation is set), only
+    # supplements associated with that MOD are processed; bulk modes
+    # (newest/since-year, mod_abbreviation=None) process every supplement.
     if process_supplements:
         try:
             sup_succeeded, sup_failed, sup_errors = process_supplemental_pdfs(
@@ -635,7 +638,8 @@ def process_single_reference(  # pragma: no cover
                 reference_id=reference_id,
                 reference_curie=reference_curie,
                 token=token,
-                methods_to_extract=methods_to_extract
+                methods_to_extract=methods_to_extract,
+                mod_abbreviation=mod_abbreviation,
             )
             if sup_succeeded or sup_failed:
                 logger.info(
@@ -841,66 +845,53 @@ def main(  # pragma: no cover
             logger.info(f"Loaded batch of {len(jobs)} jobs. Total jobs loaded: {len(all_jobs)}")
         logger.info("Finished loading all text conversion jobs.")
 
-        # SCRUM-6041: group jobs by reference_id so each reference is
-        # converted at most once per batch tick. After conversion, every
-        # MOD's per-reference workflow tag is transitioned (on_success or
-        # on_failed) — so a paper in WB+ZFIN+FB corpora produces one PDFX
-        # run, not three. Per-source dedup inside process_single_reference
-        # additionally skips files already converted in earlier batch ticks.
-        from collections import defaultdict
-        jobs_by_reference: Dict[int, List[Dict]] = defaultdict(list)
-        for job in all_jobs:
-            jobs_by_reference[job['reference_id']].append(job)
-
+        # Per-MOD per-job iteration: each text_convert_job processes only
+        # its own MOD's files. Per-source dedup inside the helpers means a
+        # shared file (e.g., PMC main PDF) converted by MOD A's job will
+        # be skipped when MOD B's job runs — but if MOD B has a distinct
+        # MOD-specific PDF or supplement, that file gets its own conversion.
         mod_abbreviation_from_mod_id: Dict[int, str] = {}
         objects_with_errors: List[Dict] = []
-        total_count = len(jobs_by_reference)
+        total_count = len(all_jobs)
         success_count = 0
         failure_count = 0
         skipped_count = 0
         ref_times: List[float] = []
 
-        def _mod_abbr(mod_id: int) -> str:
-            if mod_id not in mod_abbreviation_from_mod_id:
-                mod_abbreviation_from_mod_id[mod_id] = db.query(
-                    ModModel.abbreviation
-                ).filter(ModModel.mod_id == mod_id).one().abbreviation
-            return mod_abbreviation_from_mod_id[mod_id]
-
-        for idx, (ref_id, ref_jobs) in enumerate(jobs_by_reference.items(), 1):
+        for idx, job in enumerate(all_jobs, 1):
             ref_start_time = time.time()
             error_msg: Optional[str] = None
-            reference_curie = ref_jobs[0]['reference_curie']
-            tag_ids = [j['reference_workflow_tag_id'] for j in ref_jobs]
-            ref_mod_abbrs = sorted({_mod_abbr(j['mod_id']) for j in ref_jobs})
 
-            logger.info(
-                f"Processing {idx}/{total_count}: {reference_curie} "
-                f"(MODs: {','.join(ref_mod_abbrs)}, jobs: {len(ref_jobs)})"
-            )
+            ref_id = job['reference_id']
+            reference_workflow_tag_id = job['reference_workflow_tag_id']
+            mod_id = job['mod_id']
+            reference_curie = job['reference_curie']
 
-            # Use the first MOD's source resolution. That MOD's main PDF
-            # (if MOD-specific) drives display_name / file_extension; per-source
-            # dedup picks up files that any MOD added later via
-            # _resolve_workflow_ref_file_info is intentionally MOD-aware,
-            # mirroring the previous per-job behavior.
-            primary_mod = _mod_abbr(ref_jobs[0]['mod_id'])
+            logger.info(f"Processing {idx}/{total_count}: {reference_curie}")
+
+            if mod_id not in mod_abbreviation_from_mod_id:
+                mod_abbreviation = db.query(ModModel.abbreviation).filter(
+                    ModModel.mod_id == mod_id
+                ).one().abbreviation
+                mod_abbreviation_from_mod_id[mod_id] = mod_abbreviation
+            else:
+                mod_abbreviation = mod_abbreviation_from_mod_id[mod_id]
+
             ref_file_info, resolve_error = _resolve_workflow_ref_file_info(
                 db=db,
                 ref_id=ref_id,
                 reference_curie=reference_curie,
-                mod_abbreviation=primary_mod,
+                mod_abbreviation=mod_abbreviation,
                 prefer_nxml=prefer_nxml
             )
 
             if ref_file_info is None:
                 skipped_count += 1
                 error_msg = resolve_error or "Could not resolve reference source file"
-                logger.warning(f"{error_msg} for {reference_curie}; marking job(s) as failed")
-                for tag_id in tag_ids:
-                    job_change_atp_code(db, tag_id, "on_failed")
+                logger.warning(f"{error_msg} for {reference_curie}; marking job as failed")
+                job_change_atp_code(db, reference_workflow_tag_id, "on_failed")
                 objects_with_errors.append(_build_workflow_error_record(
-                    db, reference_curie, "N/A", "N/A", primary_mod, error_msg
+                    db, reference_curie, "N/A", "N/A", mod_abbreviation, error_msg
                 ))
                 continue
 
@@ -919,25 +910,17 @@ def main(  # pragma: no cover
             ref_elapsed = time.time() - ref_start_time
             ref_times.append(ref_elapsed)
 
-            transition = "on_success" if success else "on_failed"
-            for tag_id in tag_ids:
-                job_change_atp_code(db, tag_id, transition)
-
             if success:
                 success_count += 1
-                logger.info(
-                    f"Completed {reference_curie} in {ref_elapsed:.2f}s "
-                    f"({len(tag_ids)} workflow tag(s) → on_success)"
-                )
+                job_change_atp_code(db, reference_workflow_tag_id, "on_success")
+                logger.info(f"Completed {reference_curie} in {ref_elapsed:.2f}s")
             else:
                 failure_count += 1
-                logger.error(
-                    f"Failed {reference_curie} after {ref_elapsed:.2f}s "
-                    f"({len(tag_ids)} workflow tag(s) → on_failed)"
-                )
+                job_change_atp_code(db, reference_workflow_tag_id, "on_failed")
+                logger.error(f"Failed {reference_curie} after {ref_elapsed:.2f}s")
                 objects_with_errors.append(_build_workflow_error_record(
                     db, reference_curie, display_name, file_extension,
-                    primary_mod, error_msg or "Unknown"
+                    mod_abbreviation, error_msg or "Unknown"
                 ))
 
         # Calculate timing statistics

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md.py
@@ -37,6 +37,7 @@ from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     poll_pdfx_status,
     download_pdfx_result,
     get_nxml_referencefile,
+    process_extracted_images,
     process_nxml_to_markdown,
     process_supplemental_pdfs,
 )
@@ -421,17 +422,23 @@ def _convert_main_pdf_via_pdfx(  # pragma: no cover
             use_in_api=False
         )
 
-        # Determine which methods to request (merged requires merge=True)
+        # Determine which methods to request (merged requires merge=True).
+        # Marker is required for figure image extraction, so ensure it is in
+        # the request set even when the caller did not explicitly ask for it
+        # (we still only upload Markdown for the methods the caller wants).
         request_methods = [m for m in methods_to_extract if m != "merged"]
         include_merge = "merged" in methods_to_extract
+        if "marker" not in request_methods:
+            request_methods.append("marker")
 
         process_id = submit_pdf_to_pdfx(
             file_content=file_content,
             token=token,
-            methods=",".join(request_methods) if request_methods else "grobid,docling,marker",
+            methods=",".join(request_methods),
             merge=include_merge,
             reference_curie=reference_curie,
-            mod_abbreviation=mod_abbreviation
+            mod_abbreviation=mod_abbreviation,
+            extract_images=True,
         )
 
         poll_pdfx_status(process_id, token)
@@ -474,6 +481,25 @@ def _convert_main_pdf_via_pdfx(  # pragma: no cover
 
             except Exception as e:
                 logger.error(f"Failed to download/upload {method} for {reference_curie}: {e}")
+
+        # Always attempt image extraction after the Markdown outputs. Failures
+        # here are reported but do not flip the per-file success — the
+        # converted MD rows are the contract callers depend on.
+        try:
+            process_extracted_images(
+                db=db,
+                process_id=process_id,
+                token=token,
+                source_display_name=display_name,
+                source_file_class="main",
+                reference_curie=reference_curie,
+                mod_abbreviation=mod_abbreviation,
+            )
+        except Exception as e:
+            logger.error(
+                f"Unexpected error during image extraction for {reference_curie} "
+                f"(main '{display_name}'): {e}"
+            )
 
         if successful_methods:
             logger.info(

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md.py
@@ -37,6 +37,7 @@ from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     poll_pdfx_status,
     download_pdfx_result,
     get_nxml_referencefile,
+    is_main_source_converted,
     process_extracted_images,
     process_nxml_to_markdown,
     process_supplemental_pdfs,
@@ -566,21 +567,40 @@ def process_single_reference(  # pragma: no cover
     main_success = False
     main_error: Optional[str] = None
 
-    # 1. Prefer nXML when available (unless forced to PDFX)
-    if prefer_nxml:
-        nxml_ref_file = get_nxml_referencefile(db, reference_id)
-        if nxml_ref_file is not None:
-            main_success, main_error = process_nxml_to_markdown(
-                db=db,
-                nxml_ref_file=nxml_ref_file,
-                reference_curie=reference_curie,
-                mod_abbreviation=mod_abbreviation
+    # 0. Per-source dedup: if either the nXML source or the main PDF source
+    # has already produced a converted_merged_main row in a prior run,
+    # treat the main side as already converted and skip the conversion call.
+    nxml_ref_file = get_nxml_referencefile(db, reference_id) if prefer_nxml else None
+    main_already_converted = False
+    if nxml_ref_file is not None and is_main_source_converted(
+        db, reference_id, nxml_ref_file.display_name, is_nxml=True
+    ):
+        main_already_converted = True
+    elif is_main_source_converted(
+        db, reference_id, display_name, is_nxml=False
+    ):
+        main_already_converted = True
+
+    if main_already_converted:
+        logger.info(
+            f"Main already converted for {reference_curie}; "
+            f"skipping nXML/PDFX call"
+        )
+        main_success = True
+
+    # 1. Prefer nXML when available (unless forced to PDFX or already converted)
+    if not main_success and prefer_nxml and nxml_ref_file is not None:
+        main_success, main_error = process_nxml_to_markdown(
+            db=db,
+            nxml_ref_file=nxml_ref_file,
+            reference_curie=reference_curie,
+            mod_abbreviation=mod_abbreviation
+        )
+        if not main_success:
+            logger.warning(
+                f"nXML conversion failed for {reference_curie} ({main_error}); "
+                f"falling back to PDFX on main PDF"
             )
-            if not main_success:
-                logger.warning(
-                    f"nXML conversion failed for {reference_curie} ({main_error}); "
-                    f"falling back to PDFX on main PDF"
-                )
 
     # 2. Fall back to (or use directly) PDFX on the main PDF
     if not main_success:
@@ -821,48 +841,66 @@ def main(  # pragma: no cover
             logger.info(f"Loaded batch of {len(jobs)} jobs. Total jobs loaded: {len(all_jobs)}")
         logger.info("Finished loading all text conversion jobs.")
 
+        # SCRUM-6041: group jobs by reference_id so each reference is
+        # converted at most once per batch tick. After conversion, every
+        # MOD's per-reference workflow tag is transitioned (on_success or
+        # on_failed) — so a paper in WB+ZFIN+FB corpora produces one PDFX
+        # run, not three. Per-source dedup inside process_single_reference
+        # additionally skips files already converted in earlier batch ticks.
+        from collections import defaultdict
+        jobs_by_reference: Dict[int, List[Dict]] = defaultdict(list)
+        for job in all_jobs:
+            jobs_by_reference[job['reference_id']].append(job)
+
         mod_abbreviation_from_mod_id: Dict[int, str] = {}
-        objects_with_errors = []
-        total_count = len(all_jobs)
+        objects_with_errors: List[Dict] = []
+        total_count = len(jobs_by_reference)
         success_count = 0
         failure_count = 0
         skipped_count = 0
-        ref_times = []
+        ref_times: List[float] = []
 
-        for idx, job in enumerate(all_jobs, 1):
+        def _mod_abbr(mod_id: int) -> str:
+            if mod_id not in mod_abbreviation_from_mod_id:
+                mod_abbreviation_from_mod_id[mod_id] = db.query(
+                    ModModel.abbreviation
+                ).filter(ModModel.mod_id == mod_id).one().abbreviation
+            return mod_abbreviation_from_mod_id[mod_id]
+
+        for idx, (ref_id, ref_jobs) in enumerate(jobs_by_reference.items(), 1):
             ref_start_time = time.time()
             error_msg: Optional[str] = None
+            reference_curie = ref_jobs[0]['reference_curie']
+            tag_ids = [j['reference_workflow_tag_id'] for j in ref_jobs]
+            ref_mod_abbrs = sorted({_mod_abbr(j['mod_id']) for j in ref_jobs})
 
-            ref_id = job['reference_id']
-            reference_workflow_tag_id = job['reference_workflow_tag_id']
-            mod_id = job['mod_id']
-            reference_curie = job['reference_curie']
+            logger.info(
+                f"Processing {idx}/{total_count}: {reference_curie} "
+                f"(MODs: {','.join(ref_mod_abbrs)}, jobs: {len(ref_jobs)})"
+            )
 
-            logger.info(f"Processing {idx}/{total_count}: {reference_curie}")
-
-            if mod_id not in mod_abbreviation_from_mod_id:
-                mod_abbreviation = db.query(ModModel.abbreviation).filter(
-                    ModModel.mod_id == mod_id
-                ).one().abbreviation
-                mod_abbreviation_from_mod_id[mod_id] = mod_abbreviation
-            else:
-                mod_abbreviation = mod_abbreviation_from_mod_id[mod_id]
-
+            # Use the first MOD's source resolution. That MOD's main PDF
+            # (if MOD-specific) drives display_name / file_extension; per-source
+            # dedup picks up files that any MOD added later via
+            # _resolve_workflow_ref_file_info is intentionally MOD-aware,
+            # mirroring the previous per-job behavior.
+            primary_mod = _mod_abbr(ref_jobs[0]['mod_id'])
             ref_file_info, resolve_error = _resolve_workflow_ref_file_info(
                 db=db,
                 ref_id=ref_id,
                 reference_curie=reference_curie,
-                mod_abbreviation=mod_abbreviation,
+                mod_abbreviation=primary_mod,
                 prefer_nxml=prefer_nxml
             )
 
             if ref_file_info is None:
                 skipped_count += 1
                 error_msg = resolve_error or "Could not resolve reference source file"
-                logger.warning(f"{error_msg} for {reference_curie}; marking job as failed")
-                job_change_atp_code(db, reference_workflow_tag_id, "on_failed")
+                logger.warning(f"{error_msg} for {reference_curie}; marking job(s) as failed")
+                for tag_id in tag_ids:
+                    job_change_atp_code(db, tag_id, "on_failed")
                 objects_with_errors.append(_build_workflow_error_record(
-                    db, reference_curie, "N/A", "N/A", mod_abbreviation, error_msg
+                    db, reference_curie, "N/A", "N/A", primary_mod, error_msg
                 ))
                 continue
 
@@ -881,17 +919,25 @@ def main(  # pragma: no cover
             ref_elapsed = time.time() - ref_start_time
             ref_times.append(ref_elapsed)
 
+            transition = "on_success" if success else "on_failed"
+            for tag_id in tag_ids:
+                job_change_atp_code(db, tag_id, transition)
+
             if success:
                 success_count += 1
-                job_change_atp_code(db, reference_workflow_tag_id, "on_success")
-                logger.info(f"Completed {reference_curie} in {ref_elapsed:.2f}s")
+                logger.info(
+                    f"Completed {reference_curie} in {ref_elapsed:.2f}s "
+                    f"({len(tag_ids)} workflow tag(s) → on_success)"
+                )
             else:
                 failure_count += 1
-                job_change_atp_code(db, reference_workflow_tag_id, "on_failed")
-                logger.error(f"Failed {reference_curie} after {ref_elapsed:.2f}s")
+                logger.error(
+                    f"Failed {reference_curie} after {ref_elapsed:.2f}s "
+                    f"({len(tag_ids)} workflow tag(s) → on_failed)"
+                )
                 objects_with_errors.append(_build_workflow_error_record(
                     db, reference_curie, display_name, file_extension,
-                    mod_abbreviation, error_msg or "Unknown"
+                    primary_mod, error_msg or "Unknown"
                 ))
 
         # Calculate timing statistics

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -85,6 +85,7 @@ def submit_pdf_to_pdfx(  # pragma: no cover
     retry_delay: int = 5,
     extract_images: bool = True,
     review_images: Optional[bool] = None,
+    clear_cache_scope: Optional[str] = "extraction",
 ) -> str:
     """
     Submit a PDF to the PDFX service for processing.
@@ -103,6 +104,12 @@ def submit_pdf_to_pdfx(  # pragma: no cover
         review_images: Optional override for the text-only LLM image review
             stage. When None, the PDFX default applies (review on when images
             are extracted). Pass False to skip the review stage explicitly.
+        clear_cache_scope: PDFX cache-clearing scope. Defaults to ``"extraction"``
+            so every submission re-runs the extractors and regenerates image
+            artifacts; this works around a server-side cache bug where a
+            stale image manifest can survive after the on-disk image files
+            have been TTL'd, producing silent zero-image results. Pass None
+            to omit the field and rely on PDFX's default behavior.
 
     Returns:
         str: The process_id for tracking the extraction job.
@@ -125,6 +132,8 @@ def submit_pdf_to_pdfx(  # pragma: no cover
     }
     if review_images is not None:
         data["review_images"] = str(review_images).lower()
+    if clear_cache_scope is not None:
+        data["clear_cache_scope"] = clear_cache_scope
 
     logger.info(f"Submitting PDF to PDFX for {reference_curie or 'unknown reference'}")
 

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -27,6 +27,8 @@ from agr_literature_service.api.crud.reference_utils import (
     get_reference,
 )
 from agr_literature_service.api.models import (
+    ModCorpusAssociationModel,
+    ModModel,
     ReferencefileModel,
     ReferenceModel,
 )
@@ -41,6 +43,34 @@ EXTRACTION_METHODS: Dict[str, str] = {
     "marker": "converted_marker_main",
     "merged": "converted_merged_main",
 }
+
+# MODs whose corpus membership makes a reference eligible for supplemental-PDF
+# conversion. Curating the supplements is expensive and only WB/ZFIN/FB
+# currently consume them, so all other references skip supplement conversion.
+ELIGIBLE_SUPPLEMENT_MODS: frozenset = frozenset({"WB", "ZFIN", "FB"})
+
+
+def is_eligible_for_supplement_conversion(db: Session, reference_id: int) -> bool:
+    """
+    Return True iff the reference is in corpus for at least one of the MODs
+    eligible for supplemental-PDF conversion (see ``ELIGIBLE_SUPPLEMENT_MODS``).
+
+    A reference is "in corpus" for a MOD when ``mod_corpus_association.corpus``
+    is True for that ``(reference_id, mod_id)`` pair. The check is at the
+    reference level — it does not depend on which MOD uploaded the supplement
+    PDFs themselves.
+    """
+    return (
+        db.query(ModCorpusAssociationModel)
+        .join(ModModel, ModModel.mod_id == ModCorpusAssociationModel.mod_id)
+        .filter(
+            ModCorpusAssociationModel.reference_id == reference_id,
+            ModCorpusAssociationModel.corpus.is_(True),
+            ModModel.abbreviation.in_(ELIGIBLE_SUPPLEMENT_MODS),
+        )
+        .first()
+        is not None
+    )
 
 
 class PdfDetail(TypedDict):
@@ -899,6 +929,14 @@ def process_supplemental_pdfs(  # pragma: no cover
     """
     if methods_to_extract is None:
         methods_to_extract = list(EXTRACTION_METHODS.keys())
+
+    if not is_eligible_for_supplement_conversion(db, reference_id):
+        logger.info(
+            f"Skipping supplemental PDF conversion for {reference_curie}: "
+            f"reference is not in corpus for any of "
+            f"{sorted(ELIGIBLE_SUPPLEMENT_MODS)}"
+        )
+        return 0, 0, []
 
     supplements = get_pdf_files_for_reference(db, reference_id, "supplement")
     if not supplements:

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -42,6 +42,15 @@ EXTRACTION_METHODS: Dict[str, str] = {
     "merged": "converted_merged_main",
 }
 
+# file_class assigned to figure images extracted from PDFs by PDFX/Marker,
+# parallel to the converted_*_main / converted_*_supplement Markdown classes.
+FIGURE_FILE_CLASSES: Dict[str, str] = {
+    "main": "converted_main_figure",
+    "supplement": "converted_supplement_figure",
+}
+# Marker emits .png; the manifest filenames also end in .png.
+CONVERTED_FIGURE_FILE_EXTENSION = "png"
+
 
 class PdfDetail(TypedDict):
     """Type for PDF processing detail."""
@@ -73,7 +82,9 @@ def submit_pdf_to_pdfx(  # pragma: no cover
     reference_curie: Optional[str] = None,
     mod_abbreviation: Optional[str] = None,
     max_retries: int = 3,
-    retry_delay: int = 5
+    retry_delay: int = 5,
+    extract_images: bool = True,
+    review_images: Optional[bool] = None,
 ) -> str:
     """
     Submit a PDF to the PDFX service for processing.
@@ -87,6 +98,11 @@ def submit_pdf_to_pdfx(  # pragma: no cover
         mod_abbreviation: Optional MOD abbreviation for logging.
         max_retries: Maximum number of retry attempts for transient failures.
         retry_delay: Delay between retries in seconds.
+        extract_images: Whether to ask PDFX to extract figure images via Marker.
+            Defaults to True so all conversions also produce image artifacts.
+        review_images: Optional override for the text-only LLM image review
+            stage. When None, the PDFX default applies (review on when images
+            are extracted). Pass False to skip the review stage explicitly.
 
     Returns:
         str: The process_id for tracking the extraction job.
@@ -104,8 +120,11 @@ def submit_pdf_to_pdfx(  # pragma: no cover
     # Prepare multipart form data
     data = {
         "methods": methods,
-        "merge": str(merge).lower()
+        "merge": str(merge).lower(),
+        "extract_images": str(extract_images).lower(),
     }
+    if review_images is not None:
+        data["review_images"] = str(review_images).lower()
 
     logger.info(f"Submitting PDF to PDFX for {reference_curie or 'unknown reference'}")
 
@@ -235,6 +254,167 @@ def download_pdfx_result(process_id: str, method: str, token: str) -> bytes:  # 
     response.raise_for_status()
 
     return response.content
+
+
+def download_pdfx_image_manifest(process_id: str, token: str) -> Dict:  # pragma: no cover
+    """
+    Fetch the image manifest produced by a PDFX extraction job.
+
+    Returns the parsed JSON payload from
+    ``/api/v1/extract/{process_id}/images/urls``. The payload's ``images``
+    list contains one entry per extracted image, each with a presigned ``url``
+    plus marker metadata (figure_label, figure_number, image_review_*, etc.).
+    The list will be empty when ``extract_images=true`` was not requested.
+    """
+    pdfx_api_url = os.environ.get("PDFX_API_URL", "https://pdfx.alliancegenome.org")
+    url = f"{pdfx_api_url}/api/v1/extract/{process_id}/images/urls"
+    headers = {"Authorization": f"Bearer {token}"}
+    response = requests.get(url, headers=headers, timeout=60)
+    response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"Unexpected manifest payload type for PDFX job {process_id}: "
+            f"{type(payload).__name__}"
+        )
+    return payload
+
+
+def download_pdfx_image(image_url: str) -> bytes:  # pragma: no cover
+    """
+    Download a single image artifact from a presigned S3 URL returned by
+    :func:`download_pdfx_image_manifest`.
+
+    No bearer token is needed — the URL is already pre-signed.
+    """
+    response = requests.get(image_url, timeout=60)
+    response.raise_for_status()
+    return response.content
+
+
+def process_extracted_images(  # pragma: no cover
+    db: Session,
+    process_id: str,
+    token: str,
+    source_display_name: str,
+    source_file_class: str,
+    reference_curie: str,
+    mod_abbreviation: Optional[str],
+) -> Tuple[int, int, List[str]]:
+    """
+    Fetch the PDFX image manifest for ``process_id`` and upload each image as
+    a referencefile under the dedicated figure file_class.
+
+    The output file_class is derived from the source PDF's file_class:
+    ``main`` → ``converted_main_figure`` and ``supplement`` →
+    ``converted_supplement_figure`` (see :data:`FIGURE_FILE_CLASSES`). Display
+    names follow the existing converted-output convention
+    ``{source_display_name}_{suffix}`` so each figure is grouped under its
+    source PDF in the UI; the suffix is ``image_{idx:03d}`` (1-indexed by
+    manifest order) so names stay stable, sortable, and unique within a
+    source PDF.
+
+    Returns ``(succeeded_count, failed_count, errors)``. Image-extraction
+    failures never raise — the caller's overall conversion still succeeds
+    based on the Markdown outputs.
+    """
+    figure_file_class = FIGURE_FILE_CLASSES.get(source_file_class)
+    if figure_file_class is None:
+        logger.warning(
+            f"No figure file_class mapping for source file_class "
+            f"'{source_file_class}'; skipping image extraction for "
+            f"{reference_curie}"
+        )
+        return 0, 0, []
+
+    try:
+        manifest = download_pdfx_image_manifest(process_id, token)
+    except Exception as e:
+        msg = f"Failed to fetch PDFX image manifest: {e}"
+        logger.warning(f"{msg} (process_id={process_id}, ref={reference_curie})")
+        return 0, 0, [msg]
+
+    images = manifest.get("images") or []
+    if not images:
+        logger.info(
+            f"No extracted images returned by PDFX for {reference_curie} "
+            f"({source_file_class} '{source_display_name}', process_id={process_id})"
+        )
+        return 0, 0, []
+
+    succeeded = 0
+    failed = 0
+    errors: List[str] = []
+
+    for idx, image in enumerate(images, start=1):
+        image_url = image.get("url")
+        if not image_url:
+            failed += 1
+            errors.append(f"image {idx}: manifest entry missing 'url'")
+            continue
+
+        # display_name: {source}_image_{idx:03d}, mirroring the {source}_{method}
+        # convention used for converted Markdown outputs. file_upload_single's
+        # find_first_available_display_name will append _N if needed for
+        # uniqueness within the reference.
+        output_display_name = f"{source_display_name}_image_{idx:03d}"
+
+        try:
+            image_bytes = download_pdfx_image(image_url)
+        except Exception as e:
+            failed += 1
+            errors.append(f"image {idx} ({output_display_name}): download failed: {e}")
+            logger.error(
+                f"Failed to download image {idx} for {reference_curie} "
+                f"({source_file_class} '{source_display_name}'): {e}"
+            )
+            continue
+
+        if not image_bytes:
+            failed += 1
+            errors.append(f"image {idx} ({output_display_name}): empty content")
+            continue
+
+        metadata = {
+            "reference_curie": reference_curie,
+            "display_name": output_display_name,
+            "file_class": figure_file_class,
+            "file_publication_status": "final",
+            "file_extension": CONVERTED_FIGURE_FILE_EXTENSION,
+            "pdf_type": None,
+            "is_annotation": None,
+            "mod_abbreviation": mod_abbreviation,
+        }
+
+        try:
+            file_upload(
+                db=db,
+                metadata=metadata,
+                file=UploadFile(
+                    file=BytesIO(image_bytes),
+                    filename=f"{output_display_name}.{CONVERTED_FIGURE_FILE_EXTENSION}",
+                ),
+                upload_if_already_converted=True,
+            )
+            succeeded += 1
+            logger.info(
+                f"Uploaded extracted figure for {reference_curie} as "
+                f"{figure_file_class} '{output_display_name}'"
+            )
+        except Exception as e:
+            failed += 1
+            errors.append(f"image {idx} ({output_display_name}): upload failed: {e}")
+            logger.error(
+                f"Failed to upload extracted image {idx} for {reference_curie}: {e}"
+            )
+
+    if succeeded or failed:
+        logger.info(
+            f"Image extraction for {reference_curie} "
+            f"({source_file_class} '{source_display_name}'): "
+            f"{succeeded} succeeded, {failed} failed"
+        )
+    return succeeded, failed, errors
 
 
 # Valid pdf_type values
@@ -526,18 +706,24 @@ def _process_single_pdf_file(  # pragma: no cover
     if not file_content:
         return False, [], "Failed to download PDF content"
 
-    # Determine which methods to request
+    # Determine which methods to request. Image extraction requires marker, so
+    # ensure it is in the request set whenever it would otherwise be omitted —
+    # we still only upload Markdown for the methods the caller asked for.
     request_methods = [m for m in methods_to_extract if m != "merged"]
     include_merge = "merged" in methods_to_extract
+    if "marker" not in request_methods:
+        request_methods.append("marker")
 
-    # Submit to PDFX
+    # Submit to PDFX with image extraction enabled (default), so the same job
+    # produces both Markdown and figure images in one PDFX run per source PDF.
     process_id = submit_pdf_to_pdfx(
         file_content=file_content,
         token=token,
-        methods=",".join(request_methods) if request_methods else "grobid,docling,marker",
+        methods=",".join(request_methods),
         merge=include_merge,
         reference_curie=reference_curie,
-        mod_abbreviation=mod_abbreviation
+        mod_abbreviation=mod_abbreviation,
+        extract_images=True,
     )
 
     # Poll for completion
@@ -588,6 +774,25 @@ def _process_single_pdf_file(  # pragma: no cover
 
         except Exception as e:
             logger.error(f"Failed to download/upload {method} for {reference_curie}: {e}")
+
+    # Always attempt image extraction after the Markdown outputs. Failures here
+    # are reported but do not flip the per-file success — the converted MD
+    # rows are the contract callers depend on.
+    try:
+        process_extracted_images(
+            db=db,
+            process_id=process_id,
+            token=token,
+            source_display_name=display_name,
+            source_file_class=file_class,
+            reference_curie=reference_curie,
+            mod_abbreviation=mod_abbreviation,
+        )
+    except Exception as e:
+        logger.error(
+            f"Unexpected error during image extraction for {reference_curie} "
+            f"({file_class} '{display_name}'): {e}"
+        )
 
     if successful_methods:
         logger.info(

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -82,6 +82,171 @@ def is_eligible_for_supplement_conversion(db: Session, reference_id: int) -> boo
     )
 
 
+# Suffixes appended to a source file's display_name when its converted
+# Markdown row is created. nXML conversions produce ``_nxml``; PDFX runs
+# produce ``_merged`` (the canonical "done" marker — the per-method rows
+# _grobid/_docling/_marker may or may not all be present, but a successful
+# conversion always writes the merged row). The legacy TEI->MD batch wrote
+# ``_tei``-suffixed rows; those still count as "converted" unless a caller
+# explicitly opts to overwrite them.
+_NXML_SUFFIX = "_nxml"
+_PDF_MERGED_SUFFIX = "_merged"
+_TEI_SUFFIX = "_tei"
+
+
+def _converted_main_suffixes(is_nxml: bool, ignore_tei_derived: bool) -> List[str]:
+    if is_nxml:
+        return [_NXML_SUFFIX]
+    suffixes = [_PDF_MERGED_SUFFIX]
+    if not ignore_tei_derived:
+        suffixes.append(_TEI_SUFFIX)
+    return suffixes
+
+
+def _converted_supplement_suffixes(ignore_tei_derived: bool) -> List[str]:
+    suffixes = [_PDF_MERGED_SUFFIX]
+    if not ignore_tei_derived:
+        suffixes.append(_TEI_SUFFIX)
+    return suffixes
+
+
+def is_main_source_converted(
+    db: Session,
+    reference_id: int,
+    source_display_name: str,
+    *,
+    is_nxml: bool,
+    ignore_tei_derived: bool = False,
+) -> bool:
+    """
+    Has the given main-side source file already produced a converted_merged_main
+    Markdown row? Matches by display_name suffix:
+    ``{source_display_name}_nxml`` for nXML sources, ``{source_display_name}_merged``
+    for main PDFs (plus legacy ``_tei`` rows unless ``ignore_tei_derived=True``).
+    """
+    expected_names = [
+        f"{source_display_name}{suffix}"
+        for suffix in _converted_main_suffixes(is_nxml, ignore_tei_derived)
+    ]
+    return (
+        db.query(ReferencefileModel)
+        .filter(
+            ReferencefileModel.reference_id == reference_id,
+            ReferencefileModel.file_class == "converted_merged_main",
+            ReferencefileModel.file_extension == "md",
+            ReferencefileModel.file_publication_status == "final",
+            ReferencefileModel.display_name.in_(expected_names),
+        )
+        .first()
+        is not None
+    )
+
+
+def is_supplement_source_converted(
+    db: Session,
+    reference_id: int,
+    source_display_name: str,
+    *,
+    ignore_tei_derived: bool = False,
+) -> bool:
+    """
+    Has the given supplement PDF already produced a converted_merged_supplement
+    Markdown row? Matches by display_name suffix ``_merged`` (plus legacy
+    ``_tei`` rows unless ``ignore_tei_derived=True``).
+    """
+    expected_names = [
+        f"{source_display_name}{suffix}"
+        for suffix in _converted_supplement_suffixes(ignore_tei_derived)
+    ]
+    return (
+        db.query(ReferencefileModel)
+        .filter(
+            ReferencefileModel.reference_id == reference_id,
+            ReferencefileModel.file_class == "converted_merged_supplement",
+            ReferencefileModel.file_extension == "md",
+            ReferencefileModel.file_publication_status == "final",
+            ReferencefileModel.display_name.in_(expected_names),
+        )
+        .first()
+        is not None
+    )
+
+
+class PendingMainSource(TypedDict):
+    """A main-side source file that still needs conversion."""
+    kind: Literal["nxml", "pdf"]
+    ref_file: ReferencefileModel
+
+
+def pending_main_sources(
+    db: Session,
+    reference_id: int,
+    prefer_nxml: bool = True,
+    ignore_tei_derived: bool = False,
+) -> List[PendingMainSource]:
+    """
+    Return the main-side source files for a reference whose converted
+    Markdown output is missing (and so still needs to be produced).
+
+    Per-source dedup: a source is "already converted" iff a
+    ``converted_merged_main`` row exists with the matching ``_nxml`` /
+    ``_merged`` display_name suffix (and ``_tei`` for legacy rows unless
+    ``ignore_tei_derived`` is True). This lets later batch ticks (or
+    later MOD workflow tags) pick up just the new sources, without
+    re-running PDFX/nXML on files that have already been processed.
+
+    When ``prefer_nxml`` is True (default) and an nXML source exists, it
+    is the only main source returned (its conversion is the canonical
+    main MD); main PDFs are returned only if no nXML is present. When
+    ``prefer_nxml`` is False, nXML is ignored and only pending main PDFs
+    are returned.
+    """
+    pending: List[PendingMainSource] = []
+
+    nxml = get_nxml_referencefile(db, reference_id) if prefer_nxml else None
+    if nxml is not None:
+        if not is_main_source_converted(
+            db, reference_id, nxml.display_name,
+            is_nxml=True, ignore_tei_derived=ignore_tei_derived,
+        ):
+            pending.append({"kind": "nxml", "ref_file": nxml})
+        # nXML present (converted or pending) — by convention we don't ALSO
+        # convert main PDFs when nXML is the chosen source for this reference.
+        return pending
+
+    for pdf in get_pdf_files_for_reference(db, reference_id, "main"):
+        if not is_main_source_converted(
+            db, reference_id, pdf.display_name,
+            is_nxml=False, ignore_tei_derived=ignore_tei_derived,
+        ):
+            pending.append({"kind": "pdf", "ref_file": pdf})
+    return pending
+
+
+def pending_supplement_sources(
+    db: Session,
+    reference_id: int,
+    ignore_tei_derived: bool = False,
+) -> List[ReferencefileModel]:
+    """
+    Return the supplement PDFs for a reference whose
+    ``converted_merged_supplement`` output is missing.
+
+    Per-source dedup so a later batch tick (or a later MOD's
+    "conversion needed" tag) only processes supplements that haven't been
+    converted yet — supplements MOD A converted in an earlier run are
+    skipped, supplements MOD B added later are picked up.
+    """
+    pending: List[ReferencefileModel] = []
+    for supp in get_pdf_files_for_reference(db, reference_id, "supplement"):
+        if not is_supplement_source_converted(
+            db, reference_id, supp.display_name,
+            ignore_tei_derived=ignore_tei_derived,
+        ):
+            pending.append(supp)
+    return pending
+
+
 class PdfDetail(TypedDict):
     """Type for PDF processing detail."""
     referencefile_id: int
@@ -1152,19 +1317,29 @@ def process_supplemental_pdfs(  # pragma: no cover
         )
         return 0, 0, []
 
-    supplements = get_pdf_files_for_reference(db, reference_id, "supplement")
-    if not supplements:
+    # Per-source dedup: only process supplements whose converted_merged_supplement
+    # output is missing. Already-converted supplements (e.g., processed in an
+    # earlier batch run for a different MOD) are skipped so we don't burn
+    # PDFX time re-running them.
+    pending = pending_supplement_sources(db, reference_id)
+    if not pending:
+        all_supplements = get_pdf_files_for_reference(db, reference_id, "supplement")
+        if all_supplements:
+            logger.info(
+                f"All {len(all_supplements)} supplemental PDF(s) for "
+                f"{reference_curie} already converted; nothing to do"
+            )
         return 0, 0, []
 
     logger.info(
-        f"Processing {len(supplements)} supplemental PDF(s) for {reference_curie}"
+        f"Processing {len(pending)} pending supplemental PDF(s) for {reference_curie}"
     )
 
     succeeded = 0
     failed = 0
     errors: List[str] = []
 
-    for pdf_file in supplements:
+    for pdf_file in pending:
         try:
             success, _methods, error = _process_single_pdf_file(
                 db=db,

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -253,6 +253,99 @@ def pending_main_sources(
     return pending
 
 
+_SOURCE_SUFFIXES = (
+    _NXML_SUFFIX,
+    _PDF_MERGED_SUFFIX,
+    _TEI_SUFFIX,
+    "_grobid",
+    "_docling",
+    "_marker",
+)
+
+
+def find_source_for_converted(
+    reference: ReferenceModel,
+    converted_display_name: str,
+    converted_file_class: str,
+) -> Optional[ReferencefileModel]:
+    """
+    Given a ``converted_*_main`` / ``converted_*_supplement`` Markdown row,
+    return the source ReferencefileModel it was produced from (or None if
+    the source can't be identified).
+
+    Uses the display_name suffix convention written by the conversion
+    helpers: ``{source}_{nxml|merged|tei|grobid|docling|marker}``.
+    """
+    base: Optional[str] = None
+    for suffix in _SOURCE_SUFFIXES:
+        if converted_display_name.endswith(suffix):
+            base = converted_display_name[: -len(suffix)]
+            break
+    if base is None:
+        return None
+
+    nxml_suffix_used = converted_display_name.endswith(_NXML_SUFFIX)
+    if converted_file_class.endswith("_main"):
+        source_class = "nXML" if nxml_suffix_used else "main"
+    elif converted_file_class.endswith("_supplement"):
+        source_class = "supplement"
+    else:
+        return None
+
+    for ref_file in reference.referencefiles or []:
+        if ref_file.file_class == source_class and ref_file.display_name == base:
+            return ref_file
+    return None
+
+
+def sync_converted_file_mods_to_sources(
+    db: Session,
+    reference: ReferenceModel,
+) -> int:
+    """
+    For each converted Markdown row of this reference, ensure its
+    ``referencefile_mod`` associations include every association the source
+    file has. Idempotent: only ADDS missing associations; never removes.
+
+    Returns the number of associations added (0 when everything is
+    already in sync).
+
+    SCRUM-6041: when a MOD-specific batch run converts a shared file,
+    the converted output is initially associated only with that one MOD.
+    A subsequent on-demand call can use this helper to make the converted
+    output also visible to every other MOD whose source file the same
+    reference points at — including null-mod (PMC, open-access) sources.
+    """
+    from agr_literature_service.api.models.referencefile_model import (
+        ReferencefileModAssociationModel,
+    )
+    added = 0
+    for ref_file in reference.referencefiles or []:
+        fc = ref_file.file_class or ""
+        if not fc.startswith("converted_"):
+            continue
+        if ref_file.file_extension != "md":
+            continue
+        if not (fc.endswith("_main") or fc.endswith("_supplement")):
+            continue
+        source = find_source_for_converted(
+            reference, ref_file.display_name or "", fc,
+        )
+        if source is None:
+            continue
+        target_mod_ids = {a.mod_id for a in (ref_file.referencefile_mods or [])}
+        source_mod_ids = {a.mod_id for a in (source.referencefile_mods or [])}
+        for missing_mod_id in source_mod_ids - target_mod_ids:
+            db.add(ReferencefileModAssociationModel(
+                referencefile_id=ref_file.referencefile_id,
+                mod_id=missing_mod_id,
+            ))
+            added += 1
+    if added:
+        db.commit()
+    return added
+
+
 def pending_supplement_sources(
     db: Session,
     reference_id: int,

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -178,11 +178,33 @@ class PendingMainSource(TypedDict):
     ref_file: ReferencefileModel
 
 
+def _file_is_for_mod(
+    ref_file: ReferencefileModel, mod_abbreviation: Optional[str]
+) -> bool:
+    """
+    True iff ``ref_file`` should be considered owned by ``mod_abbreviation``.
+
+    A MOD owns a referencefile iff there is a ``referencefile_mod`` row
+    associating the file with that MOD, OR the file has at least one
+    referencefile_mod row with ``mod_id IS NULL`` (shared / PMC).
+    Pass ``mod_abbreviation=None`` to disable the filter (any file matches).
+    """
+    if mod_abbreviation is None:
+        return True
+    for ref_file_mod in ref_file.referencefile_mods or []:
+        if ref_file_mod.mod is None:
+            return True
+        if ref_file_mod.mod.abbreviation == mod_abbreviation:
+            return True
+    return False
+
+
 def pending_main_sources(
     db: Session,
     reference_id: int,
     prefer_nxml: bool = True,
     ignore_tei_derived: bool = False,
+    mod_abbreviation: Optional[str] = None,
 ) -> List[PendingMainSource]:
     """
     Return the main-side source files for a reference whose converted
@@ -200,11 +222,17 @@ def pending_main_sources(
     main MD); main PDFs are returned only if no nXML is present. When
     ``prefer_nxml`` is False, nXML is ignored and only pending main PDFs
     are returned.
+
+    When ``mod_abbreviation`` is provided, only main PDFs associated with
+    that MOD (or shared / null-mod files) are considered; other MODs'
+    MOD-specific PDFs are excluded so each MOD's text_convert_job only
+    processes its own files. ``mod_abbreviation=None`` disables the
+    filter (any file is eligible).
     """
     pending: List[PendingMainSource] = []
 
     nxml = get_nxml_referencefile(db, reference_id) if prefer_nxml else None
-    if nxml is not None:
+    if nxml is not None and _file_is_for_mod(nxml, mod_abbreviation):
         if not is_main_source_converted(
             db, reference_id, nxml.display_name,
             is_nxml=True, ignore_tei_derived=ignore_tei_derived,
@@ -215,6 +243,8 @@ def pending_main_sources(
         return pending
 
     for pdf in get_pdf_files_for_reference(db, reference_id, "main"):
+        if not _file_is_for_mod(pdf, mod_abbreviation):
+            continue
         if not is_main_source_converted(
             db, reference_id, pdf.display_name,
             is_nxml=False, ignore_tei_derived=ignore_tei_derived,
@@ -227,6 +257,7 @@ def pending_supplement_sources(
     db: Session,
     reference_id: int,
     ignore_tei_derived: bool = False,
+    mod_abbreviation: Optional[str] = None,
 ) -> List[ReferencefileModel]:
     """
     Return the supplement PDFs for a reference whose
@@ -236,9 +267,16 @@ def pending_supplement_sources(
     "conversion needed" tag) only processes supplements that haven't been
     converted yet — supplements MOD A converted in an earlier run are
     skipped, supplements MOD B added later are picked up.
+
+    When ``mod_abbreviation`` is provided, only supplements associated
+    with that MOD (or shared / null-mod files) are returned, so each
+    MOD's text_convert_job only processes its own supplements.
+    ``mod_abbreviation=None`` disables the filter (any file is eligible).
     """
     pending: List[ReferencefileModel] = []
     for supp in get_pdf_files_for_reference(db, reference_id, "supplement"):
+        if not _file_is_for_mod(supp, mod_abbreviation):
+            continue
         if not is_supplement_source_converted(
             db, reference_id, supp.display_name,
             ignore_tei_derived=ignore_tei_derived,
@@ -1287,10 +1325,11 @@ def process_supplemental_pdfs(  # pragma: no cover
     reference_id: int,
     reference_curie: str,
     token: str,
-    methods_to_extract: Optional[List[str]] = None
+    methods_to_extract: Optional[List[str]] = None,
+    mod_abbreviation: Optional[str] = None,
 ) -> Tuple[int, int, List[str]]:
     """
-    Convert all supplemental PDFs for a reference to Markdown via PDFX.
+    Convert supplemental PDFs for a reference to Markdown via PDFX.
 
     Uses the existing per-PDF helper (_process_single_pdf_file), which already
     handles supplement file_class naming ('converted_{method}_supplement').
@@ -1301,6 +1340,11 @@ def process_supplemental_pdfs(  # pragma: no cover
         reference_curie: The reference curie for metadata/logging.
         token: PDFX bearer token.
         methods_to_extract: List of methods to extract (default: all).
+        mod_abbreviation: When provided, only supplements associated with
+            this MOD (or shared / null-mod ones) are processed — each MOD's
+            text_convert_job is responsible only for its own supplements.
+            ``None`` (the default) processes every supplement, used by
+            bulk-mode entry points that have no MOD context.
 
     Returns:
         Tuple of (succeeded_count, failed_count, per_supplement_errors). Each
@@ -1320,14 +1364,22 @@ def process_supplemental_pdfs(  # pragma: no cover
     # Per-source dedup: only process supplements whose converted_merged_supplement
     # output is missing. Already-converted supplements (e.g., processed in an
     # earlier batch run for a different MOD) are skipped so we don't burn
-    # PDFX time re-running them.
-    pending = pending_supplement_sources(db, reference_id)
+    # PDFX time re-running them. With mod_abbreviation set, also skip
+    # supplements that don't belong to this MOD.
+    pending = pending_supplement_sources(
+        db, reference_id, mod_abbreviation=mod_abbreviation
+    )
     if not pending:
         all_supplements = get_pdf_files_for_reference(db, reference_id, "supplement")
         if all_supplements:
+            scope = (
+                f"for {mod_abbreviation}"
+                if mod_abbreviation
+                else "across all MODs"
+            )
             logger.info(
-                f"All {len(all_supplements)} supplemental PDF(s) for "
-                f"{reference_curie} already converted; nothing to do"
+                f"All eligible supplemental PDF(s) for {reference_curie} "
+                f"({scope}) already converted; nothing to do"
             )
         return 0, 0, []
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -127,6 +127,7 @@ services:
       REPLY_TO: "${REPLY_TO}"
       ATEAM_API_URL: "${ATEAM_API_URL}"
       SGD_API_URL: "${SGD_API_URL}"
+      PDFX_API_URL: "${PDFX_API_URL}"
       GUNICORN_WORKERS: "${GUNICORN_WORKERS:-4}"  # Number of worker processes (default: 4)
       LOG_LEVEL: "${LOG_LEVEL:-info}"  # Gunicorn log level (default: info)
       DEBEZIUM_STATUS_PATH: "${DEBEZIUM_STATUS_PATH:-/var/lib/debezium_status}"
@@ -247,6 +248,7 @@ services:
       DEBEZIUM_KSQLDB_PORT: "${DEBEZIUM_KSQLDB_PORT}"
       TZ: "UTC"
       PDF2TEI_API_URL: "${PDF2TEI_API_URL}"
+      PDFX_API_URL: "${PDFX_API_URL}"
       SGD_API_URL: "${SGD_API_URL}"
       PERSISTENT_STORE_DB_USERNAME: "${PERSISTENT_STORE_DB_USERNAME}"
       PERSISTENT_STORE_DB_PASSWORD: "${PERSISTENT_STORE_DB_PASSWORD}"
@@ -329,6 +331,7 @@ services:
       ENV_STATE: "${ENV_STATE}"
       ID_MATI_URL: "${ID_MATI_URL}"
       ATEAM_API_URL: "${ATEAM_API_URL}"
+      PDFX_API_URL: "${PDFX_API_URL}"
       PSQL_USERNAME: "${PSQL_USERNAME}"
       PSQL_PASSWORD: "${PSQL_PASSWORD}"
       PSQL_HOST: "${PSQL_HOST}"

--- a/tests/api/test_file_conversion.py
+++ b/tests/api/test_file_conversion.py
@@ -137,6 +137,150 @@ class TestConversionJobManager:
 
 
 # ---------------------------------------------------------------------------
+# Unit tests for the figures-in-response helpers (no DB, no HTTP)
+# ---------------------------------------------------------------------------
+
+class TestFiguresHelpers:
+    """Tests for _figures_for_source and _attach_figures.
+
+    These verify that extracted-figure rows in the DB are surfaced under the
+    correct per-file-progress entry in the conversion_request response,
+    grouped by their source PDF's display_name and file_class.
+    """
+
+    @staticmethod
+    def _make_ref_file(file_class, display_name, referencefile_id,
+                       file_extension="png", file_publication_status="final"):
+        from unittest.mock import MagicMock
+        rf = MagicMock()
+        rf.file_class = file_class
+        rf.display_name = display_name
+        rf.referencefile_id = referencefile_id
+        rf.file_extension = file_extension
+        rf.file_publication_status = file_publication_status
+        return rf
+
+    def _make_reference(self, ref_files):
+        from unittest.mock import MagicMock
+        ref = MagicMock()
+        ref.referencefiles = ref_files
+        return ref
+
+    def test_figures_for_source_returns_matching_rows_sorted(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        # Two figures for "paper" (main), plus an unrelated supp figure and
+        # a different paper's figure that must be excluded.
+        rfs = [
+            self._make_ref_file("converted_main_figure", "paper_image_002", 11),
+            self._make_ref_file("converted_main_figure", "paper_image_001", 10),
+            self._make_ref_file("converted_supplement_figure", "supp_image_001", 20),
+            self._make_ref_file("converted_main_figure", "other_image_001", 30),
+        ]
+        result = _figures_for_source(self._make_reference(rfs), "paper", "main")
+        # Sorted by display_name; only main-class figures whose name has the
+        # 'paper_image_' prefix.
+        assert [r["display_name"] for r in result] == ["paper_image_001", "paper_image_002"]
+        assert [r["referencefile_id"] for r in result] == [10, 11]
+        assert all(r["file_class"] == "converted_main_figure" for r in result)
+
+    def test_figures_for_source_supplement_uses_supplement_class(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        rfs = [
+            self._make_ref_file("converted_supplement_figure", "supp1_image_001", 1),
+            self._make_ref_file("converted_main_figure", "supp1_image_002", 2),
+        ]
+        result = _figures_for_source(self._make_reference(rfs), "supp1", "supplement")
+        assert [r["referencefile_id"] for r in result] == [1]
+
+    def test_figures_for_source_skips_non_final_rows(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        rfs = [
+            self._make_ref_file("converted_main_figure", "paper_image_001", 1,
+                                file_publication_status="temp"),
+            self._make_ref_file("converted_main_figure", "paper_image_002", 2),
+        ]
+        result = _figures_for_source(self._make_reference(rfs), "paper", "main")
+        assert [r["referencefile_id"] for r in result] == [2]
+
+    def test_figures_for_source_unknown_file_class_returns_empty(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        rfs = [self._make_ref_file("converted_main_figure", "paper_image_001", 1)]
+        # nXML / tei / unknown source classes have no figure mapping.
+        assert _figures_for_source(self._make_reference(rfs), "paper", "nXML") == []
+        assert _figures_for_source(self._make_reference(rfs), "paper", None) == []
+        assert _figures_for_source(self._make_reference(rfs), None, "main") == []
+
+    def test_figures_for_source_no_referencefiles_returns_empty(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        ref = self._make_reference([])
+        assert _figures_for_source(ref, "paper", "main") == []
+
+    def test_attach_figures_mutates_each_progress_entry(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _attach_figures,
+        )
+        rfs = [
+            self._make_ref_file("converted_main_figure", "paper_image_001", 100),
+            self._make_ref_file("converted_supplement_figure", "supp_image_001", 200),
+            self._make_ref_file("converted_supplement_figure", "supp_image_002", 201),
+        ]
+        progress = [
+            {
+                "source": {"display_name": "paper", "file_class": "main",
+                           "referencefile_id": 1},
+                "converted": {"display_name": "paper_merged",
+                              "file_class": "converted_merged_main",
+                              "referencefile_id": 50},
+                "figures": [],
+                "status": "success",
+                "error": None,
+            },
+            {
+                "source": {"display_name": "supp", "file_class": "supplement",
+                           "referencefile_id": 2},
+                "converted": {"display_name": "supp_merged",
+                              "file_class": "converted_merged_supplement",
+                              "referencefile_id": 51},
+                "figures": [],
+                "status": "success",
+                "error": None,
+            },
+        ]
+        _attach_figures(self._make_reference(rfs), progress)
+        assert [f["referencefile_id"] for f in progress[0]["figures"]] == [100]
+        assert [f["referencefile_id"] for f in progress[1]["figures"]] == [200, 201]
+
+    def test_attach_figures_handles_entries_with_null_source(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _attach_figures,
+        )
+        rfs = [self._make_ref_file("converted_main_figure", "paper_image_001", 1)]
+        progress = [
+            {
+                "source": None,
+                "converted": {"display_name": "orphan_merged",
+                              "file_class": "converted_merged_main",
+                              "referencefile_id": 7},
+                "figures": [],
+                "status": "success",
+                "error": None,
+            },
+        ]
+        _attach_figures(self._make_reference(rfs), progress)
+        assert progress[0]["figures"] == []
+
+
+# ---------------------------------------------------------------------------
 # Integration tests for the /converted and /conversion_status endpoints
 # ---------------------------------------------------------------------------
 

--- a/tests/api/test_file_conversion.py
+++ b/tests/api/test_file_conversion.py
@@ -432,7 +432,15 @@ class TestConvertedEndpoint:
         _make_referencefile(db, test_reference.new_ref_curie, "paper_supp",
                             "supplement", "pdf", "md5_partial_supp_pdf")
 
+        # SCRUM-6026: supplement conversion only runs for refs in corpus for
+        # WB/ZFIN/FB. This test asserts the endpoint behavior when supplement
+        # conversion is in flight, so make the eligibility helper return True
+        # (eligibility itself is unit-tested in test_pdf2md_utils.py).
         with patch(
+            "agr_literature_service.api.crud.file_conversion_crud."
+            "is_eligible_for_supplement_conversion",
+            return_value=True,
+        ), patch(
             "agr_literature_service.api.crud.file_conversion_crud.run_conversion_job",
             return_value=None,
         ):

--- a/tests/lit_processing/pdf2md/test_pdf2md.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md.py
@@ -185,6 +185,8 @@ class TestProcessSingleReference:
             "mod_abbreviation": "WB"
         }
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
@@ -195,7 +197,7 @@ class TestProcessSingleReference:
     def test_nxml_preferred_pdfx_skipped(
         self,
         mock_download, mock_submit, mock_poll, mock_download_result,
-        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted,
     ):
         """nXML present -> convert via nXML path, skip PDFX for main."""
         mock_db = MagicMock()
@@ -216,6 +218,8 @@ class TestProcessSingleReference:
         mock_download_result.assert_not_called()
         mock_process_supps.assert_called_once()
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
@@ -226,7 +230,7 @@ class TestProcessSingleReference:
     def test_no_nxml_falls_back_to_pdfx(
         self,
         mock_download, mock_submit, mock_poll, mock_download_result,
-        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted,
     ):
         """No nXML -> PDFX path runs for main, supplements still processed."""
         mock_db = MagicMock()
@@ -252,6 +256,8 @@ class TestProcessSingleReference:
             assert mock_upload.call_count == len(EXTRACTION_METHODS)
             mock_process_supps.assert_called_once()
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
@@ -262,7 +268,7 @@ class TestProcessSingleReference:
     def test_nxml_failure_falls_back_to_pdfx(
         self,
         mock_download, mock_submit, mock_poll, mock_download_result,
-        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted,
     ):
         """nXML present but conversion fails -> fall back to PDFX."""
         mock_db = MagicMock()
@@ -287,12 +293,15 @@ class TestProcessSingleReference:
             mock_submit.assert_called_once()
             assert mock_upload.call_count == len(EXTRACTION_METHODS)
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.download_file")
     def test_handles_download_exception(
-        self, mock_download, mock_get_nxml, mock_nxml_convert, mock_process_supps
+        self, mock_download, mock_get_nxml, mock_nxml_convert, mock_process_supps,
+        mock_main_converted,
     ):
         """PDFX download exception -> failure returned with message."""
         mock_db = MagicMock()
@@ -307,6 +316,8 @@ class TestProcessSingleReference:
         assert success is False
         assert "Download failed" in error
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
@@ -317,7 +328,7 @@ class TestProcessSingleReference:
     def test_returns_failure_when_no_methods_succeed(
         self,
         mock_download, mock_submit, mock_poll, mock_download_result,
-        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted,
     ):
         """All PDFX methods empty -> failure returned."""
         mock_db = MagicMock()
@@ -335,6 +346,8 @@ class TestProcessSingleReference:
         assert success is False
         assert "No methods successfully extracted" in error
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
@@ -345,7 +358,7 @@ class TestProcessSingleReference:
     def test_processes_specific_methods(
         self,
         mock_download, mock_submit, mock_poll, mock_download_result,
-        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted,
     ):
         """Only specified methods are processed."""
         mock_db = MagicMock()
@@ -373,11 +386,13 @@ class TestProcessSingleReference:
             _args, kwargs = mock_process_supps.call_args
             assert kwargs["methods_to_extract"] == ["grobid", "docling"]
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
     def test_supplement_failures_do_not_fail_reference(
-        self, mock_get_nxml, mock_nxml_convert, mock_process_supps
+        self, mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted
     ):
         """Supplement failures are logged but don't fail the reference."""
         mock_db = MagicMock()
@@ -392,11 +407,13 @@ class TestProcessSingleReference:
         assert success is True
         assert error is None
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
     def test_nxml_only_no_main_pdf_succeeds(
-        self, mock_get_nxml, mock_nxml_convert, mock_process_supps
+        self, mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted
     ):
         """Reference with nXML but no main PDF succeeds via nXML path."""
         mock_db = MagicMock()
@@ -412,11 +429,13 @@ class TestProcessSingleReference:
         assert success is True
         assert error is None
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
     def test_no_nxml_and_no_main_pdf_fails(
-        self, mock_get_nxml, mock_nxml_convert, mock_process_supps
+        self, mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted
     ):
         """Reference with neither nXML nor main PDF fails."""
         mock_db = MagicMock()
@@ -431,6 +450,8 @@ class TestProcessSingleReference:
         assert success is False
         assert "no main PDF available" in error
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
@@ -441,7 +462,7 @@ class TestProcessSingleReference:
     def test_prefer_nxml_false_forces_pdfx(
         self,
         mock_download, mock_submit, mock_poll, mock_download_result,
-        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted,
     ):
         """prefer_nxml=False skips nXML lookup and always uses PDFX."""
         mock_db = MagicMock()
@@ -465,11 +486,13 @@ class TestProcessSingleReference:
             mock_nxml_convert.assert_not_called()
             mock_submit.assert_called_once()
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
     def test_process_supplements_false_skips_supplements(
-        self, mock_get_nxml, mock_nxml_convert, mock_process_supps
+        self, mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted
     ):
         """process_supplements=False skips supplement processing entirely."""
         mock_db = MagicMock()
@@ -485,6 +508,8 @@ class TestProcessSingleReference:
         assert error is None
         mock_process_supps.assert_not_called()
 
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.is_main_source_converted",
+           return_value=False)
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_supplemental_pdfs")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.process_nxml_to_markdown")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md.get_nxml_referencefile")
@@ -495,7 +520,7 @@ class TestProcessSingleReference:
     def test_both_flags_false(
         self,
         mock_download, mock_submit, mock_poll, mock_download_result,
-        mock_get_nxml, mock_nxml_convert, mock_process_supps,
+        mock_get_nxml, mock_nxml_convert, mock_process_supps, mock_main_converted,
     ):
         """Both flags False -> PDFX only on main, no supplements, no nXML lookup."""
         mock_db = MagicMock()

--- a/tests/lit_processing/pdf2md/test_pdf2md_utils.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md_utils.py
@@ -15,12 +15,14 @@ import pytest
 import requests
 
 from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+    ELIGIBLE_SUPPLEMENT_MODS,
     EXTRACTION_METHODS,
     PdfDetail,
     ProcessingResult,
     submit_pdf_to_pdfx,
     poll_pdfx_status,
     download_pdfx_result,
+    is_eligible_for_supplement_conversion,
     resolve_curie_to_reference,
     get_pdf_files_for_reference,
     get_nxml_referencefile,
@@ -528,3 +530,59 @@ class TestProcessSupplementalPdfs:
         assert failed == 1
         assert len(errors) == 1
         assert "boom" in errors[0]
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils._process_single_pdf_file")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils."
+           "is_eligible_for_supplement_conversion")
+    def test_skips_when_reference_not_eligible(
+        self, mock_eligible, mock_get_pdfs, mock_process
+    ):
+        """Ineligible references early-return without consulting supplement
+        PDFs or processing anything."""
+        mock_eligible.return_value = False
+
+        succeeded, failed, errors = process_supplemental_pdfs(
+            db=MagicMock(),
+            reference_id=42,
+            reference_curie="AGRKB:1",
+            token="t"
+        )
+
+        assert (succeeded, failed, errors) == (0, 0, [])
+        # Critical: the eligibility check happens BEFORE any DB / PDFX work.
+        mock_get_pdfs.assert_not_called()
+        mock_process.assert_not_called()
+
+
+class TestEligibleSupplementMods:
+    """Tests for the supplement-conversion eligibility helper."""
+
+    def test_constant_contains_expected_mods(self):
+        assert ELIGIBLE_SUPPLEMENT_MODS == frozenset({"WB", "ZFIN", "FB"})
+
+    def _build_query_chain(self, first_result):
+        """Build a MagicMock chain that mimics
+        db.query(...).join(...).filter(...).first() -> first_result."""
+        mock_db = MagicMock()
+        chain = MagicMock()
+        mock_db.query.return_value = chain
+        chain.join.return_value = chain
+        chain.filter.return_value = chain
+        chain.first.return_value = first_result
+        return mock_db, chain
+
+    def test_returns_true_when_corpus_row_exists(self):
+        """A non-None .first() result -> eligible."""
+        mock_db, chain = self._build_query_chain(first_result=MagicMock())
+        assert is_eligible_for_supplement_conversion(mock_db, 42) is True
+        # Sanity: the chain went query -> join -> filter -> first.
+        assert mock_db.query.call_count == 1
+        assert chain.join.call_count == 1
+        assert chain.filter.call_count == 1
+        assert chain.first.call_count == 1
+
+    def test_returns_false_when_no_corpus_row(self):
+        """A None .first() result -> not eligible."""
+        mock_db, _ = self._build_query_chain(first_result=None)
+        assert is_eligible_for_supplement_conversion(mock_db, 42) is False

--- a/tests/lit_processing/pdf2md/test_pdf2md_utils.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md_utils.py
@@ -107,6 +107,9 @@ class TestSubmitPdfToPdfx:
         assert sent_data["extract_images"] == "true"
         # review_images is omitted unless the caller overrides it (server default is on).
         assert "review_images" not in sent_data
+        # clear_cache_scope defaults to "extraction" so a stale server-side
+        # image manifest can't silently produce zero-image results.
+        assert sent_data["clear_cache_scope"] == "extraction"
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.requests.post")
     def test_extract_images_can_be_disabled(self, mock_post):
@@ -126,6 +129,23 @@ class TestSubmitPdfToPdfx:
         sent_data = mock_post.call_args.kwargs["data"]
         assert sent_data["extract_images"] == "false"
         assert sent_data["review_images"] == "false"
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.requests.post")
+    def test_clear_cache_scope_can_be_disabled(self, mock_post):
+        """Passing clear_cache_scope=None omits the field entirely."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"process_id": "abc123"}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        submit_pdf_to_pdfx(
+            file_content=b"pdf_content",
+            token="test_token",
+            clear_cache_scope=None,
+        )
+
+        sent_data = mock_post.call_args.kwargs["data"]
+        assert "clear_cache_scope" not in sent_data
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.requests.post")
     def test_raises_error_when_no_process_id(self, mock_post):

--- a/tests/lit_processing/pdf2md/test_pdf2md_utils.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md_utils.py
@@ -1115,3 +1115,102 @@ class TestPendingSupplementSources:
         mock_pdfs.return_value = [s1]
         mock_converted.return_value = True
         assert pending_supplement_sources(MagicMock(), 42) == []
+
+
+def _supp_for_mods(display_name: str, mods):
+    """Build a supplement ReferencefileModel mock with the given mod
+    associations. ``mods`` is a list where each entry is either a MOD
+    abbreviation string or None for a null-mod (PMC) association.
+    """
+    supp = MagicMock(display_name=display_name)
+    rf_mods = []
+    for mod_abbr in mods:
+        rf_mod = MagicMock()
+        if mod_abbr is None:
+            rf_mod.mod = None
+        else:
+            rf_mod.mod = MagicMock(abbreviation=mod_abbr)
+        rf_mods.append(rf_mod)
+    supp.referencefile_mods = rf_mods
+    return supp
+
+
+class TestFileIsForMod:
+    """Tests for the per-MOD eligibility filter used by pending_*_sources."""
+
+    def test_no_mod_filter_matches_anything(self):
+        from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+            _file_is_for_mod,
+        )
+        f = _supp_for_mods("x", ["WB"])
+        assert _file_is_for_mod(f, mod_abbreviation=None) is True
+
+    def test_matching_mod_is_eligible(self):
+        from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+            _file_is_for_mod,
+        )
+        f = _supp_for_mods("x", ["WB", "ZFIN"])
+        assert _file_is_for_mod(f, mod_abbreviation="WB") is True
+        assert _file_is_for_mod(f, mod_abbreviation="ZFIN") is True
+
+    def test_non_matching_mod_is_not_eligible(self):
+        from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+            _file_is_for_mod,
+        )
+        f = _supp_for_mods("x", ["WB"])
+        assert _file_is_for_mod(f, mod_abbreviation="ZFIN") is False
+
+    def test_null_mod_file_is_eligible_for_any_mod(self):
+        """Files with at least one mod_id IS NULL association (PMC/shared)
+        are eligible for every MOD's job."""
+        from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+            _file_is_for_mod,
+        )
+        f = _supp_for_mods("x", [None])
+        assert _file_is_for_mod(f, mod_abbreviation="WB") is True
+        assert _file_is_for_mod(f, mod_abbreviation="ZFIN") is True
+
+    def test_null_mod_plus_specific_mod(self):
+        """A file with both null and specific associations is eligible for
+        the matching MOD AND any MOD via the null association."""
+        from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+            _file_is_for_mod,
+        )
+        f = _supp_for_mods("x", [None, "WB"])
+        assert _file_is_for_mod(f, mod_abbreviation="WB") is True
+        assert _file_is_for_mod(f, mod_abbreviation="ZFIN") is True
+
+
+class TestPendingSupplementSourcesModFilter:
+    """Tests for the mod_abbreviation filter on pending_supplement_sources."""
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_supplement_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_filters_to_mod_eligible_when_mod_provided(
+        self, mock_pdfs, mock_converted
+    ):
+        wb_supp = _supp_for_mods("wb_only", ["WB"])
+        zfin_supp = _supp_for_mods("zfin_only", ["ZFIN"])
+        shared = _supp_for_mods("shared", [None])
+        mock_pdfs.return_value = [wb_supp, zfin_supp, shared]
+        mock_converted.return_value = False  # nothing converted yet
+
+        wb_pending = pending_supplement_sources(
+            MagicMock(), 42, mod_abbreviation="WB"
+        )
+        # WB sees its own + the shared null-mod, but NOT ZFIN-only
+        assert {p.display_name for p in wb_pending} == {"wb_only", "shared"}
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_supplement_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_no_mod_filter_returns_all(self, mock_pdfs, mock_converted):
+        wb_supp = _supp_for_mods("wb_only", ["WB"])
+        zfin_supp = _supp_for_mods("zfin_only", ["ZFIN"])
+        shared = _supp_for_mods("shared", [None])
+        mock_pdfs.return_value = [wb_supp, zfin_supp, shared]
+        mock_converted.return_value = False
+
+        all_pending = pending_supplement_sources(MagicMock(), 42)
+        assert {p.display_name for p in all_pending} == {
+            "wb_only", "zfin_only", "shared",
+        }

--- a/tests/lit_processing/pdf2md/test_pdf2md_utils.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md_utils.py
@@ -27,6 +27,10 @@ from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     download_pdfx_image,
     download_pdfx_image_manifest,
     is_eligible_for_supplement_conversion,
+    is_main_source_converted,
+    is_supplement_source_converted,
+    pending_main_sources,
+    pending_supplement_sources,
     process_extracted_images,
     resolve_curie_to_reference,
     get_pdf_files_for_reference,
@@ -515,11 +519,23 @@ class TestProcessNxmlToMarkdown:
 
 
 class TestProcessSupplementalPdfs:
-    """Test process_supplemental_pdfs function."""
+    """Test process_supplemental_pdfs function.
 
+    The function calls pending_supplement_sources internally for per-source
+    dedup, so these tests mock that helper directly to control which
+    supplements the function thinks are pending.
+    """
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.pending_supplement_sources")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
-    def test_no_supplements_returns_zero_counts(self, mock_get_pdfs):
-        """Zero supplements -> (0, 0, [])."""
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils."
+           "is_eligible_for_supplement_conversion")
+    def test_no_supplements_returns_zero_counts(
+        self, mock_eligible, mock_get_pdfs, mock_pending
+    ):
+        """Zero pending supplements -> (0, 0, [])."""
+        mock_eligible.return_value = True
+        mock_pending.return_value = []
         mock_get_pdfs.return_value = []
 
         succeeded, failed, errors = process_supplemental_pdfs(
@@ -534,13 +550,18 @@ class TestProcessSupplementalPdfs:
         assert errors == []
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils._process_single_pdf_file")
-    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
-    def test_mixed_success_and_failure(self, mock_get_pdfs, mock_process):
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.pending_supplement_sources")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils."
+           "is_eligible_for_supplement_conversion")
+    def test_mixed_success_and_failure(
+        self, mock_eligible, mock_pending, mock_process
+    ):
         """Mix of succeeding/failing supplements counted separately."""
+        mock_eligible.return_value = True
         s1 = MagicMock(display_name="s1")
         s2 = MagicMock(display_name="s2")
         s3 = MagicMock(display_name="s3")
-        mock_get_pdfs.return_value = [s1, s2, s3]
+        mock_pending.return_value = [s1, s2, s3]
         mock_process.side_effect = [
             (True, ["grobid"], None),
             (False, [], "pdfx err"),
@@ -561,11 +582,16 @@ class TestProcessSupplementalPdfs:
         assert "pdfx err" in errors[0]
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils._process_single_pdf_file")
-    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
-    def test_exception_in_helper_counted_as_failure(self, mock_get_pdfs, mock_process):
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.pending_supplement_sources")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils."
+           "is_eligible_for_supplement_conversion")
+    def test_exception_in_helper_counted_as_failure(
+        self, mock_eligible, mock_pending, mock_process
+    ):
         """Exceptions from the per-file helper are caught."""
+        mock_eligible.return_value = True
         s1 = MagicMock(display_name="s1")
-        mock_get_pdfs.return_value = [s1]
+        mock_pending.return_value = [s1]
         mock_process.side_effect = RuntimeError("boom")
 
         succeeded, failed, errors = process_supplemental_pdfs(
@@ -581,11 +607,11 @@ class TestProcessSupplementalPdfs:
         assert "boom" in errors[0]
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils._process_single_pdf_file")
-    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.pending_supplement_sources")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils."
            "is_eligible_for_supplement_conversion")
     def test_skips_when_reference_not_eligible(
-        self, mock_eligible, mock_get_pdfs, mock_process
+        self, mock_eligible, mock_pending, mock_process
     ):
         """Ineligible references early-return without consulting supplement
         PDFs or processing anything."""
@@ -599,8 +625,31 @@ class TestProcessSupplementalPdfs:
         )
 
         assert (succeeded, failed, errors) == (0, 0, [])
-        # Critical: the eligibility check happens BEFORE any DB / PDFX work.
-        mock_get_pdfs.assert_not_called()
+        # Critical: eligibility check happens BEFORE any DB / PDFX work.
+        mock_pending.assert_not_called()
+        mock_process.assert_not_called()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils._process_single_pdf_file")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.pending_supplement_sources")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils."
+           "is_eligible_for_supplement_conversion")
+    def test_skips_when_all_supplements_already_converted(
+        self, mock_eligible, mock_pending, mock_get_pdfs, mock_process
+    ):
+        """Per-source dedup: all supplements already converted → no PDFX work."""
+        mock_eligible.return_value = True
+        mock_pending.return_value = []  # nothing pending
+        mock_get_pdfs.return_value = [MagicMock(display_name="s1")]  # but supps exist
+
+        succeeded, failed, errors = process_supplemental_pdfs(
+            db=MagicMock(),
+            reference_id=42,
+            reference_curie="AGRKB:1",
+            token="t"
+        )
+
+        assert (succeeded, failed, errors) == (0, 0, [])
         mock_process.assert_not_called()
 
 
@@ -871,3 +920,198 @@ class TestEligibleSupplementMods:
         """A None .first() result -> not eligible."""
         mock_db, _ = self._build_query_chain(first_result=None)
         assert is_eligible_for_supplement_conversion(mock_db, 42) is False
+
+
+class TestIsMainSourceConverted:
+    """Tests for the per-source main-side conversion lookup."""
+
+    def _query_chain(self, first_result):
+        mock_db = MagicMock()
+        chain = MagicMock()
+        mock_db.query.return_value = chain
+        chain.filter.return_value = chain
+        chain.first.return_value = first_result
+        return mock_db, chain
+
+    def test_returns_true_when_matching_row_exists(self):
+        mock_db, _ = self._query_chain(first_result=MagicMock())
+        assert is_main_source_converted(
+            mock_db, 42, "paper", is_nxml=False
+        ) is True
+
+    def test_returns_false_when_no_matching_row(self):
+        mock_db, _ = self._query_chain(first_result=None)
+        assert is_main_source_converted(
+            mock_db, 42, "paper", is_nxml=False
+        ) is False
+
+    def test_nxml_source_only_matches_nxml_suffix(self):
+        """For an nXML source, only the _nxml suffix should be in the IN list."""
+        from agr_literature_service.lit_processing.pdf2md import pdf2md_utils
+        suffixes = pdf2md_utils._converted_main_suffixes(
+            is_nxml=True, ignore_tei_derived=False
+        )
+        assert suffixes == ["_nxml"]
+
+    def test_pdf_source_default_includes_tei_legacy(self):
+        from agr_literature_service.lit_processing.pdf2md import pdf2md_utils
+        suffixes = pdf2md_utils._converted_main_suffixes(
+            is_nxml=False, ignore_tei_derived=False
+        )
+        assert "_merged" in suffixes
+        assert "_tei" in suffixes
+
+    def test_pdf_source_ignore_tei_excludes_legacy(self):
+        from agr_literature_service.lit_processing.pdf2md import pdf2md_utils
+        suffixes = pdf2md_utils._converted_main_suffixes(
+            is_nxml=False, ignore_tei_derived=True
+        )
+        assert suffixes == ["_merged"]
+
+
+class TestIsSupplementSourceConverted:
+    """Tests for the per-source supplement conversion lookup."""
+
+    def _query_chain(self, first_result):
+        mock_db = MagicMock()
+        chain = MagicMock()
+        mock_db.query.return_value = chain
+        chain.filter.return_value = chain
+        chain.first.return_value = first_result
+        return mock_db, chain
+
+    def test_returns_true_when_matching_row_exists(self):
+        mock_db, _ = self._query_chain(first_result=MagicMock())
+        assert is_supplement_source_converted(mock_db, 42, "supp_a") is True
+
+    def test_returns_false_when_no_matching_row(self):
+        mock_db, _ = self._query_chain(first_result=None)
+        assert is_supplement_source_converted(mock_db, 42, "supp_a") is False
+
+    def test_default_includes_tei_legacy(self):
+        from agr_literature_service.lit_processing.pdf2md import pdf2md_utils
+        suffixes = pdf2md_utils._converted_supplement_suffixes(
+            ignore_tei_derived=False
+        )
+        assert "_merged" in suffixes
+        assert "_tei" in suffixes
+
+    def test_ignore_tei_excludes_legacy(self):
+        from agr_literature_service.lit_processing.pdf2md import pdf2md_utils
+        suffixes = pdf2md_utils._converted_supplement_suffixes(
+            ignore_tei_derived=True
+        )
+        assert suffixes == ["_merged"]
+
+
+class TestPendingMainSources:
+    """Tests for pending_main_sources helper."""
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_main_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_returns_nxml_when_present_and_pending(
+        self, mock_pdfs, mock_nxml, mock_converted
+    ):
+        nxml = MagicMock(display_name="paper")
+        mock_nxml.return_value = nxml
+        mock_converted.return_value = False  # not yet converted
+
+        result = pending_main_sources(MagicMock(), 42, prefer_nxml=True)
+
+        assert len(result) == 1
+        assert result[0]["kind"] == "nxml"
+        assert result[0]["ref_file"] is nxml
+        # Critical: when nXML is present, main PDFs are NOT also fetched.
+        mock_pdfs.assert_not_called()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_main_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_skips_nxml_when_already_converted(
+        self, mock_pdfs, mock_nxml, mock_converted
+    ):
+        nxml = MagicMock(display_name="paper")
+        mock_nxml.return_value = nxml
+        mock_converted.return_value = True  # already converted
+
+        result = pending_main_sources(MagicMock(), 42, prefer_nxml=True)
+
+        # Already-converted nXML returns []; we don't fall back to PDFs
+        # because nXML is the chosen main-text source for this reference.
+        assert result == []
+        mock_pdfs.assert_not_called()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_main_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_returns_pending_pdfs_when_no_nxml(
+        self, mock_pdfs, mock_nxml, mock_converted
+    ):
+        mock_nxml.return_value = None
+        pdf1 = MagicMock(display_name="pdf1")
+        pdf2 = MagicMock(display_name="pdf2")
+        mock_pdfs.return_value = [pdf1, pdf2]
+        # pdf1 already converted, pdf2 not.
+        mock_converted.side_effect = lambda db, ref_id, name, **kw: name == "pdf1"
+
+        result = pending_main_sources(MagicMock(), 42, prefer_nxml=True)
+
+        assert [p["ref_file"] for p in result] == [pdf2]
+        assert all(p["kind"] == "pdf" for p in result)
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_main_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_nxml_referencefile")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_prefer_nxml_false_ignores_nxml(
+        self, mock_pdfs, mock_nxml, mock_converted
+    ):
+        # prefer_nxml=False: nxml lookup is skipped entirely; only PDFs considered.
+        pdf1 = MagicMock(display_name="pdf1")
+        mock_pdfs.return_value = [pdf1]
+        mock_converted.return_value = False
+
+        result = pending_main_sources(MagicMock(), 42, prefer_nxml=False)
+
+        mock_nxml.assert_not_called()
+        assert [p["ref_file"] for p in result] == [pdf1]
+
+
+class TestPendingSupplementSources:
+    """Tests for pending_supplement_sources helper."""
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_supplement_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_returns_only_unconverted_supplements(
+        self, mock_pdfs, mock_converted
+    ):
+        s1 = MagicMock(display_name="s1")
+        s2 = MagicMock(display_name="s2")
+        s3 = MagicMock(display_name="s3")
+        mock_pdfs.return_value = [s1, s2, s3]
+        # s1 and s3 already converted; s2 still pending.
+        mock_converted.side_effect = lambda db, ref_id, name, **kw: name in {"s1", "s3"}
+
+        result = pending_supplement_sources(MagicMock(), 42)
+
+        assert result == [s2]
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_supplement_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_returns_empty_when_no_supplements(
+        self, mock_pdfs, mock_converted
+    ):
+        mock_pdfs.return_value = []
+        result = pending_supplement_sources(MagicMock(), 42)
+        assert result == []
+        mock_converted.assert_not_called()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.is_supplement_source_converted")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.get_pdf_files_for_reference")
+    def test_returns_empty_when_all_converted(
+        self, mock_pdfs, mock_converted
+    ):
+        s1 = MagicMock(display_name="s1")
+        mock_pdfs.return_value = [s1]
+        mock_converted.return_value = True
+        assert pending_supplement_sources(MagicMock(), 42) == []

--- a/tests/lit_processing/pdf2md/test_pdf2md_utils.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md_utils.py
@@ -15,12 +15,17 @@ import pytest
 import requests
 
 from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+    CONVERTED_FIGURE_FILE_EXTENSION,
     EXTRACTION_METHODS,
+    FIGURE_FILE_CLASSES,
     PdfDetail,
     ProcessingResult,
     submit_pdf_to_pdfx,
     poll_pdfx_status,
     download_pdfx_result,
+    download_pdfx_image,
+    download_pdfx_image_manifest,
+    process_extracted_images,
     resolve_curie_to_reference,
     get_pdf_files_for_reference,
     get_nxml_referencefile,
@@ -97,6 +102,30 @@ class TestSubmitPdfToPdfx:
 
         assert process_id == "abc123"
         mock_post.assert_called_once()
+        # extract_images defaults to True so every conversion also yields figure images.
+        sent_data = mock_post.call_args.kwargs["data"]
+        assert sent_data["extract_images"] == "true"
+        # review_images is omitted unless the caller overrides it (server default is on).
+        assert "review_images" not in sent_data
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.requests.post")
+    def test_extract_images_can_be_disabled(self, mock_post):
+        """Caller can opt out of image extraction explicitly."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"process_id": "abc123"}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        submit_pdf_to_pdfx(
+            file_content=b"pdf_content",
+            token="test_token",
+            extract_images=False,
+            review_images=False,
+        )
+
+        sent_data = mock_post.call_args.kwargs["data"]
+        assert sent_data["extract_images"] == "false"
+        assert sent_data["review_images"] == "false"
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.requests.post")
     def test_raises_error_when_no_process_id(self, mock_post):
@@ -528,3 +557,239 @@ class TestProcessSupplementalPdfs:
         assert failed == 1
         assert len(errors) == 1
         assert "boom" in errors[0]
+
+
+class TestFigureFileClasses:
+    """Tests for the figure file_class mapping constants."""
+
+    def test_main_and_supplement_have_distinct_classes(self):
+        assert FIGURE_FILE_CLASSES["main"] == "converted_main_figure"
+        assert FIGURE_FILE_CLASSES["supplement"] == "converted_supplement_figure"
+
+    def test_default_extension_is_png(self):
+        assert CONVERTED_FIGURE_FILE_EXTENSION == "png"
+
+
+class TestDownloadPdfxImageManifest:
+    """Test download_pdfx_image_manifest function."""
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.requests.get")
+    def test_returns_parsed_manifest(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "process_id": "abc123",
+            "images": [{"filename": "_page_0_Figure_1.png", "url": "https://s3/x"}],
+            "manifest_ttl_seconds": 3600,
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = download_pdfx_image_manifest("abc123", "test_token")
+
+        assert result["process_id"] == "abc123"
+        assert len(result["images"]) == 1
+        call_args = mock_get.call_args
+        assert "abc123" in call_args[0][0]
+        assert "/images/urls" in call_args[0][0]
+        assert call_args.kwargs["headers"]["Authorization"] == "Bearer test_token"
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.requests.get")
+    def test_rejects_non_dict_payload(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = ["not", "a", "dict"]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with pytest.raises(ValueError):
+            download_pdfx_image_manifest("abc123", "test_token")
+
+
+class TestDownloadPdfxImage:
+    """Test download_pdfx_image function."""
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.requests.get")
+    def test_returns_image_bytes(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.content = b"\x89PNGfake"
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        result = download_pdfx_image("https://s3.example/foo.png")
+
+        assert result == b"\x89PNGfake"
+        # Pre-signed URLs are unauthenticated — no Authorization header is sent.
+        kwargs = mock_get.call_args.kwargs
+        assert "headers" not in kwargs or "Authorization" not in (kwargs.get("headers") or {})
+
+
+class TestProcessExtractedImages:
+    """Test process_extracted_images function."""
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_unknown_source_file_class_returns_no_op(self, mock_manifest):
+        succeeded, failed, errors = process_extracted_images(
+            db=MagicMock(),
+            process_id="abc",
+            token="t",
+            source_display_name="paper",
+            source_file_class="weird",
+            reference_curie="AGRKB:1",
+            mod_abbreviation="WB",
+        )
+        assert (succeeded, failed, errors) == (0, 0, [])
+        mock_manifest.assert_not_called()
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_manifest_fetch_failure_is_reported_not_raised(self, mock_manifest):
+        mock_manifest.side_effect = RuntimeError("network down")
+
+        succeeded, failed, errors = process_extracted_images(
+            db=MagicMock(),
+            process_id="abc",
+            token="t",
+            source_display_name="paper",
+            source_file_class="main",
+            reference_curie="AGRKB:1",
+            mod_abbreviation="WB",
+        )
+        assert succeeded == 0
+        assert failed == 0
+        assert len(errors) == 1
+        assert "network down" in errors[0]
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_empty_manifest_is_silent_success(self, mock_manifest):
+        mock_manifest.return_value = {"images": []}
+
+        succeeded, failed, errors = process_extracted_images(
+            db=MagicMock(),
+            process_id="abc",
+            token="t",
+            source_display_name="paper",
+            source_file_class="main",
+            reference_curie="AGRKB:1",
+            mod_abbreviation=None,
+        )
+        assert (succeeded, failed, errors) == (0, 0, [])
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_uploads_each_image_with_correct_metadata(
+        self, mock_manifest, mock_download, mock_upload
+    ):
+        mock_manifest.return_value = {
+            "images": [
+                {"filename": "_page_0_Figure_1.png", "url": "https://s3/a"},
+                {"filename": "_page_0_Figure_2.png", "url": "https://s3/b"},
+            ]
+        }
+        mock_download.side_effect = [b"\x89PNGdata1", b"\x89PNGdata2"]
+
+        succeeded, failed, errors = process_extracted_images(
+            db=MagicMock(),
+            process_id="abc",
+            token="t",
+            source_display_name="paper",
+            source_file_class="main",
+            reference_curie="AGRKB:1",
+            mod_abbreviation="WB",
+        )
+
+        assert succeeded == 2
+        assert failed == 0
+        assert errors == []
+        assert mock_upload.call_count == 2
+        # Verify the first image's metadata mirrors the converted-MD convention.
+        first_metadata = mock_upload.call_args_list[0].kwargs["metadata"]
+        assert first_metadata["display_name"] == "paper_image_001"
+        assert first_metadata["file_class"] == "converted_main_figure"
+        assert first_metadata["file_extension"] == "png"
+        assert first_metadata["file_publication_status"] == "final"
+        assert first_metadata["mod_abbreviation"] == "WB"
+        assert first_metadata["reference_curie"] == "AGRKB:1"
+        assert first_metadata["pdf_type"] is None
+        assert first_metadata["is_annotation"] is None
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_supplement_uses_distinct_file_class(
+        self, mock_manifest, mock_download, mock_upload
+    ):
+        mock_manifest.return_value = {
+            "images": [{"filename": "x.png", "url": "https://s3/a"}]
+        }
+        mock_download.return_value = b"\x89PNG"
+
+        process_extracted_images(
+            db=MagicMock(),
+            process_id="abc",
+            token="t",
+            source_display_name="supp1",
+            source_file_class="supplement",
+            reference_curie="AGRKB:1",
+            mod_abbreviation=None,
+        )
+
+        metadata = mock_upload.call_args.kwargs["metadata"]
+        assert metadata["file_class"] == "converted_supplement_figure"
+        assert metadata["display_name"] == "supp1_image_001"
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_per_image_failure_does_not_abort_remaining(
+        self, mock_manifest, mock_download, mock_upload
+    ):
+        mock_manifest.return_value = {
+            "images": [
+                {"filename": "x.png", "url": "https://s3/a"},
+                {"filename": "y.png", "url": "https://s3/b"},
+                {"filename": "z.png", "url": "https://s3/c"},
+            ]
+        }
+        mock_download.side_effect = [b"\x89PNGa", RuntimeError("S3 timeout"), b"\x89PNGc"]
+
+        succeeded, failed, errors = process_extracted_images(
+            db=MagicMock(),
+            process_id="abc",
+            token="t",
+            source_display_name="paper",
+            source_file_class="main",
+            reference_curie="AGRKB:1",
+            mod_abbreviation="WB",
+        )
+
+        assert succeeded == 2
+        assert failed == 1
+        assert len(errors) == 1
+        assert "S3 timeout" in errors[0]
+        # Two successful uploads should have been attempted.
+        assert mock_upload.call_count == 2
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_manifest_entry_missing_url_is_recorded_as_failure(self, mock_manifest):
+        mock_manifest.return_value = {
+            "images": [{"filename": "x.png"}, {"filename": "y.png", "url": "https://s3/b"}]
+        }
+
+        with patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image",
+            return_value=b"\x89PNG",
+        ), patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload"
+        ):
+            succeeded, failed, errors = process_extracted_images(
+                db=MagicMock(),
+                process_id="abc",
+                token="t",
+                source_display_name="paper",
+                source_file_class="main",
+                reference_curie="AGRKB:1",
+                mod_abbreviation=None,
+            )
+
+        assert succeeded == 1
+        assert failed == 1
+        assert any("missing 'url'" in e for e in errors)


### PR DESCRIPTION
## Summary

- Extracts figure images from main + supplemental PDFs through the PDFX `/images/urls` manifest and uploads each as a referencefile under `converted_main_figure` / `converted_supplement_figure`. Display names follow the existing converted-MD convention `{source_display_name}_image_{idx:03d}`. Image-extraction failures are logged but never fail the per-file conversion; main-then-supplement ordering is preserved.
- On-demand `/reference/referencefile/conversion_request` response now carries a `figures: List[ConversionFileInfo]` per `per_file_progress` entry, grouping each PDF's extracted images under the source they came from. Empty list when none were extracted.
- Defaults `clear_cache_scope=extraction` on every PDFX submission to sidestep a server-side cache bug where a stale image manifest could survive after the on-disk image files were TTL-aged out (silent zero-image runs). Caller can opt out by passing `clear_cache_scope=None`.
- Wires `PDFX_API_URL` into the `api`, `automated_scripts`, and `dev_app` docker-compose services so deployments can target the PDFX test instance via env. Code default still falls back to the prod URL when unset.
- Tests are pure-mock (no DB, no HTTP) and cover the new helpers, the figures-in-response assembly, the form-data sent to PDFX, supplement vs main file_class, sorting, non-final rows skipped, and partial failures.

## Test plan

- [x] `make run-local-flake8` — clean
- [x] `make run-local-mypy` — `Success: no issues found in 512 source files`
- [x] Manually applied the SCRUM-5601 antibody-string-matching one-off to rdsdev (tracked separately as SCRUM-6037 for prod)
- [x] On-demand `conversion_request` flow exercised end-to-end against the pdfx-test deployment for `AGRKB:101000001222606`. Markdown ingestion verified; figure ingestion blocked on a server-side `extraction_run`-row issue Chris is investigating (DM sent with process_id `546860e3-87e6-4b22-b806-ce40d7f51af4`). Once that's resolved, retest end-to-end on stage:
  - https://stage-literature.alliancegenome.org/Biblio?action=display&referenceCurie=AGRKB:101000001222606
- [ ] Reviewer: confirm `figures` list shape on a converted reference where supplements have figures (response payload sample is in the JIRA ticket comment).
- [ ] Reviewer: confirm the new `PDFX_API_URL` env passthrough for the deployments you care about.

## Related

- JIRA: [SCRUM-5772](https://agr-jira.atlassian.net/browse/SCRUM-5772) (Ready for UAT)
- Follow-up prod migration: [SCRUM-6037](https://agr-jira.atlassian.net/browse/SCRUM-6037)
- Server-side dependency: pdfx feature branch `KANBAN-1228_pdf-image-manifest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-5772]: https://agr-jira.atlassian.net/browse/SCRUM-5772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ