### PR TITLE
fix(api): align ReferenceEmailSchemaRelated with renamed is_primary column

### DIFF
--- a/agr_literature_service/api/schemas/reference_schemas.py
+++ b/agr_literature_service/api/schemas/reference_schemas.py
@@ -148,7 +148,7 @@ class ReferenceEmailSchemaRelated(BaseModel):
     email_id: int
     email_address: str
     person_id: Optional[int] = None
-    primary: Optional[bool] = None
+    is_primary: Optional[bool] = None
     date_invalidated: Optional[str] = None
 
 


### PR DESCRIPTION
## Summary
- Completes the column rename started in `d458b9ce` (*refactor(api): rename PG-reserved-word columns and add pg_trgm indices*).
- That commit renamed `primary` → `is_primary` in the model column and in the `reference_crud.show()` payload (line 928), but missed the corresponding response schema. With `ConfigDict(extra='forbid')` set on `ReferenceEmailSchemaRelated`, every `GET /reference/{curie}` for a reference with at least one associated email started returning 500 with:

  ```
  Error in get_db: 1 validation errors:
    {'type': 'extra_forbidden',
     'loc': ('response', 'emails', 0, 'is_primary'),
     'msg': 'Extra inputs are not permitted', 'input': None}
  ```

- The number of validation errors per response equals the email count on the reference (one paper with 14 emails → 14 errors in a single request).
- Surfaced in the SCRUM-6018 TET validation grid as a non-deterministic "Could not resolve N IDs" banner — the failing curies were always the ones that had emails attached.

## Fix
One-line rename: `primary: Optional[bool]` → `is_primary: Optional[bool]` in `agr_literature_service/api/schemas/reference_schemas.py:151`, so the schema matches the data dict the CRUD already produces and the column the model already exposes (`EmailModel.is_primary`).

## Test plan
- [ ] Run the existing reference test suite — should still pass.
- [ ] `GET /reference/{curie}` for a reference with associated emails returns `200` (e.g. `AGRKB:101000001242169` had 14 emails and was 500-ing on every attempt).
- [ ] `GET /reference/{curie}` for a reference *without* emails still returns `200` (unchanged behaviour).
- [ ] No client/UI consumer needs to change — the wire field has *always* been `is_primary` in `EmailSchemaShow` / `EmailSchemaRelated`; this PR just realigns `ReferenceEmailSchemaRelated` with the rest of the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)