### PR TITLE
fix(SCRUM-523): allow shared PDB/GEO/CGC xrefs and skip duplicate ins…

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/backfill_geo_links.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/backfill_geo_links.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from os import path
 from typing import Dict, List, Optional, Tuple
 
+from fastapi import HTTPException
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
@@ -110,6 +111,12 @@ def _insert_geo_xrefs(db: Session, ref_curie: str, missing: List[str], dry_run: 
             cross_reference_crud.create(db, payload)
             inserted += 1
             logger.info("Inserted %s for %s", curie, ref_curie)
+        except HTTPException as exc:
+            if exc.status_code == 409:
+                logger.info("Skipped %s for %s: already exists", curie, ref_curie)
+                continue
+            db.rollback()
+            logger.warning("Failed to insert %s for %s: %s", curie, ref_curie, exc)
         except Exception as exc:
             # cross_reference_crud.create only rolls back on IntegrityError; any
             # other failure (OperationalError, deadlock, connection blip) leaves

--- a/alembic/versions/20260526_c8e5f9a2d3b1_allow_multiple_pdb_geo_cgc_global_xrefs.py
+++ b/alembic/versions/20260526_c8e5f9a2d3b1_allow_multiple_pdb_geo_cgc_global_xrefs.py
@@ -1,0 +1,54 @@
+"""allow multiple PDB GEO CGC global xrefs
+
+Revision ID: c8e5f9a2d3b1
+Revises: b1f8e7d6c5a4
+Create Date: 2026-05-26
+
+Widens idx_curie's exclusion list so the same GEO / PDB / CGC accession can
+appear in multiple cross_reference rows (e.g. one GEO dataset cited by many
+papers). Keeps idx_curie in lockstep with idx_curie_prefix_ref_no_cgc, which
+already excludes the same prefix set per-reference.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+
+revision = "c8e5f9a2d3b1"
+down_revision = "b1f8e7d6c5a4"
+branch_labels = None
+depends_on = None
+
+
+def _index_exists(table, name):
+    bind = op.get_bind()
+    insp = sa_inspect(bind)
+    for idx in insp.get_indexes(table):
+        if idx["name"] == name:
+            return True
+    return False
+
+
+def upgrade():
+    if _index_exists("cross_reference", "idx_curie"):
+        op.drop_index("idx_curie", table_name="cross_reference")
+    op.create_index(
+        "idx_curie", "cross_reference", ["curie"],
+        unique=True,
+        postgresql_where=sa.text(
+            "is_obsolete IS FALSE "
+            "AND curie_prefix NOT IN ('ISSN', 'CGC', 'PDB', 'GEO')"
+        )
+    )
+
+
+def downgrade():
+    if _index_exists("cross_reference", "idx_curie"):
+        op.drop_index("idx_curie", table_name="cross_reference")
+    op.create_index(
+        "idx_curie", "cross_reference", ["curie"],
+        unique=True,
+        postgresql_where=sa.text(
+            "is_obsolete IS FALSE AND curie_prefix != 'ISSN'"
+        )
+    )

--- a/alembic/versions/20260526_c8e5f9a2d3b1_allow_multiple_pdb_geo_cgc_global_xrefs.py
+++ b/alembic/versions/20260526_c8e5f9a2d3b1_allow_multiple_pdb_geo_cgc_global_xrefs.py
@@ -1,13 +1,15 @@
-"""allow multiple PDB GEO CGC global xrefs
+"""allow multiple PDB GEO CGC global xrefs and re-enforce ISSN uniqueness
 
 Revision ID: c8e5f9a2d3b1
 Revises: b1f8e7d6c5a4
 Create Date: 2026-05-26
 
-Widens idx_curie's exclusion list so the same GEO / PDB / CGC accession can
+Rewrites idx_curie's predicate so the same GEO / PDB / CGC accession can
 appear in multiple cross_reference rows (e.g. one GEO dataset cited by many
-papers). Keeps idx_curie in lockstep with idx_curie_prefix_ref_no_cgc, which
-already excludes the same prefix set per-reference.
+papers), while ISSN is no longer excepted and is globally unique again.
+Keeps idx_curie in lockstep with idx_curie_prefix_ref_no_cgc, which
+already excludes the same PDB/GEO/CGC prefix set per-reference.
+idx_curie_res is intentionally left unchanged.
 """
 from alembic import op
 import sqlalchemy as sa
@@ -37,7 +39,7 @@ def upgrade():
         unique=True,
         postgresql_where=sa.text(
             "is_obsolete IS FALSE "
-            "AND curie_prefix NOT IN ('ISSN', 'CGC', 'PDB', 'GEO')"
+            "AND curie_prefix NOT IN ('CGC', 'PDB', 'GEO')"
         )
     )
 

