### PR TITLE
always add human papers to AGR mod regardless of other MOD corpus

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/go_annotations/load_goa_human_papers.py
+++ b/agr_literature_service/lit_processing/data_ingest/go_annotations/load_goa_human_papers.py
@@ -77,9 +77,10 @@ def load_goa_human_papers() -> str:  # pragma: no cover
 
     logger.info(f"New PMIDs to load: {len(new_pmids)}")
 
-    # Associate existing papers with AGR MOD if not in any MOD corpus
+    # Associate existing papers with AGR MOD (even if already in another MOD corpus)
     papers_associated = associate_papers_with_alliance(db_session, all_pmids, 'AGR',
-                                                       ModCorpusSortSourceType.Gaf)
+                                                       ModCorpusSortSourceType.Gaf,
+                                                       add_even_if_in_other_corpus=True)
     logger.info(f"Papers associated with AGR MOD: {papers_associated}")
 
     pmids_loaded: Set[str] = set()
@@ -105,10 +106,11 @@ def load_goa_human_papers() -> str:  # pragma: no cover
 
         add_md5sum_to_database(db_session, None, pmids_loaded)
 
-        # Associate newly loaded papers with AGR MOD
+        # Associate newly loaded papers with AGR MOD (even if already in another MOD corpus)
         if len(pmids_loaded) > 0:
             newly_associated = associate_papers_with_alliance(db_session, pmids_loaded, 'AGR',
-                                                              ModCorpusSortSourceType.Gaf)
+                                                              ModCorpusSortSourceType.Gaf,
+                                                              add_even_if_in_other_corpus=True)
             papers_associated += newly_associated
 
     # Compose the report message

--- a/agr_literature_service/lit_processing/data_ingest/go_annotations/load_mod_gaf_papers.py
+++ b/agr_literature_service/lit_processing/data_ingest/go_annotations/load_mod_gaf_papers.py
@@ -230,9 +230,10 @@ def process_human_gaf(db_session, s3_url: str, all_pmids_db: Set[str]) -> str:  
     new_pmids = all_pmids - all_pmids_db
     logger.info(f"HUMAN GAF: {len(all_pmids)} total PMIDs, {len(new_pmids)} new")
 
-    # Associate existing papers with AGR MOD if not in any MOD corpus
+    # Associate existing papers with AGR MOD (even if already in another MOD corpus)
     papers_associated = associate_papers_with_alliance(db_session, all_pmids, 'AGR',
-                                                       ModCorpusSortSourceType.Gaf)
+                                                       ModCorpusSortSourceType.Gaf,
+                                                       add_even_if_in_other_corpus=True)
 
     pmids_loaded: Set[str] = set()
     if new_pmids:
@@ -257,10 +258,11 @@ def process_human_gaf(db_session, s3_url: str, all_pmids_db: Set[str]) -> str:  
 
         add_md5sum_to_database(db_session, None, pmids_loaded)
 
-        # Associate newly loaded papers with AGR MOD
+        # Associate newly loaded papers with AGR MOD (even if already in another MOD corpus)
         if pmids_loaded:
             newly_associated = associate_papers_with_alliance(db_session, pmids_loaded, 'AGR',
-                                                              ModCorpusSortSourceType.Gaf)
+                                                              ModCorpusSortSourceType.Gaf,
+                                                              add_even_if_in_other_corpus=True)
             papers_associated += newly_associated
 
     # Check for obsolete PMIDs among those not loaded

--- a/agr_literature_service/lit_processing/data_ingest/interaction/load_interaction_papers.py
+++ b/agr_literature_service/lit_processing/data_ingest/interaction/load_interaction_papers.py
@@ -71,10 +71,11 @@ def load_data(datasetName, dataType, full_obsolete_set, message):
     all_pmids_db = retrieve_all_pmids(db_session)
     new_pmids = all_pmids - set(all_pmids_db)
 
