### PR TITLE
feat(SCRUM-6055): add /by_md5 endpoint to look up referencefiles by checksum

### DIFF
--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -205,23 +205,39 @@ def get_referencefiles_by_md5(db: Session, md5sum: str) -> List[dict]:
 
         mods_payload: List[dict] = []
         for ref_file_mod in ref_file.referencefile_mods:
-            mod_payload = jsonable_encoder(ref_file_mod)
-            mod_payload.pop("mod_id", None)
-            mod_payload.pop("referencefile_id", None)
-            mod_payload["mod_abbreviation"] = (
-                ref_file_mod.mod.abbreviation if ref_file_mod.mod is not None else None
-            )
-            mods_payload.append(mod_payload)
+            mods_payload.append({
+                "referencefile_mod_id": ref_file_mod.referencefile_mod_id,
+                "mod_abbreviation": (
+                    ref_file_mod.mod.abbreviation if ref_file_mod.mod is not None else None
+                ),
+                "date_created": ref_file_mod.date_created,
+                "date_updated": ref_file_mod.date_updated,
+                "created_by": ref_file_mod.created_by,
+                "updated_by": ref_file_mod.updated_by,
+            })
 
-        match_payload = jsonable_encoder(ref_file)
-        match_payload["reference_curie"] = reference.curie
-        match_payload["open_access"] = open_access
-        match_payload["copyright_license_name"] = copyright_license_name
-        match_payload["referencefile_mods"] = mods_payload
-        match_payload["converted_referencefiles"] = _find_converted_derived_for_source(
-            db, ref_file
-        )
-        results.append(match_payload)
+        results.append({
+            "referencefile_id": ref_file.referencefile_id,
+            "reference_id": ref_file.reference_id,
+            "reference_curie": reference.curie,
+            "display_name": ref_file.display_name,
+            "file_class": ref_file.file_class,
+            "file_publication_status": ref_file.file_publication_status,
+            "file_extension": ref_file.file_extension,
+            "pdf_type": ref_file.pdf_type,
+            "md5sum": ref_file.md5sum,
+            "is_annotation": bool(ref_file.is_annotation),
+            "open_access": open_access,
+            "copyright_license_name": copyright_license_name,
+            "date_created": ref_file.date_created,
+            "date_updated": ref_file.date_updated,
+            "created_by": ref_file.created_by,
+            "updated_by": ref_file.updated_by,
+            "referencefile_mods": mods_payload,
+            "converted_referencefiles": _find_converted_derived_for_source(
+                db, ref_file
+            ),
+        })
     return results
 
 

--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -122,6 +122,109 @@ def show(db: Session, referencefile_id: int):
     return referencefile_dict
 
 
