### PR TITLE
feat(SCRUM-5784): reject retracted references in add_entry_to_dataset

### DIFF
--- a/agr_literature_service/api/crud/dataset_crud.py
+++ b/agr_literature_service/api/crud/dataset_crud.py
@@ -141,7 +141,17 @@ def add_entry_to_dataset(db: Session, request: DatasetEntrySchemaPost):
     if dataset.frozen:
         raise HTTPException(status_code=403, detail="Dataset is frozen")
     # check if reference curie is valid
-    get_reference(db, curie_or_reference_id=request.reference_curie)
+    reference = get_reference(db, curie_or_reference_id=request.reference_curie)
+    # SCRUM-5784: exclude retracted references from training sets so bad
+    # data isn't used to classify papers. retraction_status is NULL for
+    # non-retracted references and an ATP curie otherwise.
+    if reference.retraction_status:
+        raise HTTPException(
+            status_code=422,
+            detail=(f"Reference {request.reference_curie} is retracted "
+                    f"(retraction_status={reference.retraction_status}) "
+                    f"and cannot be added to a dataset.")
+        )
     new_dataset_entry = DatasetEntryModel(
         dataset_id=dataset.dataset_id,
         supporting_topic_entity_tag_id=request.supporting_topic_entity_tag_id,

--- a/tests/api/test_dataset.py
+++ b/tests/api/test_dataset.py
@@ -6,7 +6,7 @@ from starlette.testclient import TestClient
 from fastapi import status
 
 from agr_literature_service.api.main import app
-from agr_literature_service.api.models import DatasetModel
+from agr_literature_service.api.models import DatasetModel, ReferenceModel
 from agr_literature_service.api.models.dataset_model import DatasetEntryModel
 from ..fixtures import db  # noqa
 from .fixtures import auth_headers  # noqa
@@ -95,6 +95,35 @@ class TestDataset:
             dataset_entry: DatasetEntryModel = dataset.dataset_entries[0]
             assert dataset_entry.reference_curie == test_topic_entity_tag.related_ref_curie
 
+
+    def test_add_dataset_entry_rejects_retracted_reference(self, db, auth_headers, test_dataset, test_topic_entity_tag):  # noqa
+        ref_curie = test_topic_entity_tag.related_ref_curie
+        reference = db.query(ReferenceModel).filter(
+            ReferenceModel.curie == ref_curie).one()
+        reference.retraction_status = "ATP:0000346"
+        db.commit()
+        with TestClient(app) as client:
+            dataset_entry_data = {
+                "mod_abbreviation": test_dataset.mod_abbreviation,
+                "data_type": test_dataset.data_type,
+                "dataset_type": test_dataset.dataset_type,
+                "version": test_dataset.version,
+                "reference_curie": ref_curie,
+                "classification_value": "class_1",
+                "entity": None,
+                "supporting_topic_entity_tag_id": test_topic_entity_tag.new_tet_id
+            }
+            response = client.post(url="/datasets/data_entry/", json=dataset_entry_data, headers=auth_headers)
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+            assert "retracted" in response.json()["detail"].lower()
+
+            dataset_metadata = client.get(url=f"/datasets/metadata/{test_dataset.mod_abbreviation}/"
+                                              f"{test_dataset.data_type}/{test_dataset.dataset_type}/"
+                                              f"{test_dataset.version}/",
+                                          headers=auth_headers).json()
+            dataset = db.query(DatasetModel).filter(
+                DatasetModel.dataset_id == dataset_metadata["dataset_id"]).one()
+            assert len(dataset.dataset_entries) == 0
 
     def test_remove_dataset_entry(self, db, auth_headers, test_dataset, test_topic_entity_tag):  # noqa
         with TestClient(app) as client:


### PR DESCRIPTION
## Summary

- `POST /datasets/data_entry/` now returns 422 when the supplied `reference_curie` resolves to a retracted reference, so retracted papers can no longer be added to training or testing sets.
- Detection uses the existing `ReferenceModel.retraction_status` column — NULL means not retracted; any ATP curie (`ATP:0000346`, `ATP:0000347`, `ATP:0000348`) means retracted.
- Per the curator request in the ticket: *"As a curator I would like retracted papers excluded from new training sets so bad data isn't used to classify papers."*

Closes [SCRUM-5784](https://agr-jira.atlassian.net/browse/SCRUM-5784).

## Test plan

- [x] `make run-local-flake8` passes
- [x] `make run-local-mypy` passes
- [x] CI unittest job passes (new test `test_add_dataset_entry_rejects_retracted_reference` covers the rejection path and verifies the dataset stays empty)
- [x] CI functest job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-5784]: https://agr-jira.atlassian.net/browse/SCRUM-5784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