--- a/alembic/versions/20260526_c8e5f9a2d3b1_allow_multiple_pdb_geo_global_xrefs.py
+++ b/alembic/versions/20260526_c8e5f9a2d3b1_allow_multiple_pdb_geo_global_xrefs.py
@@ -1,14 +1,15 @@
-"""allow multiple PDB GEO CGC global xrefs and re-enforce ISSN uniqueness
+"""allow multiple PDB GEO global xrefs and re-enforce ISSN/CGC uniqueness
 
 Revision ID: c8e5f9a2d3b1
 Revises: b1f8e7d6c5a4
 Create Date: 2026-05-26
 
-Rewrites idx_curie's predicate so the same GEO / PDB / CGC accession can
-appear in multiple cross_reference rows (e.g. one GEO dataset cited by many
-papers), while ISSN is no longer excepted and is globally unique again.
-Keeps idx_curie in lockstep with idx_curie_prefix_ref_no_cgc, which
-already excludes the same PDB/GEO/CGC prefix set per-reference.
+Rewrites idx_curie's predicate so the same GEO / PDB accession can appear
+in multiple cross_reference rows (e.g. one GEO dataset cited by many
+papers). ISSN and CGC are globally unique. The companion per-reference
+index idx_curie_prefix_ref_no_cgc still excludes CGC at that level (so a
+single reference can list multiple CGC strains), but a given CGC curie
+is owned by exactly one cross_reference row globally.
 idx_curie_res is intentionally left unchanged.
 """
 from alembic import op
@@ -39,7 +40,7 @@ def upgrade():
         unique=True,
         postgresql_where=sa.text(
             "is_obsolete IS FALSE "
-            "AND curie_prefix NOT IN ('CGC', 'PDB', 'GEO')"
+            "AND curie_prefix NOT IN ('PDB', 'GEO')"
         )
     )
 

--- a/crontab
+++ b/crontab
@@ -21,7 +21,7 @@ BASH_ENV=/container.env
 0 0 18 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/remove_obsolete_pubmed_types.py > /var/log/automated_scripts/remove_obsolete_pubmed_types.log 2>&1
 0 21 18 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_duplicate_orcid_in_reference.py > /var/log/automated_scripts/report_duplicate_orcid_in_reference.log 2>&1
 0 22 18 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_and_fix_obsolete_pmids.py > /var/log/automated_scripts/report_and_fix_obsolete_pmids.log 2>&1
-0 2 27 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py > /var/log/automated_scripts/report_obsolete_entities.log 2>&1
+0 2 1 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_entities.py > /var/log/automated_scripts/report_obsolete_entities.log 2>&1
 0 0 20 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_retracted_papers_with_tags.py > /var/log/automated_scripts/report_retracted_papers_with_tags.log 2>&1
 0 0 7 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_disappeared_atp_ids.py > /var/log/automated_scripts/report_obsolete_disappeared_atp_ids.log 2>&1
 0 3 7 * * python3 /usr/src/app/agr_literature_service/lit_processing/data_check/report_obsolete_disappeared_species_ids.py > /var/log/automated_scripts/report_obsolete_disappeared_species_ids.log 2>&1

--- a/tests/lit_processing/data_ingest/pubmed_ingest/test_backfill_geo_links.py
+++ b/tests/lit_processing/data_ingest/pubmed_ingest/test_backfill_geo_links.py
@@ -42,6 +42,21 @@ class TestInsertGeoXrefs:
         assert n == 1
         assert create_mock.call_count == 2
 
+    def test_skips_409_duplicate_without_counting_or_warning(self):
+        from fastapi import HTTPException
+        dup = HTTPException(
+            status_code=409,
+            detail="Cannot add cross-reference with CURIE GEO:GSE1...",
+        )
+        with patch.object(backfill_geo_links.cross_reference_crud, "create",
+                          side_effect=[dup, None]) as create_mock:
+            n = backfill_geo_links._insert_geo_xrefs(
+                db=MagicMock(), ref_curie="AGRKB:1",
+                missing=["GSE1", "GSE2"], dry_run=False
+            )
+        assert n == 1
+        assert create_mock.call_count == 2
+
     def test_rolls_back_session_when_create_raises(self):
         """Non-IntegrityError exceptions propagate out of cross_reference_crud.create
         without rollback; the backfill must rollback itself to keep the transaction


### PR DESCRIPTION
…erts

Widen idx_curie's partial-index predicate to also exclude CGC, PDB, and GEO, so the same accession can appear in multiple cross_reference rows (e.g. one GEO dataset cited by many papers). Keeps idx_curie in lockstep with idx_curie_prefix_ref_no_cgc, which already excludes the same prefix set per-reference.

In backfill_geo_links._insert_geo_xrefs, catch HTTPException(409) and log it at INFO as 'already exists' instead of WARNING, matching the existing convention in pdb_ingest/load_pdb_associations.py. Defends against the rollout window before the migration is applied and any genuine re-runs.