+_CONVERTED_FILE_CLASS_FOR_SOURCE = {
+    "main": "converted_merged_main",
+    "supplement": "converted_merged_supplement",
+    "nXML": "converted_merged_main",
+}
+
+# Suffixes appended to a source's display_name by the conversion pipeline
+# (pdf2md_utils, the legacy TEI→MD batch, and the nXML→MD path). Kept in
+# sync with file_conversion_crud._SUFFIX_TO_SOURCE_CLASS and
+# _PDFX_METHOD_SUFFIXES.
+_CONVERTED_DISPLAY_NAME_SUFFIXES = (
+    "_merged", "_grobid", "_docling", "_marker", "_tei", "_nxml",
+)
+
+
+def _find_converted_derived_for_source(db: Session,
+                                       source_ref_file: ReferencefileModel) -> List[dict]:
+    """Return converted Markdown referencefiles produced from ``source_ref_file``.
+
+    Uses the display_name suffix convention written by the conversion
+    pipeline to map a converted row back to its source PDF/nXML — same
+    convention used by ``file_conversion_crud._infer_source_info``.
+    """
+    converted_file_class = _CONVERTED_FILE_CLASS_FOR_SOURCE.get(source_ref_file.file_class)
+    if not converted_file_class:
+        return []
+    rows = db.query(ReferencefileModel).filter(
+        ReferencefileModel.reference_id == source_ref_file.reference_id,
+        ReferencefileModel.file_class == converted_file_class,
+        ReferencefileModel.file_extension == "md",
+        ReferencefileModel.file_publication_status == "final",
+    ).all()
+    derived: List[dict] = []
+    source_display_name = source_ref_file.display_name or ""
+    for r in rows:
+        display_name = r.display_name or ""
+        if not display_name.startswith(source_display_name):
+            continue
+        suffix = display_name[len(source_display_name):]
+        if suffix not in _CONVERTED_DISPLAY_NAME_SUFFIXES:
+            continue
+        derived.append({
+            "referencefile_id": int(r.referencefile_id),
+            "display_name": r.display_name,
+            "file_class": r.file_class,
+            "file_extension": r.file_extension,
+        })
+    return derived
+
+
+def get_referencefiles_by_md5(db: Session, md5sum: str) -> List[dict]:
+    """Look up every referencefile with the given MD5 checksum.
+
+    Supports the PDF-only ingestion flow (SCRUM-6055): given an MD5 the
+    client computed from an uploaded PDF, return any matching referencefiles
+    together with the reference curie, MOD associations, open-access /
+    license info, and (for source files) the converted Markdown rows
+    derived from that same source. A single MD5 may resolve to multiple
+    referencefiles when the same content is attached to more than one
+    reference.
+    """
+    ref_files = (
+        db.query(ReferencefileModel)
+        .filter(ReferencefileModel.md5sum == md5sum)
+        .options(
+            joinedload(ReferencefileModel.referencefile_mods).joinedload(
+                ReferencefileModAssociationModel.mod
+            ),
+            joinedload(ReferencefileModel.reference).joinedload(
+                ReferenceModel.copyright_license
+            ),
+        )
+        .all()
+    )
+    results: List[dict] = []
+    for ref_file in ref_files:
+        reference = ref_file.reference
+        copyright_license = reference.copyright_license if reference else None
+        open_access = bool(copyright_license and copyright_license.open_access)
+        copyright_license_name = copyright_license.name if copyright_license else None
+
+        mods_payload: List[dict] = []
+        for ref_file_mod in ref_file.referencefile_mods:
+            mod_payload = jsonable_encoder(ref_file_mod)
+            mod_payload.pop("mod_id", None)
+            mod_payload.pop("referencefile_id", None)
+            mod_payload["mod_abbreviation"] = (
+                ref_file_mod.mod.abbreviation if ref_file_mod.mod is not None else None
+            )
+            mods_payload.append(mod_payload)
+
+        match_payload = jsonable_encoder(ref_file)
+        match_payload["reference_curie"] = reference.curie
+        match_payload["open_access"] = open_access
+        match_payload["copyright_license_name"] = copyright_license_name
+        match_payload["referencefile_mods"] = mods_payload
+        match_payload["converted_referencefiles"] = _find_converted_derived_for_source(
+            db, ref_file
+        )
+        results.append(match_payload)
+    return results
+
+
 def show_all(db: Session, curie_or_reference_id: str) -> List[ReferencefileSchemaRelated]:
     logger.info("Show all referencefiles")
     reference = get_reference(db=db, curie_or_reference_id=curie_or_reference_id, load_referencefiles=True)

--- a/agr_literature_service/api/routers/referencefile_router.py
+++ b/agr_literature_service/api/routers/referencefile_router.py
@@ -18,7 +18,8 @@ from agr_literature_service.api.schemas import ResponseMessageSchema
 from agr_literature_service.api.schemas.file_conversion_schemas import \
     ConversionStatusResponseSchema
 from agr_literature_service.api.schemas.referencefile_schemas import ReferencefileSchemaShow, \
-    ReferencefileSchemaUpdate, ReferencefileSchemaRelated, ReferenceFileAllMainPDFIdsSchemaPost
+    ReferencefileSchemaUpdate, ReferencefileSchemaRelated, ReferenceFileAllMainPDFIdsSchemaPost, \
+    ReferencefileByMd5MatchSchema
 from agr_literature_service.api.utils.bulk_upload_utils import validate_archive_structure
 from agr_literature_service.api.utils.bulk_upload_manager import upload_manager
 from agr_literature_service.api.utils.bulk_upload_processor import process_bulk_upload_async
