### PR TITLE
fix(SCRUM-5838): restore obsolete-entity ateam lookup after helper signature drift

### DIFF
--- a/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py
+++ b/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py
@@ -196,28 +196,28 @@ def search_entity_obsolete_status(ateam_db, entity_type, entity_curie_list):
         SELECT DISTINCT be.primaryexternalid, be.obsolete, be.primaryexternalid
         FROM biologicalentity be, {entity_type} ent_tbl
         WHERE be.id = ent_tbl.id
-        AND UPPER(be.primaryexternalid) IN :entity_curie_list
+        AND be.primaryexternalid IN :entity_curie_list
         """)
     elif entity_type == 'construct':
         sql_query = text("""
         SELECT DISTINCT r.primaryexternalid, r.obsolete, r.primaryexternalid
         FROM reagent r, construct c
         WHERE r.id = c.id
-        AND UPPER(r.primaryexternalid) IN :entity_curie_list
+        AND r.primaryexternalid IN :entity_curie_list
         """)
     elif entity_type in ['agms', 'strain', 'genotype', 'fish']:
         sql_query = text("""
         SELECT DISTINCT be.primaryexternalid, be.obsolete, be.primaryexternalid
         FROM biologicalentity be, affectedgenomicmodel agm
         WHERE be.id = agm.id
-        AND UPPER(be.primaryexternalid) IN :entity_curie_list
+        AND be.primaryexternalid IN :entity_curie_list
         """)
     elif 'targeting reagent' in entity_type:
         sql_query = text("""
         SELECT DISTINCT be.primaryexternalid, be.obsolete, be.primaryexternalid
         FROM biologicalentity be, sequencetargetingreagent str
         WHERE be.id = str.id
-        AND UPPER(be.primaryexternalid) IN :entity_curie_list
+        AND be.primaryexternalid IN :entity_curie_list
         """)
     else:
         return []

--- a/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py
+++ b/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py
@@ -136,7 +136,7 @@ def get_name_for_curie(ateam_db, entity_type_name, curie):
         FROM biologicalentity be
         JOIN affectedgenomicmodel agm ON be.id = agm.id
         WHERE be.primaryexternalid = :curie
-        AND sa.obsolete = True
+        AND be.obsolete = True
         """)
 
     elif entity_type_name == 'construct':
@@ -148,13 +148,13 @@ def get_name_for_curie(ateam_db, entity_type_name, curie):
             'ConstructFullNameSlotAnnotation',
             'ConstructSymbolSlotAnnotation'
         )
