### PR TITLE
fix(SCRUM-6146): assign per-MOD indexing tag on corpus add

### DIFF
--- a/agr_literature_service/api/crud/mod_corpus_association_crud.py
+++ b/agr_literature_service/api/crud/mod_corpus_association_crud.py
@@ -86,7 +86,7 @@ def create(db: Session, mod_corpus_association: ModCorpusAssociationSchemaPost) 
         if indexing_needed_tag:
             wft_obj = WorkflowTagModel(reference_id=reference.reference_id,
                                        mod_id=mod.mod_id,
-                                       workflow_tag_id=pre_indexing_prio_needed_tag_atp_id)
+                                       workflow_tag_id=indexing_needed_tag)
             db.add(wft_obj)
             db.commit()
 


### PR DESCRIPTION
## Summary
- `create()` in `mod_corpus_association_crud.py` hardcoded `pre_indexing_prio_needed_tag_atp_id` (`ATP:0000306`, "pre-indexing prioritization needed") when adding a paper into corpus.
- The `indexing_needed_tag` dict maps `SGD -> manual_indexing_needed_tag_atp_id (ATP:0000274)` and `ZFIN -> pre_indexing_prio_needed_tag_atp_id (ATP:0000306)`, but its value was never used — so **SGD papers received ZFIN's tag** (`ATP:0000306`) instead of `manual indexing needed`.
- Fix: use the per-MOD `indexing_needed_tag` value. ZFIN behavior is unchanged; SGD now gets `ATP:0000274`.

Introduced by commit `605aa233` (2025-05-29), which swapped the constant for all MODs instead of using the dict it added.

## Impact
- Affected ~18 prod / 15 dev SGD references (spurious `ATP:0000306`; many already manual-indexing-complete). Data cleanup is tracked separately on SCRUM-6146.

## Open product question (for reviewer / @Shuai Weng)
This fix honors the dict's evident intent (SGD auto-gets `manual indexing needed` on corpus add). If SGD should instead get **nothing** on corpus add (manual indexing appears curator-driven), the follow-up is to drop SGD from the `indexing_needed_tag` dict. Flagged in SCRUM-6146.

## Test plan
- [x] flake8 + mypy pass on the changed file
- [ ] Add a paper to SGD corpus via `create()` and confirm it gets `ATP:0000274`, not `ATP:0000306`
- [ ] Add a paper to ZFIN corpus and confirm it still gets `ATP:0000306`

🤖 Generated with [Claude Code](https://claude.com/claude-code)