### PR TITLE
fix(SCRUM-5838): unblock TET obsolete entities monthly report

### DIFF
--- a/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py
+++ b/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py
@@ -99,7 +99,7 @@ def add_missing_name_to_obsolete_ids(ateam_db, entity_type_name, obsolete_id_set
     for obsolete_id in obsolete_id_set:
         if obsolete_id in obsolete_id_to_name:
             continue
-        name = get_name_for_curie(obsolete_id)
+        name = get_name_for_curie(ateam_db, entity_type_name, obsolete_id)
         if name:
             obsolete_id_to_name[obsolete_id] = name
 


### PR DESCRIPTION
## Summary
- `add_missing_name_to_obsolete_ids` was calling `get_name_for_curie(obsolete_id)` with one argument; the function requires three `(ateam_db, entity_type_name, curie)`.
- The resulting `TypeError` was swallowed by the broad `except Exception` in `check_data()`, so the script returned before `write_report()` ran — leaving the `#!date-produced` header stuck at July (prod) / September (stage).
- One-line fix passes the two args already in scope.

## Test plan
- [ ] `python3 -m flake8 agr_literature_service/lit_processing/data_check/report_obsolete_entities.py` clean (verified locally)
- [ ] `mypy --config-file mypy.config agr_literature_service/lit_processing/data_check/report_obsolete_entities.py` clean (verified locally)
- [ ] Run script manually on stage: `python3 agr_literature_service/lit_processing/data_check/report_obsolete_entities.py` and confirm `$LOG_PATH/QC/obsolete_entity_report.log` has today's `#!date-produced` header
- [ ] Hit `/check/check_obsolete_entities` and confirm `date-produced` in the JSON response is today
- [ ] After deploying to prod, wait for next cron tick (19th of the month, 02:00 UTC per `crontab:23`) and re-verify the endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)