### PR TITLE
fix(SCRUM-6092): transition text_convert_job tag when supplements fail

### DIFF
--- a/agr_literature_service/api/crud/file_conversion_crud.py
+++ b/agr_literature_service/api/crud/file_conversion_crud.py
@@ -32,6 +32,7 @@ from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     get_nxml_referencefile,
     get_pdf_files_for_reference,
     is_eligible_for_supplement_conversion,
+    mod_has_converted_main,
     pending_main_sources,
     pending_supplement_sources,
     process_nxml_to_markdown,
@@ -199,9 +200,18 @@ def per_mod_pending_status(
     ``text_convert_job`` workflow tag for this reference.
 
     Each entry: ``{mod_abbreviation, reference_workflow_tag_id,
-    pending_main_count, pending_supplement_count, all_converted}``.
-    ``all_converted`` is True iff that MOD has no pending main or
-    supplement sources — i.e., that MOD's conversion is complete.
+    pending_main_count, pending_supplement_count, main_converted,
+    all_converted}``.
+
+    ``main_converted`` is True iff at least one of the MOD's main sources has
+    produced a ``converted_merged_main`` row — the signal that drives the
+    ``text_convert_job`` tag transition (SCRUM-6092: supplement failures
+    must not block the tag, so the transition decision keys off main only).
+
+    ``all_converted`` is True iff that MOD has no pending main or supplement
+    sources — i.e., everything PDFX/nXML could produce for the MOD is in
+    place. Useful to callers that want the complete picture; not used for
+    tag transitions.
     """
     from agr_literature_service.api.crud.workflow_tag_crud import get_jobs
     from agr_literature_service.api.models import ModModel
@@ -234,13 +244,19 @@ def per_mod_pending_status(
             )
         else:
             pending_supplements = []
+        main_converted = mod_has_converted_main(
+            db, reference.reference_id,
+            mod_abbreviation=mod_abbreviation,
+            ignore_tei_derived=overwrite_tei_md,
+        )
         out.append({
             "mod_abbreviation": mod_abbreviation,
             "reference_workflow_tag_id": job["reference_workflow_tag_id"],
             "pending_main_count": len(pending_main),
             "pending_supplement_count": len(pending_supplements),
+            "main_converted": main_converted,
             "all_converted": (
-                len(pending_main) == 0 and len(pending_supplements) == 0
+                main_converted and len(pending_supplements) == 0
             ),
         })
     return out
@@ -253,20 +269,21 @@ def transition_completed_text_convert_tags(
 ) -> int:
     """
     For each ``text_convert_job`` "needed" tag on this reference, transition
-    to ``on_success`` when no source files remain pending for that MOD.
-
-    Returns the number of tags transitioned.
+    to ``on_success`` once the MOD's main source has been converted, even
+    when supplement conversion(s) failed for any reason (SCRUM-6092:
+    oversize supplement, GROBID returning no extractable text, transient
+    PDFX errors, etc.). Returns the number of tags transitioned.
 
     Used by the on-demand endpoint to land all eligible MODs' workflow
