### PR TITLE
fix(SCRUM-6106): isolate _current_user_id per request via ContextVar

### DIFF
--- a/agr_literature_service/api/user.py
+++ b/agr_literature_service/api/user.py
@@ -42,8 +42,8 @@ def _ensure_automation_user(db: Session, program_name: str) -> UserModel:
 
 def set_global_user_id(db: Session, id: str) -> None:
     """
-    Manually set the global users.id (e.g., script/program name).
-    Treated as an automation user.
+    Set the current users.id for this request/context (e.g., script or
+    program name). Treated as an automation user.
     """
     _current_user_id.set(id)
     _ensure_automation_user(db, id)
@@ -58,7 +58,7 @@ def add_user_if_not_exists(db: Session, user_id: str) -> None:
 
 def set_global_user_from_cognito(db: Session, cognito_user: Optional[Dict[str, Any]]) -> None:
     """
-    Set the global user from a Cognito token.
+    Set the current request's user from a Cognito token.
 
     For ID tokens (user login): Looks up user by email via email table join.
     For access tokens (service accounts): Uses 'default_user' and creates if needed.

--- a/agr_literature_service/api/user.py
+++ b/agr_literature_service/api/user.py
@@ -1,3 +1,4 @@
+from contextvars import ContextVar
 from typing import Optional, Dict, Any
 from fastapi import HTTPException
 from sqlalchemy import text
@@ -6,8 +7,13 @@ from sqlalchemy.orm import Session
 from agr_literature_service.api.crud import user_crud
 from agr_literature_service.api.models.user_model import UserModel
 
-# String primary key (users.id) of the "current user" for this process/request
-_current_user_id: Optional[str] = None
+# String primary key (users.id) of the "current user" for this request.
+# A ContextVar isolates the value per asyncio task and per FastAPI threadpool
+# worker, so concurrent requests cannot overwrite each other's identity before
+# the SQLAlchemy `before_update` listener stamps `updated_by`.
+_current_user_id: ContextVar[Optional[str]] = ContextVar(
+    "_current_user_id", default=None
+)
 
 
 def _ensure_automation_user(db: Session, program_name: str) -> UserModel:
@@ -39,8 +45,7 @@ def set_global_user_id(db: Session, id: str) -> None:
     Manually set the global users.id (e.g., script/program name).
     Treated as an automation user.
     """
-    global _current_user_id
-    _current_user_id = id
+    _current_user_id.set(id)
     _ensure_automation_user(db, id)
 
 
