### PR TITLE
preserve emails with reference relations on person/email deletion and add retraction_status to search endpoint

### DIFF
--- a/agr_literature_service/api/crud/email_crud.py
+++ b/agr_literature_service/api/crud/email_crud.py
@@ -8,7 +8,7 @@ from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
-from agr_literature_service.api.models import EmailModel, PersonModel
+from agr_literature_service.api.models import EmailModel, PersonModel, ReferenceEmailModel
 from agr_literature_service.api.crud.person_crud import normalize_email
 from agr_literature_service.api.crud.user_utils import map_to_user_id
 
@@ -197,11 +197,32 @@ def patch(db: Session, email_id: int, patch_dict: Dict[str, Any]) -> Dict[str, A
 
 
 def destroy(db: Session, email_id: int) -> None:
+    """
+    Delete an email row.
+
+    This will fail if the email has any reference_email relations.
+    Use this only for emails that are not linked to any references.
+    """
     obj = db.query(EmailModel).filter(EmailModel.email_id == email_id).first()
     if not obj:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Email with email_id {email_id} not found",
         )
+
+    # Check if this email has any reference relations
+    has_reference_relations = (
+        db.query(ReferenceEmailModel.reference_email_id)
+        .filter(ReferenceEmailModel.email_id == email_id)
+        .first()
+        is not None
+    )
+    if has_reference_relations:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Cannot delete email {email_id}: it has reference relations. "
+                   "Remove the reference-email links first.",
+        )
+
     db.delete(obj)
     db.commit()