-    tags after conversion + mod-association sync. Only transitions tags
-    whose MOD genuinely has nothing left to do — MODs with pending
-    sources stay in their current state.
+    tags after conversion + mod-association sync. The cron path
+    (pdf2md.process_single_reference) already keys success off the main
+    file alone, so this brings the on-demand path into alignment with it.
     """
     from agr_literature_service.api.crud.workflow_tag_crud import job_change_atp_code
 
     transitioned = 0
     for entry in per_mod_pending_status(db, reference, overwrite_tei_md):
-        if entry["all_converted"]:
+        if entry["main_converted"]:
             try:
                 job_change_atp_code(
                     db, entry["reference_workflow_tag_id"], "on_success"
@@ -530,8 +547,9 @@ def _status_payload(db: Session, reference: ReferenceModel, *, status_str: str,
 
     ``per_mod_status`` lists every MOD with a text_convert_job tag for this
     reference and that MOD's conversion state (pending counts +
-    all_converted boolean). Best-effort: any error computing per-MOD
-    status returns an empty list rather than failing the whole response.
+    main_converted / all_converted booleans). Best-effort: any error
+    computing per-MOD status returns an empty list rather than failing
+    the whole response.
     """
     progress = _merge_progress(
         _job_progress_payload(job),

--- a/agr_literature_service/api/schemas/file_conversion_schemas.py
+++ b/agr_literature_service/api/schemas/file_conversion_schemas.py
@@ -16,15 +16,25 @@ class ConversionModStatusSchema(BaseModel):
 
     Reports the conversion state from each MOD's perspective. Returned for
     every MOD that currently has a ``text_convert_job`` workflow tag
-    pointing at this reference. ``all_converted`` is True iff that MOD has
-    no main / supplement source files left to convert (taking into account
-    SCRUM-6026 supplement eligibility for non-WB/ZFIN/FB references).
+    pointing at this reference.
+
+    ``main_converted`` is True iff at least one of the MOD's main sources
+    has produced a ``converted_merged_main`` row — this is the signal that
+    drives the workflow-tag transition (SCRUM-6092: a supplement that
+    failed for any reason must not keep the tag pinned).
+
+    ``all_converted`` is True iff that MOD has nothing pending on either
+    side — main converted AND every eligible supplement converted
+    (taking SCRUM-6026 supplement eligibility into account for
+    non-WB/ZFIN/FB references). Surfaced for callers that want the full
+    picture; not used to decide tag transitions.
     """
     model_config = ConfigDict(extra='forbid', from_attributes=True)
 
     mod_abbreviation: str
     pending_main_count: int
     pending_supplement_count: int
+    main_converted: bool
     all_converted: bool
 
 

--- a/agr_literature_service/api/utils/conversion_processor.py
+++ b/agr_literature_service/api/utils/conversion_processor.py
@@ -253,11 +253,14 @@ def run_conversion_job(job_id: str, reference_id: int, reference_curie: str,
             )
 
         # SCRUM-6041: on-demand path always reconciles converted-file mod
-        # associations with their sources and transitions every fully-
-        # converted MOD's text_convert_job tag — even when no new
-        # conversion ran in this call (the reference may already be
-        # converted but missing some MOD associations / pending tag
-        # transitions from prior MOD-specific batch runs).
+        # associations with their sources and transitions any MOD's
+        # text_convert_job tag whose main source has been converted —
+        # SCRUM-6092: supplement failures (oversize, GROBID empty, PDFX
+        # errors, etc.) do not block the tag, mirroring the cron path's
+        # main-only success semantics. Runs even when no new conversion
+        # happened in this call (the reference may already have a
+        # converted main from a prior MOD-specific batch run and just
+        # need MOD associations + a tag transition).
         try:
             db.expire_all()
             reference = get_reference(db, str(reference_id), load_referencefiles=True)

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -205,6 +205,44 @@ def _file_is_for_mod(
     return False
 
 
+def mod_has_converted_main(
+    db: Session,
+    reference_id: int,
+    mod_abbreviation: Optional[str] = None,
+    *,
+    ignore_tei_derived: bool = False,
+) -> bool:
+    """
+    True iff at least one of this MOD's main sources (nXML or main PDF) has
+    already produced a ``converted_merged_main`` Markdown row.
+
+    Distinct from ``pending_main_sources`` returning ``[]``: that result lumps
+    together "every source converted" and "no source exists at all". For
+    deciding whether to land a MOD's text_convert_job tag we need the
+    affirmative signal that the main was actually converted.
+
+    ``mod_abbreviation=None`` disables the per-MOD filter (any main source
+    matches), mirroring the convention used by ``pending_main_sources``.
+    """
+    nxml = get_nxml_referencefile(db, reference_id)
+    if nxml is not None and _file_is_for_mod(nxml, mod_abbreviation):
+        if is_main_source_converted(
+            db, reference_id, nxml.display_name,
+            is_nxml=True, ignore_tei_derived=ignore_tei_derived,
+        ):
+            return True
+
+    for pdf in get_pdf_files_for_reference(db, reference_id, "main"):
+        if not _file_is_for_mod(pdf, mod_abbreviation):
+            continue
+        if is_main_source_converted(
+            db, reference_id, pdf.display_name,
+            is_nxml=False, ignore_tei_derived=ignore_tei_derived,
+        ):
+            return True
+    return False
+
+
 def pending_main_sources(
     db: Session,
     reference_id: int,

--- a/tests/api/test_file_conversion.py
+++ b/tests/api/test_file_conversion.py
@@ -29,6 +29,7 @@ from agr_literature_service.api.utils.conversion_job_manager import (
 )
 
 from .test_reference import test_reference  # noqa: F401
+from .test_mod import test_mod  # noqa: F401
 from ..fixtures import db  # noqa: F401
 from .fixtures import auth_headers  # noqa: F401
 
@@ -622,3 +623,146 @@ class TestAssessReference:
         overwrite_assessment = _assess_reference(db, reference, overwrite_tei_md=True)
         assert overwrite_assessment["main_cached"] is False
         assert overwrite_assessment["main_missing"] is True
+
+
+# ---------------------------------------------------------------------------
+# SCRUM-6092: supplement failures must not block text_convert_job tag
+# transition. When a reference's main source is converted, the per-MOD tag
+# should land on on_success regardless of supplement outcomes (oversize PDF,
+# GROBID returning no extractable text, transient PDFX errors, etc.).
+# ---------------------------------------------------------------------------
+
+class TestSupplementFailureTagTransition:
+
+    @staticmethod
+    def _fake_job_for(reference, mod_id):
+        """Shape returned by workflow_tag_crud.get_jobs for a text_convert_job entry."""
+        return [{
+            "job_name": "text_convert_job",
+            "workflow_tag_id": "ATP:0000162",
+            "reference_id": reference.reference_id,
+            "reference_curie": reference.curie,
+            "reference_workflow_tag_id": 999_001,
+            "mod_id": mod_id,
+            "topic_id": None,
+        }]
+
+    def test_per_mod_status_exposes_main_converted_independently_of_supplements(
+        self, db, test_reference, test_mod, auth_headers,  # noqa: F811
+    ):
+        """SCRUM-6092: per_mod_pending_status must surface a main_converted
+        flag (and main_converted alone must be True when the main has a
+        converted_merged_main row, even if a supplement is still pending)."""
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            per_mod_pending_status,
+        )
+        from agr_literature_service.api.crud.reference_utils import get_reference
+
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_main_pdf_6092", pdf_type="pdf")
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_merged",
+                            "converted_merged_main", "md", "md5_main_md_6092")
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_supp",
+                            "supplement", "pdf", "md5_supp_pdf_6092")
+
+        reference = get_reference(
+            db=db,
+            curie_or_reference_id=test_reference.new_ref_curie,
+            load_referencefiles=True,
+        )
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud."
+            "is_eligible_for_supplement_conversion",
+            return_value=True,
+        ), patch(
+            "agr_literature_service.api.crud.workflow_tag_crud.get_jobs",
+            return_value=self._fake_job_for(reference, test_mod.new_mod_id),
+        ):
+            statuses = per_mod_pending_status(db, reference)
+
+        assert len(statuses) == 1
+        entry = statuses[0]
+        assert entry["mod_abbreviation"] == test_mod.new_mod_abbreviation
+        assert entry["pending_main_count"] == 0
+        assert entry["pending_supplement_count"] == 1
+        assert entry["main_converted"] is True
+        assert entry["all_converted"] is False
+
+    def test_transition_lands_tag_when_supplement_pending_after_main_converted(
+        self, db, test_reference, test_mod, auth_headers,  # noqa: F811
+    ):
+        """SCRUM-6092: transition_completed_text_convert_tags must transition
+        the MOD's text_convert_job tag to on_success once the main source
+        is converted, even when a supplement remains pending (this is the
+        path the on-demand endpoint hits after a supplement conversion
+        fails for any reason — oversize, GROBID empty, PDFX error, etc.)."""
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            transition_completed_text_convert_tags,
+        )
+        from agr_literature_service.api.crud.reference_utils import get_reference
+
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_main_pdf_6092b", pdf_type="pdf")
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_merged",
+                            "converted_merged_main", "md", "md5_main_md_6092b")
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_supp",
+                            "supplement", "pdf", "md5_supp_pdf_6092b")
+
+        reference = get_reference(
+            db=db,
+            curie_or_reference_id=test_reference.new_ref_curie,
+            load_referencefiles=True,
+        )
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud."
+            "is_eligible_for_supplement_conversion",
+            return_value=True,
+        ), patch(
+            "agr_literature_service.api.crud.workflow_tag_crud.get_jobs",
+            return_value=self._fake_job_for(reference, test_mod.new_mod_id),
+        ), patch(
+            "agr_literature_service.api.crud.workflow_tag_crud.job_change_atp_code",
+        ) as mock_transition:
+            transitioned = transition_completed_text_convert_tags(db, reference)
+
+        assert transitioned == 1
+        mock_transition.assert_called_once_with(db, 999_001, "on_success")
+
+    def test_transition_holds_when_main_still_pending(
+        self, db, test_reference, test_mod, auth_headers,  # noqa: F811
+    ):
+        """A main source that has not been converted must keep the tag in
+        place — supplement-failure tolerance is scoped to supplements only."""
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            transition_completed_text_convert_tags,
+        )
+        from agr_literature_service.api.crud.reference_utils import get_reference
+
+        _make_referencefile(db, test_reference.new_ref_curie, "paper",
+                            "main", "pdf", "md5_main_pdf_6092c", pdf_type="pdf")
+        # No converted_merged_main row → main is still pending.
+        _make_referencefile(db, test_reference.new_ref_curie, "paper_supp",
+                            "supplement", "pdf", "md5_supp_pdf_6092c")
+
+        reference = get_reference(
+            db=db,
+            curie_or_reference_id=test_reference.new_ref_curie,
+            load_referencefiles=True,
+        )
+
+        with patch(
+            "agr_literature_service.api.crud.file_conversion_crud."
+            "is_eligible_for_supplement_conversion",
+            return_value=True,
+        ), patch(
+            "agr_literature_service.api.crud.workflow_tag_crud.get_jobs",
+            return_value=self._fake_job_for(reference, test_mod.new_mod_id),
+        ), patch(
+            "agr_literature_service.api.crud.workflow_tag_crud.job_change_atp_code",
+        ) as mock_transition:
+            transitioned = transition_completed_text_convert_tags(db, reference)
+
+        assert transitioned == 0
+        mock_transition.assert_not_called()


### PR DESCRIPTION
## Summary

- **Bug:** The on-demand conversion path left the per-MOD `text_convert_job` workflow tag pinned to "needed" whenever any supplement remained unconverted — including supplements that were permanently rejected (>5 MB / page-count limit) or transiently failed (GROBID empty, PDFX errors). Real fallout: a Friday upload with a >5 MB supplemental left the workflow stuck even though the main converted cleanly.
- **Cause:** `transition_completed_text_convert_tags` keyed the transition off `all_converted`, which required `pending_supplement_count == 0`. A skipped supplement leaves no `converted_merged_supplement` row and is indistinguishable from one that was never attempted.
- **Fix:** New `mod_has_converted_main` helper (affirmative DB check for a `converted_merged_main` row matching one of the MOD's main sources), surfaced via `per_mod_pending_status` as `main_converted`. The tag transition now keys off `main_converted` — supplement failures no longer block the workflow. This brings the on-demand path in line with the cron path (`process_single_reference` already returns success on main-only).
- **API:** `ConversionModStatusSchema` gains a `main_converted: bool` field. The existing `all_converted` is preserved (slightly narrowed: now means "main converted AND supplements converted" instead of "no pending of either kind"); callers that want the full picture can still read it.

## Files changed

| File | Change |
|---|---|
| `lit_processing/pdf2md/pdf2md_utils.py` | New `mod_has_converted_main(...)` helper. |
| `api/crud/file_conversion_crud.py` | `per_mod_pending_status` now returns `main_converted`. `transition_completed_text_convert_tags` keys off `main_converted` instead of `all_converted`. |
| `api/schemas/file_conversion_schemas.py` | `main_converted: bool` added to `ConversionModStatusSchema`. |
| `api/utils/conversion_processor.py` | Comment updated to reflect main-only success semantics. |
| `tests/api/test_file_conversion.py` | New `TestSupplementFailureTagTransition` class (3 tests). |

## Test plan

- [x] `make run-local-flake8` — clean
- [x] `make run-local-mypy` — clean (521 source files)
- [ ] CI: `tests/api/test_file_conversion.py::TestSupplementFailureTagTransition` (three new tests covering: schema exposes `main_converted`; tag lands when main converted + supplement pending; tag held when main still pending)
- [ ] CI: existing `tests/lit_processing/pdf2md/test_pdf2md.py::TestProcessSingleReference::test_supplement_failures_do_not_fail_reference` still passes (cron-side behavior unchanged)
- [ ] Manual on devserver: upload a reference with a converting main + a >5 MB supplemental, call the on-demand endpoint, confirm the MOD's `text_convert_job` tag transitions to "conversion done" while the supplement is reported as failed in `per_file_progress`

## Related

- KANBAN-1327 — upstream pdfx-side complement (don't abort the whole pipeline when a single extraction method fails). This PR is the ABC-side fix that lets the workflow tag move regardless of the upstream's per-method robustness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)