### PR TITLE
build(SCRUM-6114): configure setuptools for pip install from git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
+[build-system]
+requires = ["setuptools>=67.0.0", "wheel>=0.40.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agr_literature_service"
+version = "0.1.0"
+requires-python = ">=3.9"
+
+[tool.setuptools.packages.find]
+include = ["agr_literature_service*"]
+exclude = ["tests*", "examples*", "non_pr_tests*", "docker*", "alembic*", "debezium*", "reverse_proxy*", "file_uploader*", "curation_status*"]
+
 [tool.pytest.ini_options]
 addopts = "--cov --cov-fail-under=74 -vv --cov-report html --ignore non_pr_tests/"
 markers = [


### PR DESCRIPTION
## Summary
- Add `[build-system]`, minimal `[project]` (name/version/requires-python), and `[tool.setuptools.packages.find]` to `pyproject.toml` so this repo can be installed via `agr_literature_service @ git+https://github.com/alliance-genome/agr_literature_service` from another repo's `requirements.txt`.
- Fixes the setuptools "Multiple top-level packages discovered in a flat-layout" error that previously broke wheel builds (setuptools was seeing `docker/`, `alembic/`, `debezium/`, etc. alongside `agr_literature_service/` and refusing to guess).
- Ships only the `agr_literature_service` package; excludes supporting top-level dirs (`docker`, `alembic`, `debezium`, `non_pr_tests`, `reverse_proxy`, `file_uploader`, `curation_status`) and `tests`/`examples`. No runtime dependencies declared — consuming repos continue to manage their own.

## Test plan
- [x] `python -m build --wheel` succeeds locally with no "Multiple top-level packages" error
- [x] Built wheel contains only `agr_literature_service/` paths and `.dist-info/` metadata (verified via `python -m zipfile -l`)
- [x] Wheel installs into a fresh venv and `import agr_literature_service` resolves to site-packages
- [ ] Downstream repo's `pip install -r requirements.txt` succeeds against this branch's commit SHA
- [ ] `make run-local-flake8` / `make run-local-mypy` / `./run_tests.sh` unchanged (pytest config block preserved byte-for-byte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)