--- a/agr_literature_service/api/crud/email_crud.py
+++ b/agr_literature_service/api/crud/email_crud.py
@@ -135,6 +135,15 @@ def patch(db: Session, email_id: int, patch_dict: Dict[str, Any]) -> Dict[str, A
       - date_invalidated
       - is_primary (for person emails, must be True/False, not None)
         * If set to True, demotes other primaries for the same person.
+
+    WARNING: Email rows may be shared between Person and Reference records.
+    An email with person_id set is owned by that Person, but it may also be
+    linked to References via the reference_email table. Patching the email_address
+    here will affect BOTH the Person's email AND any Reference associations.
+
+    Similarly, emails created via reference PUT/POST (with person_id=NULL) may
+    later be associated with a Person. Use caution when modifying email_address
+    to avoid unintended side effects on person-email data.
     """
     obj: Optional[EmailModel] = db.query(EmailModel).filter(EmailModel.email_id == email_id).first()
     if not obj:
@@ -202,6 +211,19 @@ def destroy(db: Session, email_id: int) -> None:
 
     This will fail if the email has any reference_email relations.
     Use this only for emails that are not linked to any references.
+
+    WARNING: Email rows may be shared between Person and Reference records.
+    Even if an email row has person_id=NULL (i.e., not currently owned by a
+    Person), it may have been created via a reference and could later be
+    associated with a Person.
+
+    Deleting Person-owned emails (person_id NOT NULL) is generally safe if
+    there are no reference relations, but be aware that:
+    - Scripts processing references only modify reference_email associations
+    - They do NOT delete underlying email rows
+    - Deleting an email that a Person relies on will remove it from their record
+
+    Always verify that the email is not in use by any Person before deleting.
     """
     obj = db.query(EmailModel).filter(EmailModel.email_id == email_id).first()
     if not obj:

--- a/agr_literature_service/api/crud/person_crud.py
+++ b/agr_literature_service/api/crud/person_crud.py
@@ -14,6 +14,7 @@ from agr_literature_service.api.models import (
     PersonCrossReferenceModel,
     PersonNameModel,
     PersonNoteModel,
+    ReferenceEmailModel,
 )
 from agr_literature_service.api.schemas import PersonSchemaCreate
 from agr_literature_service.api.crud.user_utils import map_to_user_id
@@ -218,6 +219,13 @@ def create(db: Session, payload: PersonSchemaCreate) -> PersonModel:  # noqa: C9
 
 
 def destroy(db: Session, curie_or_person_id: str) -> None:
+    """
+    Delete a person and handle their email records appropriately.
+
+    Emails that have reference relations are detached (person_id set to NULL)
+    instead of deleted, to preserve the reference-email links.
+    Emails without reference relations are deleted.
+    """
     person_id = resolve_person_id(db, curie_or_person_id)
     obj: Optional[PersonModel] = (
         db.query(PersonModel).filter(PersonModel.person_id == person_id).first()
@@ -227,6 +235,25 @@ def destroy(db: Session, curie_or_person_id: str) -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Person with curie or person_id {curie_or_person_id} not found",
         )
+
+    # Handle emails: detach those with reference relations, delete others
+    person_emails = db.query(EmailModel).filter(EmailModel.person_id == person_id).all()
+
+    for email in person_emails:
+        has_reference_relations = (
+            db.query(ReferenceEmailModel.reference_email_id)
+            .filter(ReferenceEmailModel.email_id == email.email_id)
+            .first()
+            is not None
+        )
+        if has_reference_relations:
+            # Detach from person but preserve the email for reference relations
+            email.person_id = None
+            email.is_primary = None
+        else:
+            # No reference relations, safe to delete
+            db.delete(email)
+
     db.delete(obj)
     db.commit()
 

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -537,6 +537,16 @@ def set_reference_emails(db: Session, curie_or_reference_id: str, email_addresse
     Then:
       - Delete existing reference_email rows for this reference.
       - Insert new reference_email rows for each resolved email_id.
+
+    NOTE: This function only modifies the reference_email association table.
+    It does NOT delete any rows from the email table, even when email addresses
+    are removed from a reference. This is intentional because:
+      - Email rows may be shared with Person records (via person_id).
+      - Deleting an email row could corrupt person-email data.
+      - Orphaned email rows (person_id=NULL, no reference_email links) are harmless.
+
+    If you need to delete email rows, use email_crud.destroy() with caution,
+    and only after verifying the email has no Person or Reference relations.
     """
 
     reference = get_reference(db, curie_or_reference_id)
@@ -610,9 +620,13 @@ def set_reference_emails(db: Session, curie_or_reference_id: str, email_addresse
 def add_reference_email(db: Session, curie_or_reference_id: str, email_address: str):
     """
     Add a single email association to a reference.
-    - Reuse active EmailModel if exists.
+    - Reuse active EmailModel if exists (may be owned by a Person).
     - Otherwise create a new EmailModel (person_id=NULL, is_primary=NULL).
     - Add a new reference_email row (unless it already exists).
+
+    NOTE: Email rows are reused, not duplicated. If an email_address already
+    exists in the email table (including Person-owned emails), that row is
+    linked via reference_email rather than creating a duplicate.
     """
     reference = get_reference(db, curie_or_reference_id)
     ref_id = reference.reference_id
@@ -678,6 +692,10 @@ def add_reference_email(db: Session, curie_or_reference_id: str, email_address: 
 def delete_reference_email(db: Session, curie_or_reference_id: str, reference_email_id: int):
     """
     Remove one reference_email row linking a reference to an email.
+
+    NOTE: This only removes the association in reference_email table.
+    The underlying email row in the email table is NOT deleted.
+    See set_reference_emails() docstring for rationale.
     """
     reference = get_reference(db, curie_or_reference_id)
     ref_id = reference.reference_id

--- a/agr_literature_service/api/crud/search_crud.py
+++ b/agr_literature_service/api/crud/search_crud.py
@@ -191,6 +191,13 @@ def search_references(
                     "size": facets_limits.get("pubmed_publication_status.keyword", 10)
                 }
             },
+            "retraction_status.keyword": {
+                "terms": {
+                    "field": "retraction_status",
+                    "min_doc_count": 0,
+                    "size": facets_limits.get("retraction_status.keyword", 10)
+                }
+            },
             "mods_in_corpus.keyword": {
                 "terms": {
                     "field": "mods_in_corpus.keyword",
@@ -534,6 +541,11 @@ def process_search_results(res, wft_mod_abbreviations):  # pragma: no cover
         inner = agg.get("terms") if "terms" in agg else agg.get("aggs", {}).get("terms")
         if isinstance(inner, dict) and "buckets" in inner:
             res['aggregations']["authors.name.keyword"] = inner
+
+    # add human-readable names to retraction_status aggregation
+    retraction_status_agg = res["aggregations"].get("retraction_status.keyword")
+    if retraction_status_agg:
+        add_curie_to_name_values(retraction_status_agg)
 
     return {
         "hits": hits,

--- a/agr_literature_service/api/crud/search_crud.py
+++ b/agr_literature_service/api/crud/search_crud.py
@@ -428,10 +428,12 @@ def search_references(
                             }
                         })
                 else:
+                    # Map facet field to actual ES field (retraction_status is keyword type, no .keyword suffix)
+                    es_field = "retraction_status" if facet_field == "retraction_status.keyword" else facet_field
                     # Bundle multiple values under a single bool.must for this field
                     group: Dict[str, Any] = {"bool": {"must": []}}
                     for facet_value in facet_list_values:
-                        group["bool"]["must"].append({"term": {facet_field: facet_value}})
+                        group["bool"]["must"].append({"term": {es_field: facet_value}})
                     es_body["query"]["bool"]["filter"]["bool"]["must"].append(group)
 
     # Facets (negative)
@@ -449,8 +451,10 @@ def search_references(
                         }
                     })
             else:
+                # Map facet field to actual ES field (retraction_status is keyword type, no .keyword suffix)
+                es_field = "retraction_status" if facet_field == "retraction_status.keyword" else facet_field
                 for facet_value in facet_list_values:
-                    es_body["query"]["bool"]["filter"]["bool"]["must_not"].append({"term": {facet_field: facet_value}})
+                    es_body["query"]["bool"]["filter"]["bool"]["must_not"].append({"term": {es_field: facet_value}})
 
     # Date ranges
     date_range = apply_all_date_filters(

--- a/agr_literature_service/api/models/email_model.py
+++ b/agr_literature_service/api/models/email_model.py
@@ -26,9 +26,11 @@ class EmailModel(Base, AuditedModel):
     email_id = Column(Integer, primary_key=True, autoincrement=True)
 
     # Allow person_id to be NULL
+    # Use SET NULL instead of CASCADE so emails with reference relations
+    # are preserved (detached) when a person is deleted.
     person_id = Column(
         Integer,
-        ForeignKey("person.person_id", ondelete="CASCADE"),
+        ForeignKey("person.person_id", ondelete="SET NULL"),
         nullable=True,
         index=True,
     )

--- a/agr_literature_service/api/models/person_model.py
+++ b/agr_literature_service/api/models/person_model.py
@@ -42,7 +42,9 @@ class PersonModel(Base, AuditedModel):
     # Note: cascade does NOT include "delete" or "delete-orphan" for emails.
     # Email deletion is handled manually in person_crud.destroy() to preserve
     # emails that have reference relations (they get detached instead of deleted).
-    emails = relationship("EmailModel", back_populates="person")
+    # passive_deletes=True tells SQLAlchemy to let the DB handle SET NULL via FK constraint,
+    # avoiding redundant loads and updates when a person is deleted.
+    emails = relationship("EmailModel", back_populates="person", passive_deletes=True)
     cross_references = relationship("PersonCrossReferenceModel", back_populates="person", cascade="all, delete-orphan")
     settings = relationship("PersonSettingModel", back_populates="person", cascade="all, delete-orphan")
     names = relationship("PersonNameModel", back_populates="person", cascade="all, delete-orphan")

--- a/agr_literature_service/api/models/person_model.py
+++ b/agr_literature_service/api/models/person_model.py
@@ -39,7 +39,10 @@ class PersonModel(Base, AuditedModel):
     biography_research_interest = Column(String(), nullable=True)
 
     # Only keep these relationships
-    emails = relationship("EmailModel", back_populates="person", cascade="all, delete-orphan")
+    # Note: cascade does NOT include "delete" or "delete-orphan" for emails.
+    # Email deletion is handled manually in person_crud.destroy() to preserve
+    # emails that have reference relations (they get detached instead of deleted).
+    emails = relationship("EmailModel", back_populates="person")
     cross_references = relationship("PersonCrossReferenceModel", back_populates="person", cascade="all, delete-orphan")
     settings = relationship("PersonSettingModel", back_populates="person", cascade="all, delete-orphan")
     names = relationship("PersonNameModel", back_populates="person", cascade="all, delete-orphan")

--- a/alembic/versions/20260511_0a43280cf638_change_email_person_fk_to_set_null.py
+++ b/alembic/versions/20260511_0a43280cf638_change_email_person_fk_to_set_null.py
@@ -1,6 +1,6 @@
 """change email.person_id FK from CASCADE to SET NULL
 
-Revision ID: 6a1b2c3d4e5f
+Revision ID: 0a43280cf638
 Revises: 5f3a8e2d1c4b
 Create Date: 2026-05-11
 
@@ -15,7 +15,7 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = "6a1b2c3d4e5f"
+revision = "0a43280cf638"
 down_revision = "5f3a8e2d1c4b"
 branch_labels = None
 depends_on = None

--- a/alembic/versions/20260511_change_email_person_fk_to_set_null.py
+++ b/alembic/versions/20260511_change_email_person_fk_to_set_null.py
@@ -1,0 +1,51 @@
+"""change email.person_id FK from CASCADE to SET NULL
+
+Revision ID: 6a1b2c3d4e5f
+Revises: 5f3a8e2d1c4b
+Create Date: 2026-05-11
+
+This migration changes the foreign key constraint on email.person_id
+from ON DELETE CASCADE to ON DELETE SET NULL.
+
+This ensures that when a person is deleted, their emails that have
+reference relations are preserved (detached) instead of being deleted
+along with their reference_email links.
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "6a1b2c3d4e5f"
+down_revision = "5f3a8e2d1c4b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop the existing FK constraint with CASCADE
+    op.drop_constraint("email_person_id_fkey", "email", type_="foreignkey")
+
+    # Create new FK constraint with SET NULL
+    op.create_foreign_key(
+        "email_person_id_fkey",
+        "email",
+        "person",
+        ["person_id"],
+        ["person_id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade():
+    # Drop the SET NULL FK constraint
+    op.drop_constraint("email_person_id_fkey", "email", type_="foreignkey")
+
+    # Restore the original CASCADE FK constraint
+    op.create_foreign_key(
+        "email_person_id_fkey",
+        "email",
+        "person",
+        ["person_id"],
+        ["person_id"],
+        ondelete="CASCADE",
+    )


### PR DESCRIPTION

- Change email.person_id FK from CASCADE to SET NULL
- Remove cascade delete-orphan from PersonModel.emails relationship
- Add check in email_crud.destroy() to prevent deletion of emails with reference relations
- Update person_crud.destroy() to detach emails with reference relations instead of deleting
- Add migration to update FK constraint in database

This ensures that emails linked to references are preserved when:
- A person is deleted (email becomes orphan with person_id=NULL)
- An email is directly deleted (returns 422 error instead)