@@ -139,6 +140,28 @@ def download_additional_files_tarball(reference_id: int,
                                       user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
                                       db: Session = db_session):
     return referencefile_crud.download_additional_files_tarball(db, reference_id, get_mod_access(user) if user else [])
+
+
+@router.get('/by_md5/{md5sum}',
+            status_code=status.HTTP_200_OK,
+            response_model=List[ReferencefileByMd5MatchSchema])
+def show_by_md5(md5sum: str,
+                user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+                db: Session = db_session):
+    """
+    Look up referencefiles by MD5 checksum.
+
+    Supports PDF-only ingestion: a client that has computed the MD5 of a
+    local PDF can ask whether ABC already knows that content. Returns an
+    empty list if no referencefile matches.
+
+    Each match includes the reference curie / ABC Literature ID, MOD
+    associations, open-access flag, and any converted Markdown
+    referencefiles already derived from this source (when the match is a
+    PDF or nXML source). Multiple matches are possible when the same
+    content is attached to more than one reference.
+    """
+    return referencefile_crud.get_referencefiles_by_md5(db, md5sum)
 
 
 @router.delete('/{referencefile_id}',

--- a/agr_literature_service/api/schemas/referencefile_schemas.py
+++ b/agr_literature_service/api/schemas/referencefile_schemas.py
@@ -87,3 +87,45 @@ class ReferenceFileAllMainPDFIdsSchemaPost(BaseModel):
 
     curies: List[str]
     mod_abbreviation: str
+
+
+class ReferencefileConvertedDerivedSchema(BaseModel):
+    """A converted Markdown referencefile derived from a given source PDF/nXML."""
+    model_config = ConfigDict(
+        extra='forbid',
+        from_attributes=True
+    )
+
+    referencefile_id: int
+    display_name: str
+    file_class: str
+    file_extension: str
+
+
+class ReferencefileByMd5MatchSchema(AuditedObjectModelSchema):
+    """A referencefile matched by MD5 plus context needed by PDF-only callers.
+
+    Returned by ``GET /reference/referencefile/by_md5/{md5sum}``. For source
+    PDFs (file_class ``main``/``supplement``) or nXML inputs (file_class
+    ``nXML``), ``converted_referencefiles`` lists any converted Markdown
+    rows currently in the DB that were produced from this same source.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+        from_attributes=True
+    )
+
+    referencefile_id: int
+    reference_id: int
+    reference_curie: str
+    display_name: str
+    file_class: str
+    file_publication_status: str
+    file_extension: str
+    pdf_type: Optional[str] = None
+    md5sum: str
+    is_annotation: bool
+    open_access: bool
+    copyright_license_name: Optional[str] = None
+    referencefile_mods: List[ReferencefileModSchemaRelated]
+    converted_referencefiles: List[ReferencefileConvertedDerivedSchema]

--- a/tests/api/test_referencefile.py
+++ b/tests/api/test_referencefile.py
@@ -233,3 +233,99 @@ class TestReferencefile:
                 assert mod["mod_abbreviation"] in mods_to_check
                 mods_to_check.remove(mod["mod_abbreviation"])
             assert len(mods_to_check) == 0
+
+    def test_show_by_md5_no_match(self, db, test_referencefile, auth_headers):  # noqa
+        with TestClient(app) as client:
+            response = client.get(url="/reference/referencefile/by_md5/nonexistentmd5",
+                                  headers=auth_headers)
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json() == []
+
+    def test_show_by_md5_single_match(self, db, test_referencefile, auth_headers):  # noqa
+        with TestClient(app) as client:
+            response = client.get(
+                url=f"/reference/referencefile/by_md5/{test_referencefile.md5sum}",
+                headers=auth_headers)
+            assert response.status_code == status.HTTP_200_OK
+            matches = response.json()
+            assert len(matches) == 1
+            match = matches[0]
+            assert match["referencefile_id"] == test_referencefile.referencefile_id
+            assert match["md5sum"] == test_referencefile.md5sum
+            assert match["display_name"] == "Bob"
+            assert match["file_class"] == "main"
+            assert match["file_extension"] == "pdf"
+            assert match["pdf_type"] == "pdf"
+            assert match["reference_curie"] == test_referencefile.reference.curie
+            assert match["reference_id"] == test_referencefile.reference_id
+            # No copyright license attached → open_access defaults to False
+            assert match["open_access"] is False
+            assert match["copyright_license_name"] is None
+            # No converted Markdown rows exist for this PDF
+            assert match["converted_referencefiles"] == []
+
+    def test_show_by_md5_multi_reference_match(self, db, test_referencefile, test_reference2, auth_headers):  # noqa
+        populate_test_mods()
+        shared_md5 = test_referencefile.md5sum
+        second_file = {
+            "display_name": "Bob",
+            "reference_curie": test_reference2.new_ref_curie,
+            "file_class": "main",
+            "file_publication_status": "final",
+            "file_extension": "pdf",
+            "pdf_type": "pdf",
+            "md5sum": shared_md5,
+            "mod_abbreviation": "WB"
+        }
+        second_file_id = create_metadata(db, ReferencefileSchemaPost(**second_file))
+        with TestClient(app) as client:
+            response = client.get(
+                url=f"/reference/referencefile/by_md5/{shared_md5}",
+                headers=auth_headers)
+            assert response.status_code == status.HTTP_200_OK
+            matches = response.json()
+            assert len(matches) == 2
+            ids = {m["referencefile_id"] for m in matches}
+            assert ids == {test_referencefile.referencefile_id, second_file_id}
+            curies = {m["reference_curie"] for m in matches}
+            assert curies == {test_referencefile.reference.curie,
+                              test_reference2.new_ref_curie}
+            mods_for_second = next(
+                m["referencefile_mods"] for m in matches
+                if m["referencefile_id"] == second_file_id
+            )
+            assert any(rm["mod_abbreviation"] == "WB" for rm in mods_for_second)
+
+    def test_show_by_md5_includes_converted_markdown(self, db, test_referencefile, auth_headers):  # noqa
+        converted = {
+            "display_name": f"{test_referencefile.display_name}_merged",
+            "reference_curie": test_referencefile.reference.curie,
+            "file_class": "converted_merged_main",
+            "file_publication_status": "final",
+            "file_extension": "md",
+            "pdf_type": None,
+            "md5sum": "9999999999"
+        }
+        converted_id = create_metadata(db, ReferencefileSchemaPost(**converted))
+        unrelated = {
+            "display_name": "Other_merged",
+            "reference_curie": test_referencefile.reference.curie,
+            "file_class": "converted_merged_main",
+            "file_publication_status": "final",
+            "file_extension": "md",
+            "pdf_type": None,
+            "md5sum": "8888888888"
+        }
+        create_metadata(db, ReferencefileSchemaPost(**unrelated))
+        with TestClient(app) as client:
+            response = client.get(
+                url=f"/reference/referencefile/by_md5/{test_referencefile.md5sum}",
+                headers=auth_headers)
+            assert response.status_code == status.HTTP_200_OK
+            matches = response.json()
+            assert len(matches) == 1
+            derived = matches[0]["converted_referencefiles"]
+            assert len(derived) == 1
+            assert derived[0]["referencefile_id"] == converted_id
+            assert derived[0]["file_class"] == "converted_merged_main"
+            assert derived[0]["display_name"].startswith(test_referencefile.display_name)


### PR DESCRIPTION
## Summary

- Adds `GET /reference/referencefile/by_md5/{md5sum}` so PDF-only ingestion clients can probe ABC for an existing referencefile before re-uploading the content.
- Each match returns the reference curie / ABC Literature ID, MOD associations (with `null` = PMC), open-access flag, license name, and any converted Markdown referencefiles derived from the same source PDF or nXML (via the display-name suffix convention used by `file_conversion_crud._infer_source_info`).
- Empty list when no referencefile matches; multiple entries when the same content is attached to more than one reference.

Closes [SCRUM-6055](https://agr-jira.atlassian.net/browse/SCRUM-6055).

## Test plan

- [x] `make run-local-flake8` passes
- [x] `make run-local-mypy` passes
- [x] CI unittest job passes (4 new tests: no match, single match, multi-reference match, converted-Markdown derivation)
- [x] CI functest job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6055]: https://agr-jira.atlassian.net/browse/SCRUM-6055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