### PR TITLE
fix(api): tighten schema validation to reject unknown PATCH/POST fields

### DIFF
--- a/agr_literature_service/api/schemas/base_schemas.py
+++ b/agr_literature_service/api/schemas/base_schemas.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, ConfigDict
 
 
 class AuditedObjectModelSchema(BaseModel):
-    model_config = ConfigDict(extra="ignore", from_attributes=True)
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
 
     date_created: Optional[datetime] = None
     date_updated: Optional[datetime] = None

--- a/agr_literature_service/api/schemas/copyright_license_schemas.py
+++ b/agr_literature_service/api/schemas/copyright_license_schemas.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict
 class CopyrightLicenseSchemaPost(BaseModel):
     """Schema for creating or posting a copyright license."""
     model_config = ConfigDict(
-        extra='ignore',        # ignore unexpected fields
+        extra='forbid',        # forbid unexpected fields
         from_attributes=True    # enable ORM->model initialization
     )
 


### PR DESCRIPTION
SCRUM-1899: PATCH/POST bodies with bogus field names silently returned 202/201 instead of erroring. Switch the affected schemas to Pydantic's extra='forbid' so unknown fields produce a 422.

- CopyrightLicenseSchemaPost: extra='ignore' -> 'forbid'. Was originally forbid; loosened in acb664cd "fixing unit test errors" in 2025-07. Current tests only send the four real fields, so the original failure no longer reproduces.
- AuditedObjectModelSchema (base): extra='ignore' -> 'forbid' as a safer default for future schemas. Every existing subclass declares its own model_config, so behavior is unchanged today.

FacetsOptionsSchema (search filters) intentionally left as 'ignore' -- it absorbs legacy field names by design.