### PR TITLE
chore: remove vestigial Poetry and isort stanzas from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,25 +1,3 @@
-[tool.poetry]
-name = "agr_literature_service"
-version = "0.1.0"
-description = ""
-authors = ["Your Name <you@example.com>"]
-
-[tool.poetry.dev-dependencies]
-
-[build-system]
-version = "0.1.0"
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-
-
-[tool.isort]
-profile = "hug"
-src_paths = ["agr_literature_service"]
-py_version=39
-skip = [".gitignore", ".dockerignore", "__init__.py", "agr_literature_service/api/main.py"]
-skip_glob = ["docs/*"]
-multi_line_output = 3
-
 [tool.pytest.ini_options]
 addopts = "--cov --cov-fail-under=74 -vv --cov-report html --ignore non_pr_tests/"
 markers = [


### PR DESCRIPTION
## Summary
- Nothing in this repo uses Poetry: `poetry.lock` isn't tracked or referenced anywhere, and every Dockerfile / CI workflow installs via `pip install -r requirements.txt`.
- `[tool.isort]` is similarly dead — `isort` is not invoked by any Makefile target, CI step, pre-commit hook, or script.
- Drop `[tool.poetry]`, `[tool.poetry.dev-dependencies]`, `[build-system]`, and `[tool.isort]`.
- Keep `[tool.pytest.ini_options]` — that one is load-bearing (markers `webtest` / `debezium` and `--cov-fail-under=74` are consumed by `run_tests.sh`, `Makefile:61/170`, `.github/workflows/unittest.yaml`, and `.github/workflows/debezium-integration-test.yaml`).

## Test plan
- [ ] `python3 -m pytest --collect-only -q` — confirm pytest still reads `inifile: pyproject.toml` (verified locally; the `--cov` arg from addopts is being applied)
- [ ] `./run_tests.sh` passes (CI will run this via `make run-test-bash`)
- [ ] `pytest -m "not webtest"` and `pytest -m "debezium"` still resolve the markers without `PytestUnknownMarkWarning`
- [ ] Coverage gate still enforces `--cov-fail-under=74`
- [ ] `grep -rn "tool.poetry\|build-system\|tool.isort" .` returns no results (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)