-        AND be.primaryexternalid = :curie
+        AND r.primaryexternalid = :curie
         AND sa.obsolete = True
         """)
     else:
         return None
     rows = ateam_db.execute(query, {'curie': curie}).fetchall()
-    if len(rows) > 1:
+    if len(rows) >= 1:
         return rows[0][0]
     return None
 

--- a/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py
+++ b/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from agr_literature_service.lit_processing.utils.sqlalchemy_utils import create_postgres_session
 from agr_literature_service.api.crud.ateam_db_helpers import create_ateam_db_session, \
-    atp_get_name, search_for_entity_curies
+    atp_get_name
 from agr_literature_service.api.crud.topic_entity_tag_utils import get_map_entity_curies_to_names
 from agr_literature_service.lit_processing.utils.db_read_utils import get_mod_abbreviations
 
@@ -182,6 +182,51 @@ def search_species(ateam_db, species_list):
     return rows
 
 
+def search_entity_obsolete_status(ateam_db, entity_type, entity_curie_list):
+    """
+    Return rows of (primaryexternalid, obsolete, name) for the given curies in
+    the A-team DB. Replaces the previous shared helper whose signature/return
+    shape diverged from this caller's needs.
+    """
+    if not entity_curie_list:
+        return []
+
+    if entity_type in ['gene', 'allele']:
+        sql_query = text(f"""
+        SELECT DISTINCT be.primaryexternalid, be.obsolete, be.primaryexternalid
+        FROM biologicalentity be, {entity_type} ent_tbl
+        WHERE be.id = ent_tbl.id
+        AND UPPER(be.primaryexternalid) IN :entity_curie_list
+        """)
+    elif entity_type == 'construct':
+        sql_query = text("""
+        SELECT DISTINCT r.primaryexternalid, r.obsolete, r.primaryexternalid
+        FROM reagent r, construct c
+        WHERE r.id = c.id
+        AND UPPER(r.primaryexternalid) IN :entity_curie_list
+        """)
+    elif entity_type in ['agms', 'strain', 'genotype', 'fish']:
+        sql_query = text("""
+        SELECT DISTINCT be.primaryexternalid, be.obsolete, be.primaryexternalid
+        FROM biologicalentity be, affectedgenomicmodel agm
+        WHERE be.id = agm.id
+        AND UPPER(be.primaryexternalid) IN :entity_curie_list
+        """)
+    elif 'targeting reagent' in entity_type:
+        sql_query = text("""
+        SELECT DISTINCT be.primaryexternalid, be.obsolete, be.primaryexternalid
+        FROM biologicalentity be, sequencetargetingreagent str
+        WHERE be.id = str.id
+        AND UPPER(be.primaryexternalid) IN :entity_curie_list
+        """)
+    else:
+        return []
+
+    return ateam_db.execute(
+        sql_query, {'entity_curie_list': tuple(entity_curie_list)}
+    ).fetchall()
+
+
 def check_ateam_database(ateam_db, entity_type_name, mod_entity_ids, batch_size=100):
 
     valid_ids = set()
@@ -193,7 +238,7 @@ def check_ateam_database(ateam_db, entity_type_name, mod_entity_ids, batch_size=
         if entity_type_name == 'species':
             rows = search_species(ateam_db, batch) or []
         else:
-            rows = search_for_entity_curies(ateam_db, entity_type_name, batch) or []
+            rows = search_entity_obsolete_status(ateam_db, entity_type_name, batch) or []
         for mod_entity_id, is_obsolete, name in rows:
             if is_obsolete:
                 obsolete_ids.add(mod_entity_id)

--- a/crontab
+++ b/crontab
@@ -20,7 +20,7 @@ BASH_ENV=/container.env
 0 0 18 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/remove_obsolete_pubmed_types.py > /var/log/automated_scripts/remove_obsolete_pubmed_types.log 2>&1
 0 21 18 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_duplicate_orcid_in_reference.py > /var/log/automated_scripts/report_duplicate_orcid_in_reference.log 2>&1
 0 22 18 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_and_fix_obsolete_pmids.py > /var/log/automated_scripts/report_and_fix_obsolete_pmids.log 2>&1
-0 2 19 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py > /var/log/automated_scripts/report_obsolete_entities.log 2>&1
+0 2 26 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py > /var/log/automated_scripts/report_obsolete_entities.log 2>&1
 0 0 20 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_retracted_papers_with_tags.py > /var/log/automated_scripts/report_retracted_papers_with_tags.log 2>&1
 0 0 7 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_disappeared_atp_ids.py > /var/log/automated_scripts/report_obsolete_disappeared_atp_ids.log 2>&1
 0 3 7 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_disappeared_species_ids.py > /var/log/automated_scripts/report_obsolete_disappeared_species_ids.log 2>&1


### PR DESCRIPTION
## Summary

`report_obsolete_entities.py` was failing for ZFIN obsolete genes with `'Session' object has no attribute 'lower'`. Root cause + several latent bugs in the same script are fixed here. Four focused commits:

1. **`c9dc0a3d` — Restore the A-team obsolete-status lookup.** `ateam_db_helpers.search_for_entity_curies` was refactored (commits `936fa0fb`, `f84cda11`) to a new signature `(entity_type, entity_list, taxon=None) -> List[str]` using the unified A-team client, but the only caller in this report still passed a SQLAlchemy `Session` as arg 1 and expected `(curie, obsolete, name)` triples. The broad `try/except` in `check_data()` swallowed the real `AttributeError` and surfaced only the generic log line. Fix: inline the original SQL as a local helper `search_entity_obsolete_status(ateam_db, entity_type, entity_curie_list)` matching the patterns already used by `search_species` / `get_name_for_curie` in this script. Drop the now-broken import. No changes to `ateam_db_helpers.py`.
2. **`36d3838b` — Push the cron schedule from day 19 to day 26** so the next scheduled run lands after this PR deploys.
3. **`70e38a54` — Drop `UPPER()` from the A-team curie lookup.** `UPPER()` was applied to the DB column but not to the input list, so mixed-case curies (e.g. `WB:WBGene00000001`, `FB:FBgn0123456`) would never match and every such entity would be misclassified as deleted. Now consistent with the `search_species` pattern in the same file.
4. **`2d7232f1` — Correct three SQL bugs in `get_name_for_curie`** that meant obsolete names were silently never returned for AGMs/strain/genotype/fish/construct entities (and for any single-match result):
   - `construct` branch: `WHERE` used undefined alias `be`; replaced with `r` (the FROM is `reagent r JOIN slotannotation sa`).
   - `agms/strain/genotype/fish` branch: `AND sa.obsolete = True` referenced an undefined alias; replaced with `be.obsolete = True` to preserve the filter-to-obsolete intent, consistent with the other branches.
   - Off-by-one: `if len(rows) > 1: return rows[0][0]` returned `None` for the single-match case; changed to `>= 1`.

## Test plan
- [x] `python -m py_compile`, `flake8`, and `mypy --config-file mypy.config` clean on the modified file
- [ ] Re-run `python -m agr_literature_service.lit_processing.data_check.report_obsolete_entities` against dev; confirm the ZFIN obsolete gene block completes without the `'Session' object has no attribute 'lower'` error and `QC/obsolete_entity_report.log` is produced
- [ ] Spot-check the report output for at least one MOD/entity-type combination to confirm obsolete vs deleted classification still looks correct
- [ ] Spot-check at least one obsolete AGM or construct in the report to confirm the `obsolete_name` column is now populated (was silently blank before commit 4)
- [ ] Verify a MOD with mixed-case curies (e.g. WB or FB) is no longer being wholesale-classified as "deleted" (commit 3)

## Out of scope
- The cosmetic dead-column issue in `search_entity_obsolete_status` (its 3rd SELECT column always equals the 1st) was considered and intentionally left alone — the matching shape across `search_species` and `search_entity_obsolete_status` is what lets the caller's `if name != mod_entity_id` check correctly populate species names while no-op'ing for non-species. Removing the column would either break species name reporting or require caller-side branching for marginal cleanup benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)