### PR TITLE
Adding new image permissions and overall 'can_display_images' to the reference endpoint

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -142,7 +142,7 @@ def get_effective_image_permission(db: Session, curie_or_reference_id: str) -> D
     resource_image_permission = _resource_image_permission_for_reference(db, reference)
     resource_permission_metadata = _build_resource_permission_metadata(resource_image_permission)
 
-    # Priority 1: Reference copyright_license.open_access
+    # Priority 1: Reference copyright_license.open_access (curator/PMC override)
     if reference.copyright_license_id:
         copyright_license = db.query(CopyrightLicenseModel).filter_by(
             copyright_license_id=reference.copyright_license_id
@@ -150,8 +150,8 @@ def get_effective_image_permission(db: Session, curie_or_reference_id: str) -> D
         if copyright_license:
             return {
                 "can_display_images": bool(copyright_license.open_access),
-                "source": "reference_copyright_license",
-                "reason": "Reference copyright_license overrides resource image permissions.",
+                "source": "reference_open_access",
+                "reason": "Reference has copyright license set.",
                 "publication_year": publication_year,
                 "copyright_license_id": copyright_license.copyright_license_id,
                 "copyright_license_name": copyright_license.name,
@@ -160,13 +160,36 @@ def get_effective_image_permission(db: Session, curie_or_reference_id: str) -> D
                 **resource_permission_metadata,
             }
 
-    # Priority 2: Resource image permission (from journal/publisher)
+    # Priority 2: Resource copyright_license.open_access (if publication_year >= license_start_year)
+    if reference.resource_id:
+        resource = db.query(ResourceModel).filter_by(
+            resource_id=reference.resource_id
+        ).one_or_none()
+        if resource and resource.copyright_license_id:
+            license_start_year = resource.license_start_year
+            # Check if publication year meets the license start year requirement
+            if license_start_year is None or (publication_year and publication_year >= license_start_year):
+                resource_license = resource.copyright_license
+                if resource_license:
+                    return {
+                        "can_display_images": bool(resource_license.open_access),
+                        "source": "resource_open_access",
+                        "reason": f"Resource has open access license (since {license_start_year or 'all years'}).",
+                        "publication_year": publication_year,
+                        "copyright_license_id": resource_license.copyright_license_id,
+                        "copyright_license_name": resource_license.name,
+                        "copyright_license_open_access": resource_license.open_access,
+                        "resource_id": reference.resource_id,
+                        **resource_permission_metadata,
+                    }
+
+    # Priority 3: Resource image permission (from journal/publisher)
     if resource_image_permission and resource_image_permission.image_permission:
         image_permission = resource_image_permission.image_permission
         return {
             "can_display_images": bool(image_permission.can_display_images),
             "source": "resource_image_permission",
-            "reason": "No reference copyright_license; using resource image permission.",
+            "reason": "Using resource image permission.",
             "publication_year": publication_year,
             "copyright_license_id": None,
             "copyright_license_name": None,
@@ -179,7 +202,7 @@ def get_effective_image_permission(db: Session, curie_or_reference_id: str) -> D
     return {
         "can_display_images": False,
         "source": "none",
-        "reason": "No reference copyright_license or matching resource image permission.",
+        "reason": "No reference or resource license, and no matching resource image permission.",
         "publication_year": publication_year,
         "copyright_license_id": None,
         "copyright_license_name": None,

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -45,6 +45,7 @@ from agr_literature_service.api.models import (
     ObsoleteReferenceModel,
     ReferenceRelationModel,
     ReferenceModel,
+    ResourceImagePermissionModel,
     ResourceModel,
     CopyrightLicenseModel,
     CitationModel,
@@ -74,6 +75,125 @@ from agr_literature_service.api.crud.person_crud import normalize_email
 logger = logging.getLogger(__name__)
 
 file_needed_tag_atp_id = "ATP:0000141"  # file needed
+
+
+def _extract_publication_year(reference: ReferenceModel) -> Optional[int]:
+    for date_value in (
+        reference.date_published_start,
+        reference.date_published,
+        reference.date_published_end,
+    ):
+        if date_value:
+            match = re.search(r"(1[89]\d{2}|20\d{2})", str(date_value))
+            if match:
+                return int(match.group(1))
+    return None
+
+
+def _resource_image_permission_for_reference(
+    db: Session,
+    reference: ReferenceModel,
+) -> Optional[ResourceImagePermissionModel]:
+    if not reference.resource_id:
+        return None
+
+    rows = db.query(ResourceImagePermissionModel).filter(
+        ResourceImagePermissionModel.resource_id == reference.resource_id
+    ).all()
+    if not rows:
+        return None
+
+    publication_year = _extract_publication_year(reference)
+    if publication_year is None:
+        undated_rows = [
+            row for row in rows
+            if row.start_year is None and row.end_year is None
+        ]
+        return sorted(
+            undated_rows,
+            key=lambda row: row.resource_image_permission_id
+        )[0] if undated_rows else None
+
+    matching_rows = [
+        row for row in rows
+        if (row.start_year is None or row.start_year <= publication_year)
+        and (row.end_year is None or row.end_year >= publication_year)
+    ]
+    if not matching_rows:
+        return None
+
+    return sorted(
+        matching_rows,
+        key=lambda row: (
+            row.start_year is None,
+            -(row.start_year or 0),
+            row.end_year is None,
+            row.end_year or 9999,
+            row.resource_image_permission_id,
+        )
+    )[0]
+
+
+def get_effective_image_permission(db: Session, curie_or_reference_id: str) -> Dict[str, Any]:
+    reference = get_reference(db, curie_or_reference_id)
+    publication_year = _extract_publication_year(reference)
+
+    if reference.copyright_license_id:
+        copyright_license = db.query(CopyrightLicenseModel).filter_by(
+            copyright_license_id=reference.copyright_license_id
+        ).one_or_none()
+        if copyright_license:
+            return {
+                "can_display_images": bool(copyright_license.open_access),
+                "source": "reference_copyright_license",
+                "reason": "Reference copyright_license overrides resource image permissions.",
+                "publication_year": publication_year,
+                "copyright_license_id": copyright_license.copyright_license_id,
+                "copyright_license_name": copyright_license.name,
+                "copyright_license_open_access": copyright_license.open_access,
+                "image_permission_id": None,
+                "resource_image_permission_id": None,
+                "permission_text": None,
+                "permission_url": None,
+                "resource_id": reference.resource_id,
+            }
+
+    resource_image_permission = _resource_image_permission_for_reference(db, reference)
+    if resource_image_permission and resource_image_permission.image_permission:
+        image_permission = resource_image_permission.image_permission
+        return {
+            "can_display_images": bool(image_permission.can_display_images),
+            "source": "resource_image_permission",
+            "reason": "No reference copyright_license is set; using resource image permission.",
+            "publication_year": publication_year,
+            "copyright_license_id": None,
+            "copyright_license_name": None,
+            "copyright_license_open_access": None,
+            "image_permission_id": image_permission.image_permission_id,
+            "image_permission_name": image_permission.name,
+            "resource_image_permission_id": resource_image_permission.resource_image_permission_id,
+            "permission_text": image_permission.permission_text,
+            "permission_url": image_permission.permission_url,
+            "resource_id": reference.resource_id,
+            "start_year": resource_image_permission.start_year,
+            "end_year": resource_image_permission.end_year,
+            "notes": resource_image_permission.notes,
+        }
+
+    return {
+        "can_display_images": False,
+        "source": "none",
+        "reason": "No reference copyright_license or matching resource image permission is set.",
+        "publication_year": publication_year,
+        "copyright_license_id": None,
+        "copyright_license_name": None,
+        "copyright_license_open_access": None,
+        "image_permission_id": None,
+        "resource_image_permission_id": None,
+        "permission_text": None,
+        "permission_url": None,
+        "resource_id": reference.resource_id,
+    }
 
 
 def create(db: Session, reference: ReferenceSchemaPost):  # noqa
@@ -570,6 +690,7 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
     reference = get_reference(db, curie_or_reference_id, load_authors=True, load_mod_corpus_associations=True,
                               load_mesh_terms=True, load_obsolete_references=True)
     reference_data = jsonable_encoder(reference)
+    reference_data["effective_image_permission"] = get_effective_image_permission(db, curie_or_reference_id)
     if reference.resource_id:
         reference_data["resource_curie"] = \
             db.query(ResourceModel.curie).filter(ResourceModel.resource_id == reference.resource_id).first()[0]

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -138,6 +138,11 @@ def get_effective_image_permission(db: Session, curie_or_reference_id: str) -> D
     reference = get_reference(db, curie_or_reference_id)
     publication_year = _extract_publication_year(reference)
 
+    # Always fetch resource image permission metadata to include in response
+    resource_image_permission = _resource_image_permission_for_reference(db, reference)
+    resource_permission_metadata = _build_resource_permission_metadata(resource_image_permission)
+
+    # Priority 1: Reference copyright_license.open_access
     if reference.copyright_license_id:
         copyright_license = db.query(CopyrightLicenseModel).filter_by(
             copyright_license_id=reference.copyright_license_id
@@ -151,48 +156,64 @@ def get_effective_image_permission(db: Session, curie_or_reference_id: str) -> D
                 "copyright_license_id": copyright_license.copyright_license_id,
                 "copyright_license_name": copyright_license.name,
                 "copyright_license_open_access": copyright_license.open_access,
-                "image_permission_id": None,
-                "resource_image_permission_id": None,
-                "permission_text": None,
-                "permission_url": None,
                 "resource_id": reference.resource_id,
+                **resource_permission_metadata,
             }
 
-    resource_image_permission = _resource_image_permission_for_reference(db, reference)
+    # Priority 2: Resource image permission (from journal/publisher)
     if resource_image_permission and resource_image_permission.image_permission:
         image_permission = resource_image_permission.image_permission
         return {
             "can_display_images": bool(image_permission.can_display_images),
             "source": "resource_image_permission",
-            "reason": "No reference copyright_license is set; using resource image permission.",
+            "reason": "No reference copyright_license; using resource image permission.",
             "publication_year": publication_year,
             "copyright_license_id": None,
             "copyright_license_name": None,
             "copyright_license_open_access": None,
+            "resource_id": reference.resource_id,
+            **resource_permission_metadata,
+        }
+
+    # Default: no permission
+    return {
+        "can_display_images": False,
+        "source": "none",
+        "reason": "No reference copyright_license or matching resource image permission.",
+        "publication_year": publication_year,
+        "copyright_license_id": None,
+        "copyright_license_name": None,
+        "copyright_license_open_access": None,
+        "resource_id": reference.resource_id,
+        **resource_permission_metadata,
+    }
+
+
+def _build_resource_permission_metadata(
+    resource_image_permission: Optional[ResourceImagePermissionModel],
+) -> Dict[str, Any]:
+    """Build metadata dict for resource image permission (always included in response)."""
+    if resource_image_permission and resource_image_permission.image_permission:
+        image_permission = resource_image_permission.image_permission
+        return {
             "image_permission_id": image_permission.image_permission_id,
             "image_permission_name": image_permission.name,
             "resource_image_permission_id": resource_image_permission.resource_image_permission_id,
             "permission_text": image_permission.permission_text,
             "permission_url": image_permission.permission_url,
-            "resource_id": reference.resource_id,
             "start_year": resource_image_permission.start_year,
             "end_year": resource_image_permission.end_year,
             "notes": resource_image_permission.notes,
         }
-
     return {
-        "can_display_images": False,
-        "source": "none",
-        "reason": "No reference copyright_license or matching resource image permission is set.",
-        "publication_year": publication_year,
-        "copyright_license_id": None,
-        "copyright_license_name": None,
-        "copyright_license_open_access": None,
         "image_permission_id": None,
+        "image_permission_name": None,
         "resource_image_permission_id": None,
         "permission_text": None,
         "permission_url": None,
-        "resource_id": reference.resource_id,
+        "start_year": None,
+        "end_year": None,
+        "notes": None,
     }
 
 

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -134,8 +134,13 @@ def _resource_image_permission_for_reference(
     )[0]
 
 
-def get_effective_image_permission(db: Session, curie_or_reference_id: str) -> Dict[str, Any]:
-    reference = get_reference(db, curie_or_reference_id)
+def get_effective_image_permission(
+    db: Session,
+    curie_or_reference_id: str,
+    reference: Optional[ReferenceModel] = None,
+) -> Dict[str, Any]:
+    if reference is None:
+        reference = get_reference(db, curie_or_reference_id)
     publication_year = _extract_publication_year(reference)
 
     # Always fetch resource image permission metadata to include in response
@@ -734,7 +739,7 @@ def show(db: Session, curie_or_reference_id: str):  # noqa
     reference = get_reference(db, curie_or_reference_id, load_authors=True, load_mod_corpus_associations=True,
                               load_mesh_terms=True, load_obsolete_references=True)
     reference_data = jsonable_encoder(reference)
-    reference_data["effective_image_permission"] = get_effective_image_permission(db, curie_or_reference_id)
+    reference_data["effective_image_permission"] = get_effective_image_permission(db, curie_or_reference_id, reference)
     if reference.resource_id:
         reference_data["resource_curie"] = \
             db.query(ResourceModel.curie).filter(ResourceModel.resource_id == reference.resource_id).first()[0]

--- a/agr_literature_service/api/models/image_permission_model.py
+++ b/agr_literature_service/api/models/image_permission_model.py
@@ -34,7 +34,7 @@ class ImagePermissionModel(Base, AuditedModel):
 
     permission_text = Column(
         TEXT(),
-        nullable=False
+        nullable=True
     )
 
     permission_url = Column(

--- a/agr_literature_service/api/models/image_permission_model.py
+++ b/agr_literature_service/api/models/image_permission_model.py
@@ -34,7 +34,7 @@ class ImagePermissionModel(Base, AuditedModel):
 
     permission_text = Column(
         TEXT(),
-        nullable=True
+        nullable=False
     )
 
     permission_url = Column(

--- a/agr_literature_service/api/routers/reference_router.py
+++ b/agr_literature_service/api/routers/reference_router.py
@@ -198,6 +198,14 @@ def show(curie_or_reference_id: str,
     return reference_crud.show(db, curie_or_reference_id)
 
 
+@router.get('/{curie_or_reference_id}/image_permission',
+            status_code=200)
+def show_image_permission(curie_or_reference_id: str,
+                          user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+                          db: Session = db_session):
+    return reference_crud.get_effective_image_permission(db, curie_or_reference_id)
+
+
 @router.get('/{curie_or_reference_id}/versions',
             status_code=200)
 def show_versions(curie_or_reference_id: str,

--- a/agr_literature_service/api/schemas/image_permission_schemas.py
+++ b/agr_literature_service/api/schemas/image_permission_schemas.py
@@ -10,7 +10,7 @@ class ImagePermissionSchemaPost(BaseModel):
     model_config = ConfigDict(extra='forbid', from_attributes=True)
 
     name: str
-    permission_text: Optional[str] = None
+    permission_text: str = ''
     permission_url: Optional[str] = None
     can_display_images: bool = False
 

--- a/agr_literature_service/api/schemas/image_permission_schemas.py
+++ b/agr_literature_service/api/schemas/image_permission_schemas.py
@@ -10,14 +10,14 @@ class ImagePermissionSchemaPost(BaseModel):
     model_config = ConfigDict(extra='forbid', from_attributes=True)
 
     name: str
-    permission_text: str
+    permission_text: Optional[str] = None
     permission_url: Optional[str] = None
     can_display_images: bool = False
 
-    @field_validator('name', 'permission_text')
-    def value_is_not_blank(cls, v: str) -> str:
+    @field_validator('name')
+    def name_is_not_blank(cls, v: str) -> str:
         if not v.strip():
-            raise ValueError('Value cannot be blank')
+            raise ValueError('name cannot be blank')
         return v
 
 
@@ -30,10 +30,10 @@ class ImagePermissionSchemaUpdate(BaseModel):
     permission_url: Optional[str] = None
     can_display_images: Optional[bool] = None
 
-    @field_validator('name', 'permission_text')
-    def value_is_not_blank(cls, v: Optional[str]) -> Optional[str]:
+    @field_validator('name')
+    def name_is_not_blank(cls, v: Optional[str]) -> Optional[str]:
         if v is not None and not v.strip():
-            raise ValueError('Value cannot be blank')
+            raise ValueError('name cannot be blank')
         return v
 
 
@@ -43,7 +43,7 @@ class ImagePermissionSchemaShow(AuditedObjectModelSchema):
 
     image_permission_id: int
     name: str
-    permission_text: str
+    permission_text: Optional[str] = None
     permission_url: Optional[str] = None
     can_display_images: bool
 

--- a/agr_literature_service/api/schemas/reference_schemas.py
+++ b/agr_literature_service/api/schemas/reference_schemas.py
@@ -197,6 +197,7 @@ class ReferenceSchemaShow(AuditedObjectModelSchema):
     copyright_license_description: Optional[str] = None
     copyright_license_open_access: Optional[bool] = None
     copyright_license_last_updated_by: Optional[str] = None
+    effective_image_permission: Optional[Dict[str, Any]] = None
     invalid_cross_reference_ids: Optional[List[str]] = None
     authors: Optional[List[AuthorSchemaShow]] = None
     emails: Optional[List[ReferenceEmailSchemaRelated]] = None

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import Session
 
 from agr_literature_service.api.models import (
     ImagePermissionModel,
+    ReferenceModel,
     ResourceImagePermissionModel,
     ResourceModel,
 )
@@ -98,6 +99,7 @@ class ResourceLookup:
     resource_by_abbreviation: Dict[str, List[ResourceModel]]
     resource_by_title: Dict[str, List[ResourceModel]]
     resource_by_curie: Dict[str, ResourceModel]
+    reference_count_by_resource_id: Dict[int, int]
 
 
 @dataclass
@@ -302,6 +304,12 @@ def load_env_file(env_file: Optional[Path]) -> None:
 
 def build_resource_lookup(db: Session) -> ResourceLookup:
     resources = db.query(ResourceModel).all()
+    reference_counts = dict(
+        db.query(ReferenceModel.resource_id, func.count(ReferenceModel.reference_id))
+        .filter(ReferenceModel.resource_id.isnot(None))
+        .group_by(ReferenceModel.resource_id)
+        .all()
+    )
     by_exact_abbreviation: Dict[str, List[ResourceModel]] = {}
     by_exact_title: Dict[str, List[ResourceModel]] = {}
     by_abbreviation: Dict[str, List[ResourceModel]] = {}
@@ -323,6 +331,7 @@ def build_resource_lookup(db: Session) -> ResourceLookup:
         resource_by_abbreviation=by_abbreviation,
         resource_by_title=by_title,
         resource_by_curie=by_curie,
+        reference_count_by_resource_id=reference_counts,
     )
 
 
@@ -337,6 +346,15 @@ def choose_unique(candidates: List[ResourceModel]) -> Optional[ResourceModel]:
     return None
 
 
+def choose_active_resource(candidates: List[ResourceModel], lookup: ResourceLookup) -> Optional[ResourceModel]:
+    active_candidates = [
+        resource
+        for resource in candidates
+        if lookup.reference_count_by_resource_id.get(resource.resource_id, 0) > 0
+    ]
+    return choose_unique(active_candidates)
+
+
 def choose_unique_by_title(candidates: List[ResourceModel], full_journal_name: str) -> Optional[ResourceModel]:
     if not full_journal_name:
         return None
@@ -347,6 +365,45 @@ def choose_unique_by_title(candidates: List[ResourceModel], full_journal_name: s
         if normalize_for_match(resource.title or "") == title_key
     ]
     return choose_unique(title_matches)
+
+
+def choose_active_by_title(
+    candidates: List[ResourceModel],
+    full_journal_name: str,
+    lookup: ResourceLookup,
+) -> Optional[ResourceModel]:
+    if not full_journal_name:
+        return None
+    title_key = normalize_for_match(full_journal_name)
+    title_matches = [
+        resource
+        for resource in candidates
+        if normalize_for_match(resource.title or "") == title_key
+    ]
+    return choose_active_resource(title_matches, lookup)
+
+
+def resolve_candidates(
+    candidates: List[ResourceModel],
+    match_label: str,
+    row: JournalPermissionRow,
+    lookup: ResourceLookup,
+) -> Tuple[Optional[ResourceModel], Optional[str]]:
+    resource = choose_unique(candidates)
+    if resource:
+        return resource, match_label
+    resource = choose_active_resource(candidates, lookup)
+    if resource:
+        return resource, f"active {match_label}"
+    resource = choose_unique_by_title(candidates, row.full_journal_name)
+    if resource:
+        return resource, f"{match_label} plus title"
+    resource = choose_active_by_title(candidates, row.full_journal_name, lookup)
+    if resource:
+        return resource, f"active {match_label} plus title"
+    if len(candidates) > 1:
+        return None, f"ambiguous {match_label}"
+    return None, None
 
 
 def find_resource(
@@ -362,46 +419,39 @@ def find_resource(
             return resource, "manual"
         return None, f"manual curie not found: {manual_curie}"
 
-    candidates = lookup.resource_by_exact_abbreviation.get(normalize_exact(row.journal_abbreviation), [])
-    resource = choose_unique(candidates)
-    if resource:
-        return resource, "exact title_abbreviation"
-    resource = choose_unique_by_title(candidates, row.full_journal_name)
-    if resource:
-        return resource, "exact title_abbreviation plus title"
-    if len(candidates) > 1:
-        return None, "ambiguous exact title_abbreviation"
-
-    candidates = lookup.resource_by_exact_title.get(normalize_exact(row.full_journal_name), [])
-    resource = choose_unique(candidates)
-    if resource:
-        return resource, "exact title"
-    if len(candidates) > 1:
-        return None, "ambiguous exact title"
-
-    candidates = lookup.resource_by_abbreviation.get(normalize_abbreviation(row.journal_abbreviation), [])
-    resource = choose_unique(candidates)
-    if resource:
-        return resource, "title_abbreviation"
-    resource = choose_unique_by_title(candidates, row.full_journal_name)
-    if resource:
-        return resource, "title_abbreviation plus title"
-    if len(candidates) > 1:
-        return None, "ambiguous title_abbreviation"
-
-    candidates = lookup.resource_by_title.get(normalize_for_match(row.full_journal_name), [])
-    resource = choose_unique(candidates)
-    if resource:
-        return resource, "title"
-    if len(candidates) > 1:
-        return None, "ambiguous title"
+    candidate_sets = [
+        (
+            lookup.resource_by_exact_abbreviation.get(normalize_exact(row.journal_abbreviation), []),
+            "exact title_abbreviation",
+        ),
+        (
+            lookup.resource_by_exact_title.get(normalize_exact(row.full_journal_name), []),
+            "exact title",
+        ),
+        (
+            lookup.resource_by_abbreviation.get(normalize_abbreviation(row.journal_abbreviation), []),
+            "title_abbreviation",
+        ),
+        (
+            lookup.resource_by_title.get(normalize_for_match(row.full_journal_name), []),
+            "title",
+        ),
+    ]
+    for candidates, match_label in candidate_sets:
+        resource, result = resolve_candidates(candidates, match_label, row, lookup)
+        if result:
+            return resource, result
 
     return None, "not found"
 
 
-def candidate_labels(candidates: List[ResourceModel]) -> str:
+def candidate_labels_with_reference_counts(
+    candidates: List[ResourceModel],
+    lookup: ResourceLookup,
+) -> str:
     return "; ".join(
-        f"{resource.curie} ({resource.title_abbreviation or resource.title or 'no title'})"
+        f"{resource.curie} ({resource.title_abbreviation or resource.title or 'no title'}, "
+        f"references={lookup.reference_count_by_resource_id.get(resource.resource_id, 0)})"
         for resource in candidates
     )
 
@@ -422,26 +472,32 @@ def describe_resource_match_failure(
     if exact_abbreviation_candidates:
         return (
             f"{match_reason}; exact title_abbreviation candidates: "
-            f"{candidate_labels(exact_abbreviation_candidates)}"
+            f"{candidate_labels_with_reference_counts(exact_abbreviation_candidates, lookup)}"
         )
 
     exact_title_key = normalize_exact(row.full_journal_name)
     exact_title_candidates = lookup.resource_by_exact_title.get(exact_title_key, [])
     if exact_title_candidates:
-        return f"{match_reason}; exact title candidates: {candidate_labels(exact_title_candidates)}"
+        return (
+            f"{match_reason}; exact title candidates: "
+            f"{candidate_labels_with_reference_counts(exact_title_candidates, lookup)}"
+        )
 
     abbreviation_key = normalize_abbreviation(row.journal_abbreviation)
     abbreviation_candidates = lookup.resource_by_abbreviation.get(abbreviation_key, [])
     if abbreviation_candidates:
         return (
             f"{match_reason}; title_abbreviation candidates: "
-            f"{candidate_labels(abbreviation_candidates)}"
+            f"{candidate_labels_with_reference_counts(abbreviation_candidates, lookup)}"
         )
 
     title_key = normalize_for_match(row.full_journal_name)
     title_candidates = lookup.resource_by_title.get(title_key, [])
     if title_candidates:
-        return f"{match_reason}; title candidates: {candidate_labels(title_candidates)}"
+        return (
+            f"{match_reason}; title candidates: "
+            f"{candidate_labels_with_reference_counts(title_candidates, lookup)}"
+        )
 
     return (
         "no resource matched normalized title_abbreviation "

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -50,7 +50,6 @@ SCRIPT_USER = path.basename(__file__).replace(".py", "")
 MOD_PERMISSION_COLUMNS = ["FB", "MGI", "RGD", "SGD", "WB", "XB", "ZFIN"]
 NOTE_COLUMNS = [
     "Comments",
-    "Hybrid Journal",
     "Embargo",
     "Author permission required?",
     "Delay of Use",
@@ -71,6 +70,7 @@ PERMISSION_URL_PATTERN = re.compile(
     r"(copyright|licens|open[-_]?access|permission|polic|reprint|rights)",
     flags=re.IGNORECASE,
 )
+URL_LABEL_WORD_RE = re.compile(r"[a-z0-9]+", flags=re.IGNORECASE)
 
 
 @dataclass
@@ -85,6 +85,7 @@ class JournalPermissionRow:
     end_year: Optional[int]
     permission_name: str
     legacy_permission_name: str
+    hashed_permission_name: str
     permission_text: str
     permission_url: Optional[str]
     can_display_images: bool
@@ -205,6 +206,26 @@ def permission_url(row: Dict[str, str]) -> Optional[str]:
     return "; ".join(urls) if urls else None
 
 
+def compact_label(value: str, max_length: int = 160) -> str:
+    text = clean(value)
+    if len(text) <= max_length:
+        return text
+    return text[:max_length].rsplit(" ", 1)[0].rstrip(".,;:") + "..."
+
+
+def permission_url_label(permission_url_value: str) -> str:
+    labels = []
+    for url in permission_url_value.split(";"):
+        url = clean(url)
+        if not url:
+            continue
+        without_scheme = re.sub(r"^https?://", "", url, flags=re.IGNORECASE)
+        host, _, path_part = without_scheme.partition("/")
+        path_words = " ".join(URL_LABEL_WORD_RE.findall(path_part))
+        labels.append(compact_label(f"{host} {path_words}".strip(), 120))
+    return " / ".join(labels)
+
+
 def build_permission_text(row: Dict[str, str]) -> str:
     acknowledgement = clean(row.get("WB Acknowledgements"))
     if not is_blankish(acknowledgement):
@@ -215,22 +236,10 @@ def build_permission_text(row: Dict[str, str]) -> str:
 
 def build_notes(row: Dict[str, str]) -> str:
     notes = []
-    curator_id = clean(row.get("na"))
-    if not is_blankish(curator_id):
-        notes.append(f"Curator ID: {curator_id}")
-
     for column in NOTE_COLUMNS:
         value = clean(row.get(column))
         if value and not is_blankish(value):
             notes.append(f"{column}: {value}")
-
-    mod_values = []
-    for column in MOD_PERMISSION_COLUMNS:
-        value = clean(row.get(column))
-        if value and not is_blankish(value):
-            mod_values.append(f"{column}={value}")
-    if mod_values:
-        notes.append("MOD permissions: " + "; ".join(mod_values))
 
     return "\n".join(notes)
 
@@ -260,6 +269,25 @@ def build_legacy_permission_name(row: Dict[str, str], start_year: Optional[int],
 
 
 def build_permission_name(
+    row: Dict[str, str],
+    permission_text: str,
+    permission_url_value: Optional[str],
+    can_display_images: bool,
+) -> str:
+    publisher = clean(row.get("Publisher")) or "unknown publisher"
+    descriptor_parts = []
+    license_type = clean(row.get("License type"))
+    if not is_blankish(license_type):
+        descriptor_parts.append(license_type)
+    if permission_url_value:
+        descriptor_parts.append(permission_url_label(permission_url_value))
+    if permission_text:
+        descriptor_parts.append(compact_label(permission_text, 160))
+    descriptor_parts.append("display allowed" if can_display_images else "display not allowed")
+    return compact_label(f"{publisher} image permission: {' | '.join(descriptor_parts)}", 500)
+
+
+def build_hashed_permission_name(
     row: Dict[str, str],
     permission_text: str,
     permission_url_value: Optional[str],
@@ -306,6 +334,12 @@ def parse_tsv(input_file: Path, subset_can_display: bool) -> Iterable[JournalPer
                     can_display_images,
                 ),
                 legacy_permission_name=build_legacy_permission_name(normalized_row, start_year, end_year),
+                hashed_permission_name=build_hashed_permission_name(
+                    normalized_row,
+                    permission_text,
+                    permission_url_value,
+                    can_display_images,
+                ),
                 permission_text=permission_text,
                 permission_url=permission_url_value,
                 can_display_images=can_display_images,
@@ -659,6 +693,8 @@ def upsert_permission(
     permission = existing_permissions.get(row.permission_name)
     if permission is None:
         permission = existing_permissions.get(row.legacy_permission_name)
+    if permission is None:
+        permission = existing_permissions.get(row.hashed_permission_name)
     if permission is None:
         stats.permissions_created += 1
         logger.info(f"Line {row.line_no}: create image_permission '{row.permission_name}'")

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -305,6 +305,8 @@ def detect_permission_type(row: Dict[str, str]) -> Optional[str]:
     if "oa" in combined or "open access" in combined:
         return "Open Access"
     if "granted" in combined:
+        if "subset" in combined:
+            return "Permission Granted (subset)"
         return "Permission Granted"
     if "publisher permission" in combined:
         return "Publisher Permission"

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -63,6 +63,7 @@ POSITIVE_PERMISSION_PATTERNS = (
     "publisher permission",
     "permission to use images",
     "contract",
+    "granted",
     "oa",
 )
 

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -77,6 +77,7 @@ POSITIVE_PERMISSION_PATTERNS = (
 @dataclass
 class JournalPermissionRow:
     line_no: int
+    curator_id: str
     data: Dict[str, str]
     journal_abbreviation: str
     publisher: str
@@ -100,6 +101,7 @@ class ResourceLookup:
 @dataclass
 class FailedRow:
     line_no: int
+    curator_id: str
     journal_abbreviation: str
     publisher: str
     full_journal_name: str
@@ -261,6 +263,7 @@ def parse_tsv(input_file: Path, subset_can_display: bool) -> Iterable[JournalPer
             start_year, end_year = parse_year_range(normalized_row)
             yield JournalPermissionRow(
                 line_no=line_no,
+                curator_id=clean(normalized_row.get("na")),
                 data=normalized_row,
                 journal_abbreviation=journal,
                 publisher=publisher,
@@ -464,6 +467,7 @@ def add_failed_row(
 ) -> None:
     stats.failed_rows.append(FailedRow(
         line_no=row.line_no,
+        curator_id=row.curator_id,
         journal_abbreviation=row.journal_abbreviation,
         publisher=row.publisher,
         full_journal_name=row.full_journal_name,
@@ -655,6 +659,7 @@ def write_failure_report(stats: LoadStats, report_file: Path) -> None:
             delimiter="\t",
             fieldnames=[
                 "line_no",
+                "curator_id",
                 "journal_abbreviation",
                 "publisher",
                 "full_journal_name",
@@ -666,6 +671,7 @@ def write_failure_report(stats: LoadStats, report_file: Path) -> None:
         for row in stats.failed_rows:
             writer.writerow({
                 "line_no": row.line_no,
+                "curator_id": row.curator_id,
                 "journal_abbreviation": row.journal_abbreviation,
                 "publisher": row.publisher,
                 "full_journal_name": row.full_journal_name,

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -93,6 +93,8 @@ class JournalPermissionRow:
 
 @dataclass
 class ResourceLookup:
+    resource_by_exact_abbreviation: Dict[str, List[ResourceModel]]
+    resource_by_exact_title: Dict[str, List[ResourceModel]]
     resource_by_abbreviation: Dict[str, List[ResourceModel]]
     resource_by_title: Dict[str, List[ResourceModel]]
     resource_by_curie: Dict[str, ResourceModel]
@@ -143,6 +145,10 @@ def normalize_for_match(value: str) -> str:
     text = text.replace("&", " and ")
     text = re.sub(r"[^a-z0-9]+", " ", text)
     return clean(text)
+
+
+def normalize_exact(value: str) -> str:
+    return clean(value).lower().rstrip(".")
 
 
 def normalize_abbreviation(value: str) -> str:
@@ -296,6 +302,8 @@ def load_env_file(env_file: Optional[Path]) -> None:
 
 def build_resource_lookup(db: Session) -> ResourceLookup:
     resources = db.query(ResourceModel).all()
+    by_exact_abbreviation: Dict[str, List[ResourceModel]] = {}
+    by_exact_title: Dict[str, List[ResourceModel]] = {}
     by_abbreviation: Dict[str, List[ResourceModel]] = {}
     by_title: Dict[str, List[ResourceModel]] = {}
     by_curie: Dict[str, ResourceModel] = {}
@@ -303,11 +311,15 @@ def build_resource_lookup(db: Session) -> ResourceLookup:
     for resource in resources:
         by_curie[resource.curie] = resource
         if resource.title_abbreviation:
+            by_exact_abbreviation.setdefault(normalize_exact(resource.title_abbreviation), []).append(resource)
             by_abbreviation.setdefault(normalize_abbreviation(resource.title_abbreviation), []).append(resource)
         if resource.title:
+            by_exact_title.setdefault(normalize_exact(resource.title), []).append(resource)
             by_title.setdefault(normalize_for_match(resource.title), []).append(resource)
 
     return ResourceLookup(
+        resource_by_exact_abbreviation=by_exact_abbreviation,
+        resource_by_exact_title=by_exact_title,
         resource_by_abbreviation=by_abbreviation,
         resource_by_title=by_title,
         resource_by_curie=by_curie,
@@ -325,6 +337,18 @@ def choose_unique(candidates: List[ResourceModel]) -> Optional[ResourceModel]:
     return None
 
 
+def choose_unique_by_title(candidates: List[ResourceModel], full_journal_name: str) -> Optional[ResourceModel]:
+    if not full_journal_name:
+        return None
+    title_key = normalize_for_match(full_journal_name)
+    title_matches = [
+        resource
+        for resource in candidates
+        if normalize_for_match(resource.title or "") == title_key
+    ]
+    return choose_unique(title_matches)
+
+
 def find_resource(
     row: JournalPermissionRow,
     lookup: ResourceLookup,
@@ -338,10 +362,30 @@ def find_resource(
             return resource, "manual"
         return None, f"manual curie not found: {manual_curie}"
 
+    candidates = lookup.resource_by_exact_abbreviation.get(normalize_exact(row.journal_abbreviation), [])
+    resource = choose_unique(candidates)
+    if resource:
+        return resource, "exact title_abbreviation"
+    resource = choose_unique_by_title(candidates, row.full_journal_name)
+    if resource:
+        return resource, "exact title_abbreviation plus title"
+    if len(candidates) > 1:
+        return None, "ambiguous exact title_abbreviation"
+
+    candidates = lookup.resource_by_exact_title.get(normalize_exact(row.full_journal_name), [])
+    resource = choose_unique(candidates)
+    if resource:
+        return resource, "exact title"
+    if len(candidates) > 1:
+        return None, "ambiguous exact title"
+
     candidates = lookup.resource_by_abbreviation.get(normalize_abbreviation(row.journal_abbreviation), [])
     resource = choose_unique(candidates)
     if resource:
         return resource, "title_abbreviation"
+    resource = choose_unique_by_title(candidates, row.full_journal_name)
+    if resource:
+        return resource, "title_abbreviation plus title"
     if len(candidates) > 1:
         return None, "ambiguous title_abbreviation"
 
@@ -372,6 +416,19 @@ def describe_resource_match_failure(
     manual_curie = manual_resource_map.get(manual_key)
     if manual_curie:
         return f"manual resource_curie was supplied but not found: {manual_curie}"
+
+    exact_abbreviation_key = normalize_exact(row.journal_abbreviation)
+    exact_abbreviation_candidates = lookup.resource_by_exact_abbreviation.get(exact_abbreviation_key, [])
+    if exact_abbreviation_candidates:
+        return (
+            f"{match_reason}; exact title_abbreviation candidates: "
+            f"{candidate_labels(exact_abbreviation_candidates)}"
+        )
+
+    exact_title_key = normalize_exact(row.full_journal_name)
+    exact_title_candidates = lookup.resource_by_exact_title.get(exact_title_key, [])
+    if exact_title_candidates:
+        return f"{match_reason}; exact title candidates: {candidate_labels(exact_title_candidates)}"
 
     abbreviation_key = normalize_abbreviation(row.journal_abbreviation)
     abbreviation_candidates = lookup.resource_by_abbreviation.get(abbreviation_key, [])

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -246,10 +246,19 @@ def build_notes(row: Dict[str, str]) -> Optional[str]:
             continue
         if column == "Comments" and not ACTIONABLE_COMMENT_PATTERN.search(value):
             continue
-        if value and not is_blankish(value):
-            notes.append(f"{column}: {value}")
+        # For single-value columns, omit the prefix if context is clear
+        if column == "Embargo":
+            notes.append(f"Embargo: {value}")
+        elif column == "Delay of Use":
+            notes.append(f"Delay: {value}")
+        elif column == "Author permission required?":
+            if value.lower() not in ("no", "n"):
+                notes.append(f"Author permission required: {value}")
+        else:
+            # Comments - include as-is without prefix if it's actionable
+            notes.append(value)
 
-    return "\n".join(notes) or None
+    return "; ".join(notes) if notes else None
 
 
 def has_positive_permission_signal(row: Dict[str, str], subset_can_display: bool) -> bool:
@@ -276,6 +285,41 @@ def build_legacy_permission_name(row: Dict[str, str], start_year: Optional[int],
     return f"Journal image permission: {journal} | {publisher} | {range_label(start_year, end_year)}"
 
 
+def detect_permission_type(row: Dict[str, str]) -> Optional[str]:
+    """Detect permission type from MOD columns and other fields."""
+    mod_values = []
+    for column in MOD_PERMISSION_COLUMNS:
+        value = clean(row.get(column)).lower()
+        if value and not is_blankish(value):
+            mod_values.append(value)
+
+    combined = " ".join(mod_values)
+    hybrid = clean(row.get("Hybrid Journal")).lower()
+
+    # Check MOD column patterns in priority order
+    if "blanket" in combined:
+        return "Blanket Permission"
+    if "contract" in combined:
+        return "Contract"
+    if "oa" in combined or "open access" in combined:
+        return "Open Access"
+    if "granted" in combined:
+        return "Permission Granted"
+    if "publisher permission" in combined:
+        return "Publisher Permission"
+
+    # Check Hybrid Journal column
+    if hybrid:
+        if "open access" in hybrid:
+            return "Open Access"
+        if "creative commons" in hybrid:
+            return "Creative Commons"
+        if "hybrid" in hybrid or "yes" in hybrid:
+            return "Hybrid"
+
+    return None
+
+
 def build_permission_name(
     row: Dict[str, str],
     permission_text: str,
@@ -283,16 +327,30 @@ def build_permission_name(
     can_display_images: bool,
 ) -> str:
     publisher = clean(row.get("Publisher")) or "unknown publisher"
-    descriptor_parts = []
+    parts = []
+
+    # Primary: License type (e.g., "CC BY 4.0")
     license_type = clean(row.get("License type"))
     if not is_blankish(license_type):
-        descriptor_parts.append(license_type)
-    if permission_url_value:
-        descriptor_parts.append(permission_url_label(permission_url_value))
-    if permission_text:
-        descriptor_parts.append(compact_label(permission_text, 160))
-    descriptor_parts.append("display allowed" if can_display_images else "display not allowed")
-    return compact_label(f"{publisher} image permission: {' | '.join(descriptor_parts)}", 500)
+        parts.append(license_type)
+
+    # Secondary: Permission type from MOD columns (e.g., "Blanket Permission", "Open Access")
+    permission_type = detect_permission_type(row)
+    if permission_type:
+        # Avoid redundancy: don't add "Creative Commons" if license already specifies CC
+        if permission_type == "Creative Commons" and "CC " in " ".join(parts):
+            pass
+        # Avoid redundancy: don't add "Open Access" if "OA" is in license type
+        elif permission_type == "Open Access" and "oa" in " ".join(parts).lower():
+            pass
+        else:
+            parts.append(permission_type)
+
+    # If nothing specific, indicate display status
+    if not parts:
+        parts.append("Display Allowed" if can_display_images else "No Display Permission")
+
+    return f"{publisher} - {' | '.join(parts)}"
 
 
 def build_hashed_permission_name(

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -11,9 +11,8 @@ The script uses SQLAlchemy models so audited/version tables are populated by
 the normal ORM/versioning machinery when --apply is used.
 
 Usage:
-    python -m agr_literature_service.lit_processing.oneoff_scripts.load_journal_image_permissions
-    python -m agr_literature_service.lit_processing.oneoff_scripts.load_journal_image_permissions --apply
-    python -m agr_literature_service.lit_processing.oneoff_scripts.load_journal_image_permissions --env-file .env_codex --apply
+    python load_journal_image_permissions.py
+    python load_journal_image_permissions.py --apply
 """
 
 import argparse
@@ -41,7 +40,7 @@ logging.basicConfig(format="%(message)s")
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-DEFAULT_INPUT_FILE = "journal_permission.tsv"
+DEFAULT_INPUT_FILE = "data/journal_permission.tsv"
 SCRIPT_USER = path.basename(__file__).replace(".py", "")
 
 MOD_PERMISSION_COLUMNS = ["FB", "MGI", "RGD", "SGD", "WB", "XB", "ZFIN"]

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -13,6 +13,7 @@ the normal ORM/versioning machinery when --apply is used.
 Usage:
     python load_journal_image_permissions.py
     python load_journal_image_permissions.py --apply
+    python load_journal_image_permissions.py --report-file data/journal_permission_load_report.tsv
 """
 
 import argparse
@@ -41,6 +42,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 DEFAULT_INPUT_FILE = "data/journal_permission.tsv"
+DEFAULT_REPORT_FILE = "data/journal_permission_load_report.tsv"
 SCRIPT_USER = path.basename(__file__).replace(".py", "")
 
 MOD_PERMISSION_COLUMNS = ["FB", "MGI", "RGD", "SGD", "WB", "XB", "ZFIN"]
@@ -96,6 +98,16 @@ class ResourceLookup:
 
 
 @dataclass
+class FailedRow:
+    line_no: int
+    journal_abbreviation: str
+    publisher: str
+    full_journal_name: str
+    reason: str
+    detail: str
+
+
+@dataclass
 class LoadStats:
     rows_seen: int = 0
     rows_skipped: int = 0
@@ -108,6 +120,11 @@ class LoadStats:
     links_updated: int = 0
     links_unchanged: int = 0
     errors: int = 0
+    failed_rows: List[FailedRow] = None
+
+    def __post_init__(self) -> None:
+        if self.failed_rows is None:
+            self.failed_rows = []
 
 
 def clean(value: Optional[str]) -> str:
@@ -335,6 +352,43 @@ def find_resource(
     return None, "not found"
 
 
+def candidate_labels(candidates: List[ResourceModel]) -> str:
+    return "; ".join(
+        f"{resource.curie} ({resource.title_abbreviation or resource.title or 'no title'})"
+        for resource in candidates
+    )
+
+
+def describe_resource_match_failure(
+    row: JournalPermissionRow,
+    lookup: ResourceLookup,
+    manual_resource_map: Dict[str, str],
+    match_reason: str,
+) -> str:
+    manual_key = row.journal_abbreviation or row.full_journal_name
+    manual_curie = manual_resource_map.get(manual_key)
+    if manual_curie:
+        return f"manual resource_curie was supplied but not found: {manual_curie}"
+
+    abbreviation_key = normalize_abbreviation(row.journal_abbreviation)
+    abbreviation_candidates = lookup.resource_by_abbreviation.get(abbreviation_key, [])
+    if abbreviation_candidates:
+        return (
+            f"{match_reason}; title_abbreviation candidates: "
+            f"{candidate_labels(abbreviation_candidates)}"
+        )
+
+    title_key = normalize_for_match(row.full_journal_name)
+    title_candidates = lookup.resource_by_title.get(title_key, [])
+    if title_candidates:
+        return f"{match_reason}; title candidates: {candidate_labels(title_candidates)}"
+
+    return (
+        "no resource matched normalized title_abbreviation "
+        f"'{abbreviation_key}' or title '{title_key}'"
+    )
+
+
 def read_manual_resource_map(map_file: Optional[Path]) -> Dict[str, str]:
     if map_file is None:
         return {}
@@ -402,12 +456,34 @@ def find_resource_link(
     ).one_or_none()
 
 
-def record_skipped_resource(stats: LoadStats, row: JournalPermissionRow, match_reason: str) -> None:
+def add_failed_row(
+    stats: LoadStats,
+    row: JournalPermissionRow,
+    reason: str,
+    detail: str,
+) -> None:
+    stats.failed_rows.append(FailedRow(
+        line_no=row.line_no,
+        journal_abbreviation=row.journal_abbreviation,
+        publisher=row.publisher,
+        full_journal_name=row.full_journal_name,
+        reason=reason,
+        detail=detail,
+    ))
+
+
+def record_skipped_resource(
+    stats: LoadStats,
+    row: JournalPermissionRow,
+    match_reason: str,
+    detail: str,
+) -> None:
     stats.rows_skipped += 1
     if "ambiguous" in match_reason:
         stats.resources_ambiguous += 1
     else:
         stats.resources_unmatched += 1
+    add_failed_row(stats, row, match_reason, detail)
     logger.warning(
         f"Line {row.line_no}: skipped resource link ({match_reason}) for "
         f"{row.journal_abbreviation or row.full_journal_name}"
@@ -511,11 +587,13 @@ def process_row(
         if savepoint:
             savepoint.rollback()
         stats.errors += 1
+        add_failed_row(stats, row, "integrity error", str(err.orig if hasattr(err, "orig") else err))
         logger.error(f"Line {row.line_no}: integrity error for {row.permission_name}: {err}")
     except Exception as err:
         if savepoint:
             savepoint.rollback()
         stats.errors += 1
+        add_failed_row(stats, row, "error", str(err))
         logger.error(f"Line {row.line_no}: error for {row.permission_name}: {err}")
 
 
@@ -537,7 +615,8 @@ def load_permissions(
         stats.rows_seen += 1
         resource, match_reason = find_resource(row, lookup, manual_resource_map)
         if resource is None:
-            record_skipped_resource(stats, row, match_reason)
+            detail = describe_resource_match_failure(row, lookup, manual_resource_map, match_reason)
+            record_skipped_resource(stats, row, match_reason, detail)
             continue
         process_row(db, row, resource, existing_permissions, stats, apply)
 
@@ -564,7 +643,36 @@ def log_summary(stats: LoadStats, apply: bool) -> None:
     logger.info(f"Resource links updated: {stats.links_updated}")
     logger.info(f"Resource links unchanged: {stats.links_unchanged}")
     logger.info(f"Errors: {stats.errors}")
+    logger.info(f"Rows in failure report: {len(stats.failed_rows)}")
     logger.info("No rows are deleted by this loader.")
+
+
+def write_failure_report(stats: LoadStats, report_file: Path) -> None:
+    report_file.parent.mkdir(parents=True, exist_ok=True)
+    with report_file.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            delimiter="\t",
+            fieldnames=[
+                "line_no",
+                "journal_abbreviation",
+                "publisher",
+                "full_journal_name",
+                "reason",
+                "detail",
+            ],
+        )
+        writer.writeheader()
+        for row in stats.failed_rows:
+            writer.writerow({
+                "line_no": row.line_no,
+                "journal_abbreviation": row.journal_abbreviation,
+                "publisher": row.publisher,
+                "full_journal_name": row.full_journal_name,
+                "reason": row.reason,
+                "detail": row.detail,
+            })
+    logger.info(f"Wrote failure report: {report_file}")
 
 
 def main() -> None:
@@ -587,6 +695,11 @@ def main() -> None:
         help="Optional TSV with Journal (NLM abbrev) and resource_curie columns for manual matches",
     )
     parser.add_argument(
+        "--report-file",
+        default=DEFAULT_REPORT_FILE,
+        help=f"TSV report for rows that could not be loaded; default: {DEFAULT_REPORT_FILE}",
+    )
+    parser.add_argument(
         "--apply",
         action="store_true",
         help="Commit inserts/updates. Default is dry-run.",
@@ -601,6 +714,7 @@ def main() -> None:
     input_file = Path(args.input_file)
     env_file = Path(args.env_file) if args.env_file else None
     resource_map_file = Path(args.resource_map) if args.resource_map else None
+    report_file = Path(args.report_file)
 
     if not input_file.exists():
         raise FileNotFoundError(f"Input file does not exist: {input_file}")
@@ -623,6 +737,7 @@ def main() -> None:
             subset_can_display=args.subset_can_display,
         )
         log_summary(stats, args.apply)
+        write_failure_report(stats, report_file)
     except Exception:
         db.rollback()
         raise

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -18,6 +18,7 @@ Usage:
 
 import argparse
 import csv
+import hashlib
 import logging
 import re
 from dataclasses import dataclass
@@ -83,6 +84,7 @@ class JournalPermissionRow:
     start_year: Optional[int]
     end_year: Optional[int]
     permission_name: str
+    legacy_permission_name: str
     permission_text: str
     permission_url: Optional[str]
     can_display_images: bool
@@ -251,10 +253,27 @@ def has_positive_permission_signal(row: Dict[str, str], subset_can_display: bool
     return any(pattern in combined for pattern in POSITIVE_PERMISSION_PATTERNS)
 
 
-def build_permission_name(row: Dict[str, str], start_year: Optional[int], end_year: Optional[int]) -> str:
+def build_legacy_permission_name(row: Dict[str, str], start_year: Optional[int], end_year: Optional[int]) -> str:
     journal = clean(row.get("Journal (NLM abbrev)")) or clean(row.get("Full Journal Name")) or "unknown journal"
     publisher = clean(row.get("Publisher")) or "unknown publisher"
     return f"Journal image permission: {journal} | {publisher} | {range_label(start_year, end_year)}"
+
+
+def build_permission_name(
+    row: Dict[str, str],
+    permission_text: str,
+    permission_url_value: Optional[str],
+    can_display_images: bool,
+) -> str:
+    publisher = clean(row.get("Publisher")) or "unknown publisher"
+    fingerprint_source = "\n".join([
+        publisher,
+        permission_text,
+        permission_url_value or "",
+        str(can_display_images),
+    ])
+    fingerprint = hashlib.sha1(fingerprint_source.encode("utf-8")).hexdigest()[:8]
+    return f"{publisher} image permission ({fingerprint})"
 
 
 def parse_tsv(input_file: Path, subset_can_display: bool) -> Iterable[JournalPermissionRow]:
@@ -268,6 +287,9 @@ def parse_tsv(input_file: Path, subset_can_display: bool) -> Iterable[JournalPer
             if not journal and not full_journal_name:
                 continue
             start_year, end_year = parse_year_range(normalized_row)
+            permission_text = build_permission_text(normalized_row)
+            permission_url_value = permission_url(normalized_row)
+            can_display_images = has_positive_permission_signal(normalized_row, subset_can_display)
             yield JournalPermissionRow(
                 line_no=line_no,
                 curator_id=clean(normalized_row.get("na")),
@@ -277,10 +299,16 @@ def parse_tsv(input_file: Path, subset_can_display: bool) -> Iterable[JournalPer
                 full_journal_name=full_journal_name,
                 start_year=start_year,
                 end_year=end_year,
-                permission_name=build_permission_name(normalized_row, start_year, end_year),
-                permission_text=build_permission_text(normalized_row),
-                permission_url=permission_url(normalized_row),
-                can_display_images=has_positive_permission_signal(normalized_row, subset_can_display),
+                permission_name=build_permission_name(
+                    normalized_row,
+                    permission_text,
+                    permission_url_value,
+                    can_display_images,
+                ),
+                legacy_permission_name=build_legacy_permission_name(normalized_row, start_year, end_year),
+                permission_text=permission_text,
+                permission_url=permission_url_value,
+                can_display_images=can_display_images,
                 notes=build_notes(normalized_row),
             )
 
@@ -526,6 +554,7 @@ def read_manual_resource_map(map_file: Optional[Path]) -> Dict[str, str]:
 def update_permission_fields(permission: ImagePermissionModel, row: JournalPermissionRow) -> bool:
     changed = False
     desired = {
+        "name": row.permission_name,
         "permission_text": row.permission_text,
         "permission_url": row.permission_url,
         "can_display_images": row.can_display_images,
@@ -539,36 +568,50 @@ def update_permission_fields(permission: ImagePermissionModel, row: JournalPermi
 
 def permission_fields_changed(permission: ImagePermissionModel, row: JournalPermissionRow) -> bool:
     return any([
+        permission.name != row.permission_name,
         permission.permission_text != row.permission_text,
         permission.permission_url != row.permission_url,
         permission.can_display_images != row.can_display_images,
     ])
 
 
-def update_link_fields(link: ResourceImagePermissionModel, row: JournalPermissionRow) -> bool:
+def update_link_fields(
+    link: ResourceImagePermissionModel,
+    row: JournalPermissionRow,
+    image_permission_id: int,
+) -> bool:
+    changed = False
+    if link.image_permission_id != image_permission_id:
+        link.image_permission_id = image_permission_id
+        changed = True
     if link.notes != row.notes:
         link.notes = row.notes
-        return True
-    return False
+        changed = True
+    return changed
 
 
-def link_fields_changed(link: ResourceImagePermissionModel, row: JournalPermissionRow) -> bool:
-    return link.notes != row.notes
+def link_fields_changed(
+    link: ResourceImagePermissionModel,
+    row: JournalPermissionRow,
+    image_permission_id: Optional[int],
+) -> bool:
+    return any([
+        image_permission_id is not None and link.image_permission_id != image_permission_id,
+        link.notes != row.notes,
+    ])
 
 
 def find_resource_link(
     db: Session,
     resource_id: int,
-    image_permission_id: int,
     start_year: Optional[int],
     end_year: Optional[int],
 ) -> Optional[ResourceImagePermissionModel]:
     return db.query(ResourceImagePermissionModel).filter(
         ResourceImagePermissionModel.resource_id == resource_id,
-        ResourceImagePermissionModel.image_permission_id == image_permission_id,
         func.coalesce(ResourceImagePermissionModel.start_year, -1) == (start_year if start_year is not None else -1),
         func.coalesce(ResourceImagePermissionModel.end_year, -1) == (end_year if end_year is not None else -1),
-    ).one_or_none()
+    ).order_by(ResourceImagePermissionModel.resource_image_permission_id).first()
 
 
 def add_failed_row(
@@ -615,6 +658,8 @@ def upsert_permission(
 ) -> Optional[ImagePermissionModel]:
     permission = existing_permissions.get(row.permission_name)
     if permission is None:
+        permission = existing_permissions.get(row.legacy_permission_name)
+    if permission is None:
         stats.permissions_created += 1
         logger.info(f"Line {row.line_no}: create image_permission '{row.permission_name}'")
         if not apply:
@@ -634,6 +679,8 @@ def upsert_permission(
     if changed:
         stats.permissions_updated += 1
         logger.info(f"Line {row.line_no}: update image_permission '{row.permission_name}'")
+        if apply:
+            existing_permissions[row.permission_name] = permission
     else:
         stats.permissions_unchanged += 1
     return permission
@@ -653,7 +700,6 @@ def upsert_resource_link(
         link = find_resource_link(
             db,
             resource.resource_id,
-            image_permission_id,
             row.start_year,
             row.end_year,
         )
@@ -674,7 +720,11 @@ def upsert_resource_link(
             ))
         return
 
-    changed = update_link_fields(link, row) if apply else link_fields_changed(link, row)
+    changed = (
+        update_link_fields(link, row, image_permission_id)
+        if apply and image_permission_id is not None
+        else link_fields_changed(link, row, image_permission_id)
+    )
     if changed:
         stats.links_updated += 1
         logger.info(

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -47,19 +47,11 @@ DEFAULT_REPORT_FILE = "data/journal_permission_load_report.tsv"
 SCRIPT_USER = path.basename(__file__).replace(".py", "")
 
 MOD_PERMISSION_COLUMNS = ["FB", "MGI", "RGD", "SGD", "WB", "XB", "ZFIN"]
-METADATA_COLUMNS = [
-    "Journal (NLM abbrev)",
-    "Publisher",
-    "Full Journal Name",
-    "Journal URL",
-    "Article URL",
-    "Publisher URL",
-    "Contact",
+NOTE_COLUMNS = [
     "Comments",
-    "Licensing Link",
-    "License type",
     "Hybrid Journal",
     "Embargo",
+    "Author permission required?",
     "Delay of Use",
 ]
 
@@ -72,6 +64,11 @@ POSITIVE_PERMISSION_PATTERNS = (
     "permission to use images",
     "contract",
     "oa",
+)
+
+PERMISSION_URL_PATTERN = re.compile(
+    r"(copyright|licens|open[-_]?access|permission|polic|reprint|rights)",
+    flags=re.IGNORECASE,
 )
 
 
@@ -139,7 +136,7 @@ def clean(value: Optional[str]) -> str:
 
 def is_blankish(value: Optional[str]) -> bool:
     text = clean(value).lower()
-    return text in {"", "n/a", "na", "none", "null", "-"}
+    return text in {"", "n/a", "na", "none", "null", "(null)", "-"}
 
 
 def normalize_for_match(value: str) -> str:
@@ -191,12 +188,19 @@ def range_label(start_year: Optional[int], end_year: Optional[int]) -> str:
     return f"{start_year}-{end_year}"
 
 
-def first_url(row: Dict[str, str]) -> Optional[str]:
-    for column in ["Licensing Link", "Publisher URL", "Journal URL", "Article URL"]:
-        value = clean(row.get(column))
-        if value and not is_blankish(value):
-            return value
-    return None
+def extract_urls(value: Optional[str]) -> List[str]:
+    if is_blankish(value):
+        return []
+    return [url.rstrip(").,;") for url in re.findall(r"https?://[^\s;,]+", clean(value))]
+
+
+def is_permission_url(url: str) -> bool:
+    return bool(PERMISSION_URL_PATTERN.search(url))
+
+
+def permission_url(row: Dict[str, str]) -> Optional[str]:
+    urls = [url for url in extract_urls(row.get("Licensing Link")) if is_permission_url(url)]
+    return "; ".join(urls) if urls else None
 
 
 def build_permission_text(row: Dict[str, str]) -> str:
@@ -204,21 +208,16 @@ def build_permission_text(row: Dict[str, str]) -> str:
     if not is_blankish(acknowledgement):
         return acknowledgement
 
-    parts = []
-    for column in ["Licensing Link", "License type", "Comments"]:
-        value = clean(row.get(column))
-        if value and not is_blankish(value):
-            parts.append(f"{column}: {value}")
-
-    if parts:
-        return "\n".join(parts)
-
-    return "No publisher image permission text supplied in journal_permission.tsv."
+    return ""
 
 
 def build_notes(row: Dict[str, str]) -> str:
     notes = []
-    for column in METADATA_COLUMNS:
+    curator_id = clean(row.get("na"))
+    if not is_blankish(curator_id):
+        notes.append(f"Curator ID: {curator_id}")
+
+    for column in NOTE_COLUMNS:
         value = clean(row.get(column))
         if value and not is_blankish(value):
             notes.append(f"{column}: {value}")
@@ -280,7 +279,7 @@ def parse_tsv(input_file: Path, subset_can_display: bool) -> Iterable[JournalPer
                 end_year=end_year,
                 permission_name=build_permission_name(normalized_row, start_year, end_year),
                 permission_text=build_permission_text(normalized_row),
-                permission_url=first_url(normalized_row),
+                permission_url=permission_url(normalized_row),
                 can_display_images=has_positive_permission_signal(normalized_row, subset_can_display),
                 notes=build_notes(normalized_row),
             )

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""
+Load journal_permission.tsv into image_permission and resource_image_permission.
+
+This loader is intentionally non-destructive:
+- rows present in the TSV are inserted or updated
+- existing database rows that are not present in the TSV are never removed
+- dry-run is the default; pass --apply to commit changes
+
+The script uses SQLAlchemy models so audited/version tables are populated by
+the normal ORM/versioning machinery when --apply is used.
+
+Usage:
+    python -m agr_literature_service.lit_processing.oneoff_scripts.load_journal_image_permissions
+    python -m agr_literature_service.lit_processing.oneoff_scripts.load_journal_image_permissions --apply
+    python -m agr_literature_service.lit_processing.oneoff_scripts.load_journal_image_permissions --env-file .env_codex --apply
+"""
+
+import argparse
+import csv
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from os import environ, path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from agr_literature_service.api.models import (
+    ImagePermissionModel,
+    ResourceImagePermissionModel,
+    ResourceModel,
+)
+from agr_literature_service.api.user import set_global_user_id
+from agr_literature_service.lit_processing.utils.sqlalchemy_utils import create_postgres_session
+
+logging.basicConfig(format="%(message)s")
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+DEFAULT_INPUT_FILE = "journal_permission.tsv"
+SCRIPT_USER = path.basename(__file__).replace(".py", "")
+
+MOD_PERMISSION_COLUMNS = ["FB", "MGI", "RGD", "SGD", "WB", "XB", "ZFIN"]
+METADATA_COLUMNS = [
+    "Journal (NLM abbrev)",
+    "Publisher",
+    "Full Journal Name",
+    "Journal URL",
+    "Article URL",
+    "Publisher URL",
+    "Contact",
+    "Comments",
+    "Licensing Link",
+    "License type",
+    "Hybrid Journal",
+    "Embargo",
+    "Delay of Use",
+]
+
+POSITIVE_PERMISSION_PATTERNS = (
+    "blanket",
+    "cc by",
+    "creative commons",
+    "open access",
+    "publisher permission",
+    "permission to use images",
+    "contract",
+    "oa",
+)
+
+
+@dataclass
+class JournalPermissionRow:
+    line_no: int
+    data: Dict[str, str]
+    journal_abbreviation: str
+    publisher: str
+    full_journal_name: str
+    start_year: Optional[int]
+    end_year: Optional[int]
+    permission_name: str
+    permission_text: str
+    permission_url: Optional[str]
+    can_display_images: bool
+    notes: str
+
+
+@dataclass
+class ResourceLookup:
+    resource_by_abbreviation: Dict[str, List[ResourceModel]]
+    resource_by_title: Dict[str, List[ResourceModel]]
+    resource_by_curie: Dict[str, ResourceModel]
+
+
+@dataclass
+class LoadStats:
+    rows_seen: int = 0
+    rows_skipped: int = 0
+    resources_unmatched: int = 0
+    resources_ambiguous: int = 0
+    permissions_created: int = 0
+    permissions_updated: int = 0
+    permissions_unchanged: int = 0
+    links_created: int = 0
+    links_updated: int = 0
+    links_unchanged: int = 0
+    errors: int = 0
+
+
+def clean(value: Optional[str]) -> str:
+    return re.sub(r"\s+", " ", value or "").strip()
+
+
+def is_blankish(value: Optional[str]) -> bool:
+    text = clean(value).lower()
+    return text in {"", "n/a", "na", "none", "null", "-"}
+
+
+def normalize_for_match(value: str) -> str:
+    text = clean(value).lower()
+    text = text.replace("&", " and ")
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return clean(text)
+
+
+def normalize_abbreviation(value: str) -> str:
+    text = clean(value)
+    text = re.sub(r"\s*\(.*$", "", text)
+    text = re.sub(r"\s*[<>]\s*\d{4}.*$", "", text)
+    text = text.rstrip(".")
+    return normalize_for_match(text)
+
+
+def parse_year_range(row: Dict[str, str]) -> Tuple[Optional[int], Optional[int]]:
+    journal = clean(row.get("Journal (NLM abbrev)"))
+    acknowledgement = clean(row.get("WB Acknowledgements"))
+    search_text = f"{journal} {acknowledgement}"
+
+    range_match = re.search(r"\b(1[89]\d{2}|20\d{2})\s*[-–]\s*(1[89]\d{2}|20\d{2})\b", search_text)
+    if range_match:
+        return int(range_match.group(1)), int(range_match.group(2))
+
+    before_match = re.search(r"(?:<|before\s+)(1[89]\d{2}|20\d{2})", search_text, flags=re.IGNORECASE)
+    if before_match:
+        return None, int(before_match.group(1)) - 1
+
+    after_match = re.search(r"(?:>|after\s+)(1[89]\d{2}|20\d{2})", search_text, flags=re.IGNORECASE)
+    if after_match:
+        return int(after_match.group(1)) + 1, None
+
+    return None, None
+
+
+def range_label(start_year: Optional[int], end_year: Optional[int]) -> str:
+    if start_year is None and end_year is None:
+        return "all years"
+    if start_year is None:
+        return f"through {end_year}"
+    if end_year is None:
+        return f"from {start_year}"
+    return f"{start_year}-{end_year}"
+
+
+def first_url(row: Dict[str, str]) -> Optional[str]:
+    for column in ["Licensing Link", "Publisher URL", "Journal URL", "Article URL"]:
+        value = clean(row.get(column))
+        if value and not is_blankish(value):
+            return value
+    return None
+
+
+def build_permission_text(row: Dict[str, str]) -> str:
+    acknowledgement = clean(row.get("WB Acknowledgements"))
+    if not is_blankish(acknowledgement):
+        return acknowledgement
+
+    parts = []
+    for column in ["Licensing Link", "License type", "Comments"]:
+        value = clean(row.get(column))
+        if value and not is_blankish(value):
+            parts.append(f"{column}: {value}")
+
+    if parts:
+        return "\n".join(parts)
+
+    return "No publisher image permission text supplied in journal_permission.tsv."
+
+
+def build_notes(row: Dict[str, str]) -> str:
+    notes = []
+    for column in METADATA_COLUMNS:
+        value = clean(row.get(column))
+        if value and not is_blankish(value):
+            notes.append(f"{column}: {value}")
+
+    mod_values = []
+    for column in MOD_PERMISSION_COLUMNS:
+        value = clean(row.get(column))
+        if value and not is_blankish(value):
+            mod_values.append(f"{column}={value}")
+    if mod_values:
+        notes.append("MOD permissions: " + "; ".join(mod_values))
+
+    return "\n".join(notes)
+
+
+def has_positive_permission_signal(row: Dict[str, str], subset_can_display: bool) -> bool:
+    values = []
+    values.append(clean(row.get("WB Acknowledgements")))
+    values.extend(clean(row.get(column)) for column in MOD_PERMISSION_COLUMNS)
+    values.extend(clean(row.get(column)) for column in ["License type", "Hybrid Journal", "Comments"])
+    combined = " ".join(value.lower() for value in values if value)
+
+    if not combined:
+        return False
+
+    if "subset" in combined and not subset_can_display:
+        strong_blanket_signal = "blanket" in combined or "open access" in combined or "creative commons" in combined
+        if not strong_blanket_signal:
+            return False
+
+    return any(pattern in combined for pattern in POSITIVE_PERMISSION_PATTERNS)
+
+
+def build_permission_name(row: Dict[str, str], start_year: Optional[int], end_year: Optional[int]) -> str:
+    journal = clean(row.get("Journal (NLM abbrev)")) or clean(row.get("Full Journal Name")) or "unknown journal"
+    publisher = clean(row.get("Publisher")) or "unknown publisher"
+    return f"Journal image permission: {journal} | {publisher} | {range_label(start_year, end_year)}"
+
+
+def parse_tsv(input_file: Path, subset_can_display: bool) -> Iterable[JournalPermissionRow]:
+    with input_file.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        for line_no, row in enumerate(reader, start=2):
+            normalized_row = {key: clean(value) for key, value in row.items()}
+            journal = clean(normalized_row.get("Journal (NLM abbrev)"))
+            publisher = clean(normalized_row.get("Publisher"))
+            full_journal_name = clean(normalized_row.get("Full Journal Name"))
+            if not journal and not full_journal_name:
+                continue
+            start_year, end_year = parse_year_range(normalized_row)
+            yield JournalPermissionRow(
+                line_no=line_no,
+                data=normalized_row,
+                journal_abbreviation=journal,
+                publisher=publisher,
+                full_journal_name=full_journal_name,
+                start_year=start_year,
+                end_year=end_year,
+                permission_name=build_permission_name(normalized_row, start_year, end_year),
+                permission_text=build_permission_text(normalized_row),
+                permission_url=first_url(normalized_row),
+                can_display_images=has_positive_permission_signal(normalized_row, subset_can_display),
+                notes=build_notes(normalized_row),
+            )
+
+
+def load_env_file(env_file: Optional[Path]) -> None:
+    if env_file is None:
+        return
+    if not env_file.exists():
+        raise FileNotFoundError(f"Environment file does not exist: {env_file}")
+
+    for raw_line in env_file.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip("'").strip('"')
+        environ.setdefault(key, value)
+
+
+def build_resource_lookup(db: Session) -> ResourceLookup:
+    resources = db.query(ResourceModel).all()
+    by_abbreviation: Dict[str, List[ResourceModel]] = {}
+    by_title: Dict[str, List[ResourceModel]] = {}
+    by_curie: Dict[str, ResourceModel] = {}
+
+    for resource in resources:
+        by_curie[resource.curie] = resource
+        if resource.title_abbreviation:
+            by_abbreviation.setdefault(normalize_abbreviation(resource.title_abbreviation), []).append(resource)
+        if resource.title:
+            by_title.setdefault(normalize_for_match(resource.title), []).append(resource)
+
+    return ResourceLookup(
+        resource_by_abbreviation=by_abbreviation,
+        resource_by_title=by_title,
+        resource_by_curie=by_curie,
+    )
+
+
+def choose_unique(candidates: List[ResourceModel]) -> Optional[ResourceModel]:
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        # Duplicate resources sometimes differ only by obsolete/import history.
+        # Prefer the lowest resource_id for deterministic dry-run reporting, but
+        # require manual review by treating the match as ambiguous.
+        return None
+    return None
+
+
+def find_resource(
+    row: JournalPermissionRow,
+    lookup: ResourceLookup,
+    manual_resource_map: Dict[str, str],
+) -> Tuple[Optional[ResourceModel], str]:
+    manual_key = row.journal_abbreviation or row.full_journal_name
+    manual_curie = manual_resource_map.get(manual_key)
+    if manual_curie:
+        resource = lookup.resource_by_curie.get(manual_curie)
+        if resource:
+            return resource, "manual"
+        return None, f"manual curie not found: {manual_curie}"
+
+    candidates = lookup.resource_by_abbreviation.get(normalize_abbreviation(row.journal_abbreviation), [])
+    resource = choose_unique(candidates)
+    if resource:
+        return resource, "title_abbreviation"
+    if len(candidates) > 1:
+        return None, "ambiguous title_abbreviation"
+
+    candidates = lookup.resource_by_title.get(normalize_for_match(row.full_journal_name), [])
+    resource = choose_unique(candidates)
+    if resource:
+        return resource, "title"
+    if len(candidates) > 1:
+        return None, "ambiguous title"
+
+    return None, "not found"
+
+
+def read_manual_resource_map(map_file: Optional[Path]) -> Dict[str, str]:
+    if map_file is None:
+        return {}
+    if not map_file.exists():
+        raise FileNotFoundError(f"Manual resource map does not exist: {map_file}")
+
+    mapping = {}
+    with map_file.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        for line_no, row in enumerate(reader, start=2):
+            journal = clean(row.get("Journal (NLM abbrev)") or row.get("journal") or row.get("journal_abbreviation"))
+            curie = clean(row.get("resource_curie") or row.get("curie"))
+            if not journal or not curie:
+                logger.warning(f"Manual map line {line_no}: skipped; expected journal and resource_curie")
+                continue
+            mapping[journal] = curie
+    return mapping
+
+
+def update_permission_fields(permission: ImagePermissionModel, row: JournalPermissionRow) -> bool:
+    changed = False
+    desired = {
+        "permission_text": row.permission_text,
+        "permission_url": row.permission_url,
+        "can_display_images": row.can_display_images,
+    }
+    for field, value in desired.items():
+        if getattr(permission, field) != value:
+            setattr(permission, field, value)
+            changed = True
+    return changed
+
+
+def permission_fields_changed(permission: ImagePermissionModel, row: JournalPermissionRow) -> bool:
+    return any([
+        permission.permission_text != row.permission_text,
+        permission.permission_url != row.permission_url,
+        permission.can_display_images != row.can_display_images,
+    ])
+
+
+def update_link_fields(link: ResourceImagePermissionModel, row: JournalPermissionRow) -> bool:
+    if link.notes != row.notes:
+        link.notes = row.notes
+        return True
+    return False
+
+
+def link_fields_changed(link: ResourceImagePermissionModel, row: JournalPermissionRow) -> bool:
+    return link.notes != row.notes
+
+
+def find_resource_link(
+    db: Session,
+    resource_id: int,
+    image_permission_id: int,
+    start_year: Optional[int],
+    end_year: Optional[int],
+) -> Optional[ResourceImagePermissionModel]:
+    return db.query(ResourceImagePermissionModel).filter(
+        ResourceImagePermissionModel.resource_id == resource_id,
+        ResourceImagePermissionModel.image_permission_id == image_permission_id,
+        func.coalesce(ResourceImagePermissionModel.start_year, -1) == (start_year if start_year is not None else -1),
+        func.coalesce(ResourceImagePermissionModel.end_year, -1) == (end_year if end_year is not None else -1),
+    ).one_or_none()
+
+
+def record_skipped_resource(stats: LoadStats, row: JournalPermissionRow, match_reason: str) -> None:
+    stats.rows_skipped += 1
+    if "ambiguous" in match_reason:
+        stats.resources_ambiguous += 1
+    else:
+        stats.resources_unmatched += 1
+    logger.warning(
+        f"Line {row.line_no}: skipped resource link ({match_reason}) for "
+        f"{row.journal_abbreviation or row.full_journal_name}"
+    )
+
+
+def upsert_permission(
+    db: Session,
+    row: JournalPermissionRow,
+    existing_permissions: Dict[str, ImagePermissionModel],
+    stats: LoadStats,
+    apply: bool,
+) -> Optional[ImagePermissionModel]:
+    permission = existing_permissions.get(row.permission_name)
+    if permission is None:
+        stats.permissions_created += 1
+        logger.info(f"Line {row.line_no}: create image_permission '{row.permission_name}'")
+        if not apply:
+            return None
+        permission = ImagePermissionModel(
+            name=row.permission_name,
+            permission_text=row.permission_text,
+            permission_url=row.permission_url,
+            can_display_images=row.can_display_images,
+        )
+        db.add(permission)
+        db.flush()
+        existing_permissions[row.permission_name] = permission
+        return permission
+
+    changed = update_permission_fields(permission, row) if apply else permission_fields_changed(permission, row)
+    if changed:
+        stats.permissions_updated += 1
+        logger.info(f"Line {row.line_no}: update image_permission '{row.permission_name}'")
+    else:
+        stats.permissions_unchanged += 1
+    return permission
+
+
+def upsert_resource_link(
+    db: Session,
+    row: JournalPermissionRow,
+    resource: ResourceModel,
+    permission: Optional[ImagePermissionModel],
+    stats: LoadStats,
+    apply: bool,
+) -> None:
+    image_permission_id = permission.image_permission_id if permission is not None else None
+    link = None
+    if image_permission_id is not None:
+        link = find_resource_link(
+            db,
+            resource.resource_id,
+            image_permission_id,
+            row.start_year,
+            row.end_year,
+        )
+
+    if link is None:
+        stats.links_created += 1
+        logger.info(
+            f"Line {row.line_no}: create resource_image_permission "
+            f"{resource.curie} -> '{row.permission_name}' ({range_label(row.start_year, row.end_year)})"
+        )
+        if apply:
+            db.add(ResourceImagePermissionModel(
+                resource_id=resource.resource_id,
+                image_permission_id=image_permission_id,
+                start_year=row.start_year,
+                end_year=row.end_year,
+                notes=row.notes,
+            ))
+        return
+
+    changed = update_link_fields(link, row) if apply else link_fields_changed(link, row)
+    if changed:
+        stats.links_updated += 1
+        logger.info(
+            f"Line {row.line_no}: update resource_image_permission "
+            f"{link.resource_image_permission_id}"
+        )
+    else:
+        stats.links_unchanged += 1
+
+
+def process_row(
+    db: Session,
+    row: JournalPermissionRow,
+    resource: ResourceModel,
+    existing_permissions: Dict[str, ImagePermissionModel],
+    stats: LoadStats,
+    apply: bool,
+) -> None:
+    savepoint = db.begin_nested() if apply else None
+    try:
+        permission = upsert_permission(db, row, existing_permissions, stats, apply)
+        upsert_resource_link(db, row, resource, permission, stats, apply)
+        if savepoint:
+            savepoint.commit()
+    except IntegrityError as err:
+        if savepoint:
+            savepoint.rollback()
+        stats.errors += 1
+        logger.error(f"Line {row.line_no}: integrity error for {row.permission_name}: {err}")
+    except Exception as err:
+        if savepoint:
+            savepoint.rollback()
+        stats.errors += 1
+        logger.error(f"Line {row.line_no}: error for {row.permission_name}: {err}")
+
+
+def load_permissions(
+    db: Session,
+    input_file: Path,
+    manual_resource_map: Dict[str, str],
+    apply: bool,
+    subset_can_display: bool,
+) -> LoadStats:
+    stats = LoadStats()
+    lookup = build_resource_lookup(db)
+    existing_permissions = {
+        permission.name: permission
+        for permission in db.query(ImagePermissionModel).all()
+    }
+
+    for row in parse_tsv(input_file, subset_can_display):
+        stats.rows_seen += 1
+        resource, match_reason = find_resource(row, lookup, manual_resource_map)
+        if resource is None:
+            record_skipped_resource(stats, row, match_reason)
+            continue
+        process_row(db, row, resource, existing_permissions, stats, apply)
+
+    if apply:
+        db.commit()
+    else:
+        db.rollback()
+
+    return stats
+
+
+def log_summary(stats: LoadStats, apply: bool) -> None:
+    mode = "APPLIED" if apply else "DRY RUN"
+    logger.info("=" * 60)
+    logger.info(f"{mode} summary")
+    logger.info(f"Rows seen: {stats.rows_seen}")
+    logger.info(f"Rows skipped: {stats.rows_skipped}")
+    logger.info(f"Resource unmatched: {stats.resources_unmatched}")
+    logger.info(f"Resource ambiguous: {stats.resources_ambiguous}")
+    logger.info(f"Image permissions created: {stats.permissions_created}")
+    logger.info(f"Image permissions updated: {stats.permissions_updated}")
+    logger.info(f"Image permissions unchanged: {stats.permissions_unchanged}")
+    logger.info(f"Resource links created: {stats.links_created}")
+    logger.info(f"Resource links updated: {stats.links_updated}")
+    logger.info(f"Resource links unchanged: {stats.links_unchanged}")
+    logger.info(f"Errors: {stats.errors}")
+    logger.info("No rows are deleted by this loader.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Upsert journal image permissions from journal_permission.tsv"
+    )
+    parser.add_argument(
+        "--input-file",
+        default=DEFAULT_INPUT_FILE,
+        help=f"TSV input file; default: {DEFAULT_INPUT_FILE}",
+    )
+    parser.add_argument(
+        "--env-file",
+        default=None,
+        help="Optional env file to load before connecting, e.g. .env_codex",
+    )
+    parser.add_argument(
+        "--resource-map",
+        default=None,
+        help="Optional TSV with Journal (NLM abbrev) and resource_curie columns for manual matches",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit inserts/updates. Default is dry-run.",
+    )
+    parser.add_argument(
+        "--subset-can-display",
+        action="store_true",
+        help="Treat 'Granted for a subset' style values as can_display_images=True.",
+    )
+    args = parser.parse_args()
+
+    input_file = Path(args.input_file)
+    env_file = Path(args.env_file) if args.env_file else None
+    resource_map_file = Path(args.resource_map) if args.resource_map else None
+
+    if not input_file.exists():
+        raise FileNotFoundError(f"Input file does not exist: {input_file}")
+
+    load_env_file(env_file)
+    manual_resource_map = read_manual_resource_map(resource_map_file)
+
+    db = create_postgres_session(False)
+    try:
+        if args.apply:
+            set_global_user_id(db, SCRIPT_USER)
+        else:
+            logger.info("Running in dry-run mode. Pass --apply to commit changes.")
+
+        stats = load_permissions(
+            db=db,
+            input_file=input_file,
+            manual_resource_map=manual_resource_map,
+            apply=args.apply,
+            subset_can_display=args.subset_can_display,
+        )
+        log_summary(stats, args.apply)
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_journal_image_permissions.py
@@ -70,6 +70,10 @@ PERMISSION_URL_PATTERN = re.compile(
     r"(copyright|licens|open[-_]?access|permission|polic|reprint|rights)",
     flags=re.IGNORECASE,
 )
+ACTIONABLE_COMMENT_PATTERN = re.compile(
+    r"(acknowledg|attribution|copyright|creative commons|display|license|licens|permission|reproduce|reprint|rights)",
+    flags=re.IGNORECASE,
+)
 URL_LABEL_WORD_RE = re.compile(r"[a-z0-9]+", flags=re.IGNORECASE)
 
 
@@ -89,7 +93,7 @@ class JournalPermissionRow:
     permission_text: str
     permission_url: Optional[str]
     can_display_images: bool
-    notes: str
+    notes: Optional[str]
 
 
 @dataclass
@@ -234,14 +238,18 @@ def build_permission_text(row: Dict[str, str]) -> str:
     return ""
 
 
-def build_notes(row: Dict[str, str]) -> str:
+def build_notes(row: Dict[str, str]) -> Optional[str]:
     notes = []
     for column in NOTE_COLUMNS:
         value = clean(row.get(column))
+        if not value or is_blankish(value):
+            continue
+        if column == "Comments" and not ACTIONABLE_COMMENT_PATTERN.search(value):
+            continue
         if value and not is_blankish(value):
             notes.append(f"{column}: {value}")
 
-    return "\n".join(notes)
+    return "\n".join(notes) or None
 
 
 def has_positive_permission_signal(row: Dict[str, str], subset_can_display: bool) -> bool:


### PR DESCRIPTION
along with the script for loading image permission data that curators collected.

can_display_images generation precedence:

 1. reference.copyright_license.open_access → true - show "reference open access" in UI
 2. resource.copyright_license.open_access (if publication_year > license_start_year) → true - show "resource open access"  in UI
 3. resource_image_permission.can_display_images → true - shows permission name in UI
 4. false