-    # Associate HUMAN papers with AGR MOD
+    # Associate HUMAN papers with AGR MOD (even if already in another MOD corpus)
     if datasetName == "HUMAN":
         associate_papers_with_alliance(db_session, all_pmids, 'AGR',
-                                       ModCorpusSortSourceType.Interaction)
+                                       ModCorpusSortSourceType.Interaction,
+                                       add_even_if_in_other_corpus=True)
 
     if len(new_pmids) == 0:
         message = check_pmids_and_compose_message(db_session, datasetName, file_name,
@@ -101,10 +102,11 @@ def load_data(datasetName, dataType, full_obsolete_set, message):
 
     add_md5sum_to_database(db_session, None, pmids_loaded)
 
-    # Associate newly loaded HUMAN papers with AGR MOD
+    # Associate newly loaded HUMAN papers with AGR MOD (even if already in another MOD corpus)
     if datasetName == "HUMAN" and len(pmids_loaded) > 0:
         associate_papers_with_alliance(db_session, pmids_loaded, 'AGR',
-                                       ModCorpusSortSourceType.Interaction)
+                                       ModCorpusSortSourceType.Interaction,
+                                       add_even_if_in_other_corpus=True)
 
     message = check_pmids_and_compose_message(db_session, datasetName, file_name,
                                               all_pmids, pmids_loaded, pmid_to_src,

--- a/agr_literature_service/lit_processing/data_ingest/utils/alliance_paper_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/alliance_paper_utils.py
@@ -25,12 +25,18 @@ logger = logging.getLogger(__name__)
 
 def associate_papers_with_alliance(db_session, all_pmids: Set[str],
                                    mod_abbr: str = 'AGR',
-                                   sort_source: ModCorpusSortSourceType = ModCorpusSortSourceType.Automated_alliance) -> int:
+                                   sort_source: ModCorpusSortSourceType = ModCorpusSortSourceType.Automated_alliance,
+                                   add_even_if_in_other_corpus: bool = False) -> int:
     """
     Associate papers with a MOD (default: AGR).
-    Only associate papers that do NOT already have a mod_corpus_association
-    with corpus=True for any MOD. This ensures we only add papers to the
-    specified MOD that are not already in another MOD's corpus.
+
+    By default, only associate papers that do NOT already have a
+    mod_corpus_association with corpus=True for any MOD. This ensures we only
+    add papers to the specified MOD that are not already in another MOD's corpus.
+
+    When add_even_if_in_other_corpus=True, papers will be added to the target MOD
+    even if they already have corpus=True in another MOD (but not if they're already
+    associated with the target MOD).
 
     Args:
         db_session: Database session
@@ -38,6 +44,8 @@ def associate_papers_with_alliance(db_session, all_pmids: Set[str],
         mod_abbr: MOD abbreviation to associate with (default: 'AGR')
         sort_source: The source type for mod_corpus_sort_source column
                      (default: Automated_alliance)
+        add_even_if_in_other_corpus: If True, add to target MOD even if paper
+                                     is already in another MOD's corpus (default: False)
 
     Returns:
         Number of papers associated with the MOD
@@ -75,13 +83,23 @@ def associate_papers_with_alliance(db_session, all_pmids: Set[str],
 
     ref_ids_list = list(reference_ids_in_db)
 
-    # Get reference_ids that already have corpus=True for any MOD
-    # OR already have an association with the target MOD (to avoid unique constraint violation)
-    refs_to_exclude_query = text(
-        "SELECT DISTINCT reference_id FROM mod_corpus_association "
-        "WHERE reference_id = ANY(:ref_ids) "
-        "AND (corpus = True OR mod_id = :mod_id)"
-    )
+    # Get reference_ids to exclude from association
+    # When add_even_if_in_other_corpus=True: only exclude papers already associated with target MOD
+    # When add_even_if_in_other_corpus=False: also exclude papers with corpus=True for any MOD
+    if add_even_if_in_other_corpus:
+        # Only exclude papers already associated with the target MOD
+        refs_to_exclude_query = text(
+            "SELECT DISTINCT reference_id FROM mod_corpus_association "
+            "WHERE reference_id = ANY(:ref_ids) "
+            "AND mod_id = :mod_id"
+        )
+    else:
+        # Exclude papers with corpus=True for any MOD OR already associated with target MOD
+        refs_to_exclude_query = text(
+            "SELECT DISTINCT reference_id FROM mod_corpus_association "
+            "WHERE reference_id = ANY(:ref_ids) "
+            "AND (corpus = True OR mod_id = :mod_id)"
+        )
     refs_to_exclude = db_session.execute(
         refs_to_exclude_query,
         {"ref_ids": ref_ids_list, "mod_id": mod_id}


### PR DESCRIPTION
Previously, human papers from GOA, GAF, and interaction datasets were only added to AGR if they weren't in any other MOD's corpus. This change ensures human papers are always added to the AGR mod if not already present there, even if they exist in other MOD corpora.

- Add `add_even_if_in_other_corpus` parameter to `associate_papers_with_alliance()`
- Update load_goa_human_papers.py to use the new parameter
- Update load_mod_gaf_papers.py (process_human_gaf) to use the new parameter
- Update load_interaction_papers.py for HUMAN dataset to use the new parameter