@@ -59,11 +64,9 @@ def set_global_user_from_cognito(db: Session, cognito_user: Optional[Dict[str, A
     For access tokens (service accounts): Uses 'default_user' and creates if needed.
     For None (VPN bypass): Sets current user to None (anonymous access).
     """
-    global _current_user_id
-
     # VPN bypass - no authenticated user (anonymous access)
     if cognito_user is None:
-        _current_user_id = None
+        _current_user_id.set(None)
         return
 
     # Check if this is a service account (access token from client_credentials flow)
@@ -71,7 +74,7 @@ def set_global_user_from_cognito(db: Session, cognito_user: Optional[Dict[str, A
     if token_type == "access":
         # Service account - use default_user
         default_user_id = "default_user"
-        _current_user_id = default_user_id
+        _current_user_id.set(default_user_id)
         _ensure_automation_user(db, default_user_id)
         return
 
@@ -103,13 +106,13 @@ def set_global_user_from_cognito(db: Session, cognito_user: Optional[Dict[str, A
                    "Contact an administrator to create your user account."
         )
 
-    # Set the global user ID from the query result
-    _current_user_id = result[0]
+    # Set the current user ID from the query result
+    _current_user_id.set(result[0])
 
 
 def get_global_user_id() -> Optional[str]:
     """Return the current users.id (string PK), or None."""
-    return _current_user_id
+    return _current_user_id.get()
 
 
 def get_current_user_pk(db: Session) -> Optional[int]:
@@ -117,9 +120,10 @@ def get_current_user_pk(db: Session) -> Optional[int]:
     Return the integer users.user_id for the current user (creating the automation
     user if necessary). Use this when inserting into the `transaction` table.
     """
-    if _current_user_id is None:
+    uid = _current_user_id.get()
+    if uid is None:
         return None
-    u = _ensure_automation_user(db, _current_user_id)
+    u = _ensure_automation_user(db, uid)
     return getattr(u, "user_id", None)
 
 

--- a/tests/api/test_audited_model.py
+++ b/tests/api/test_audited_model.py
@@ -44,12 +44,11 @@ def _ensure_user(db, uid: str): # noqa
 def _clear_global_user():
     """Ensure each test starts with no global user set."""
     from agr_literature_service.api import user as user_mod
-    prev = user_mod._current_user_id
-    user_mod._current_user_id = None
+    token = user_mod._current_user_id.set(None)
     try:
         yield
     finally:
-        user_mod._current_user_id = prev
+        user_mod._current_user_id.reset(token)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/api/test_user_context_isolation.py
+++ b/tests/api/test_user_context_isolation.py
@@ -12,6 +12,10 @@ tests would fail: both tasks/threads would observe whichever set ran last.
 
 import asyncio
 import threading
+from typing import Dict, Optional
+
+import anyio
+import pytest
 
 from agr_literature_service.api.user import (
     _current_user_id,
@@ -19,18 +23,26 @@ from agr_literature_service.api.user import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_global_user():
+    """Ensure each test starts with no current user set."""
+    token = _current_user_id.set(None)
+    try:
+        yield
+    finally:
+        _current_user_id.reset(token)
+
+
 def test_contextvar_isolated_across_asyncio_tasks():
     """Two concurrent asyncio tasks see only their own user id."""
 
-    async def _set_and_read(uid: str, hold_seconds: float) -> str:
+    async def _set_and_read(uid: str, hold_seconds: float) -> Optional[str]:
         _current_user_id.set(uid)
         # Yield to the event loop so the other task can run between the
         # set() and the get(). With a process-global, this is exactly the
         # window where the other coroutine would clobber the value.
         await asyncio.sleep(hold_seconds)
-        result = get_global_user_id()
-        assert result is not None
-        return result
+        return get_global_user_id()
 
     async def _run():
         return await asyncio.gather(
@@ -44,19 +56,23 @@ def test_contextvar_isolated_across_asyncio_tasks():
 
 
 def test_contextvar_isolated_across_threads():
-    """Two threads (simulating FastAPI's sync-endpoint threadpool)
-    see only their own user id."""
-    results: dict[str, str] = {}
+    """Two raw threads see only their own user id.
+
+    Raw `threading.Thread` does not share a Context across threads, so this
+    test guards against re-introduction of a module-level global; it is not
+    a model of FastAPI's threadpool dispatch (see the anyio test below for
+    that).
+    """
+    results: Dict[str, Optional[str]] = {}
     barrier = threading.Barrier(2)
 
     def _worker(uid: str) -> None:
         _current_user_id.set(uid)
-        # Wait for the other thread to also set its value before reading,
-        # which is the exact race produced by FastAPI's threadpool.
+        # Wait for the other thread to also set its value before reading.
+        # With a process-global, this is the window where one thread would
+        # observe the other's user id.
         barrier.wait()
-        observed = get_global_user_id()
-        assert observed is not None
-        results[uid] = observed
+        results[uid] = get_global_user_id()
 
     t1 = threading.Thread(target=_worker, args=("user_a",))
     t2 = threading.Thread(target=_worker, args=("user_b",))
@@ -66,3 +82,30 @@ def test_contextvar_isolated_across_threads():
     t2.join()
 
     assert results == {"user_a": "user_a", "user_b": "user_b"}
+
+
+def test_contextvar_does_not_leak_between_threadpool_calls():
+    """Two sequential calls through anyio's threadpool — the actual
+    dispatch path used by FastAPI for sync endpoints — must not see each
+    other's user id, even when reused by the same worker thread.
+
+    `anyio.to_thread.run_sync` wraps each call in
+    `contextvars.copy_context().run(...)`, so a `.set()` inside the
+    callable mutates only that copy and is discarded on return. With the
+    pre-fix module global, the first call's identity would persist into
+    the second.
+    """
+
+    def _set_user(uid: str) -> None:
+        _current_user_id.set(uid)
+
+    def _read_user() -> object:
+        return get_global_user_id()
+
+    async def _run():
+        await anyio.to_thread.run_sync(_set_user, "user_a")
+        # Second call: must not observe "user_a" set by the first call,
+        # even if anyio reuses the same worker thread.
+        return await anyio.to_thread.run_sync(_read_user)
+
+    assert asyncio.run(_run()) is None

--- a/tests/api/test_user_context_isolation.py
+++ b/tests/api/test_user_context_isolation.py
@@ -1,0 +1,68 @@
+"""
+Regression test for SCRUM-6106.
+
+The `_current_user_id` ContextVar in `agr_literature_service.api.user`
+must be isolated per asyncio task and per thread, so concurrent requests
+cannot overwrite each other's identity before the SQLAlchemy
+`before_update` listener stamps `updated_by`.
+
+Before the fix, `_current_user_id` was a module-level global, and these
+tests would fail: both tasks/threads would observe whichever set ran last.
+"""
+
+import asyncio
+import threading
+
+from agr_literature_service.api.user import (
+    _current_user_id,
+    get_global_user_id,
+)
+
+
+def test_contextvar_isolated_across_asyncio_tasks():
+    """Two concurrent asyncio tasks see only their own user id."""
+
+    async def _set_and_read(uid: str, hold_seconds: float) -> str:
+        _current_user_id.set(uid)
+        # Yield to the event loop so the other task can run between the
+        # set() and the get(). With a process-global, this is exactly the
+        # window where the other coroutine would clobber the value.
+        await asyncio.sleep(hold_seconds)
+        result = get_global_user_id()
+        assert result is not None
+        return result
+
+    async def _run():
+        return await asyncio.gather(
+            _set_and_read("user_a", 0.05),
+            _set_and_read("user_b", 0.01),
+        )
+
+    a, b = asyncio.run(_run())
+    assert a == "user_a"
+    assert b == "user_b"
+
+
+def test_contextvar_isolated_across_threads():
+    """Two threads (simulating FastAPI's sync-endpoint threadpool)
+    see only their own user id."""
+    results: dict[str, str] = {}
+    barrier = threading.Barrier(2)
+
+    def _worker(uid: str) -> None:
+        _current_user_id.set(uid)
+        # Wait for the other thread to also set its value before reading,
+        # which is the exact race produced by FastAPI's threadpool.
+        barrier.wait()
+        observed = get_global_user_id()
+        assert observed is not None
+        results[uid] = observed
+
+    t1 = threading.Thread(target=_worker, args=("user_a",))
+    t2 = threading.Thread(target=_worker, args=("user_b",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert results == {"user_a": "user_a", "user_b": "user_b"}


### PR DESCRIPTION
## Summary

Fixes [SCRUM-6106](https://agr-jira.atlassian.net/browse/SCRUM-6106).

- Replace the module-level `_current_user_id` global in
  `agr_literature_service/api/user.py` with a
  `contextvars.ContextVar`, isolating the current user per request
  across both asyncio tasks and FastAPI's sync-endpoint threadpool.
- The SQLAlchemy `before_update` listener on `AuditedModel` reads
  this value to stamp `updated_by`; under the old global, concurrent
  curator requests could trample each other and produce wrong
  attributions (the symptom that prompted the ticket was SGD
  `mod_corpus_association` rows showing an FB curator as the
  "sorter").
- Public API (`get_global_user_id` / `set_global_user_id` /
  `set_global_user_from_cognito` / `get_current_user_pk`) is
  unchanged, so no router or event-listener call site needs to
  change. Function names retain the "global" prefix for now to keep
  the diff small; a rename across the ~244 call sites is a follow-up.

## Tests

- `tests/api/test_user_context_isolation.py` (new):
    - asyncio-task race: two `asyncio.gather` tasks set different
      ids with overlapping sleeps; each must observe its own.
    - threading race: two raw `threading.Thread` workers,
      coordinated by a `Barrier`, must observe their own ids — a
      guard against re-introducing a process-global.
    - threadpool reuse: two sequential `anyio.to_thread.run_sync`
      calls; the second must observe `None` (the first call's
      `set()` is discarded by anyio's `copy_context().run(...)`).
      This is the actual dispatch path FastAPI uses for sync
      endpoints.
- `tests/api/test_audited_model.py`: existing `_clear_global_user`
  autouse fixture updated to use the ContextVar set/reset token
  API (previously assigned to the module attribute directly).

All three tests fail under the pre-fix global and pass under the
ContextVar.

## Historical data

Out of scope for this PR. The `mod_corpus_association_version`
table stores the same corrupted `updated_by` value, so the original
correct curator cannot be recovered from the database. Curators
will review and correct suspect rows manually.

## Test plan

- [x] `make run-local-flake8` — clean.
- [x] `make run-local-mypy` — `Success: no issues found in 527 source files`.
- [x] Manual smoke test on RDS dev: sorting a paper now stamps the
      acting curator on `mod_corpus_association.updated_by`
      (verified on `AGRKB:101000001224742`).
- [ ] CI: full test suite, including the new
      `test_user_context_isolation.py` regression cases.
- [ ] Manual concurrency check post-merge: two curators (or one
      curator + an automated job) operating on the dev API in
      parallel — confirm `updated_by` always matches the
      requesting curator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6106]: https://agr-jira.atlassian.net/browse/SCRUM-6106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