### PR TITLE
fix(SCRUM-523): split-on-failure recovery for NCBI elink batches

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/backfill_geo_links.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/backfill_geo_links.py
@@ -22,7 +22,7 @@ from agr_literature_service.api.models import CrossReferenceModel, ReferenceMode
 from agr_literature_service.api.schemas.cross_reference_schemas import CrossReferenceSchemaPost
 from agr_literature_service.api.user import set_global_user_id
 from agr_literature_service.lit_processing.data_ingest.pubmed_ingest.get_geo_links import (
-    get_geo_accessions_for_pmids,
+    get_geo_accessions_for_pmids_with_split,
 )
 from agr_literature_service.lit_processing.utils.sqlalchemy_utils import create_postgres_session
 
@@ -150,9 +150,10 @@ def backfill(mod_abbreviation: str = "",
         batch = refs[start:start + batch_size]
         pmids = [pmid for _, _, pmid in batch]
         try:
-            pmid_to_gse = get_geo_accessions_for_pmids(pmids)
+            pmid_to_gse = get_geo_accessions_for_pmids_with_split(pmids)
         except Exception as exc:
-            logger.error("elink batch failed (%d PMIDs starting at %d): %s", len(pmids), start, exc)
+            logger.error("elink batch failed unexpectedly (%d PMIDs starting at %d): %s",
+                         len(pmids), start, exc)
             continue
         existing = _existing_geo_curies(db, [r[0] for r in batch])
         for ref_id, ref_curie, pmid in batch:

--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/get_geo_links.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/get_geo_links.py
@@ -42,16 +42,26 @@ def _throttle() -> None:
 def _get_with_retry(url: str, params: Dict[str, str]) -> dict:
     last_exc = None
     for attempt in range(_MAX_RETRIES):
+        wait = _RETRY_BACKOFF_BASE ** attempt
+        r = None
         try:
             r = requests.get(url, params=params, timeout=30)
             r.raise_for_status()
             return r.json()
-        except requests.exceptions.RequestException as exc:
+        except requests.exceptions.JSONDecodeError as exc:
+            body_preview = r.text[:500] if r is not None and r.text else ""
+            logger.warning(
+                "NCBI %s returned non-JSON (attempt %d/%d): %s; body[:500]=%r; retrying in %ds",
+                url, attempt + 1, _MAX_RETRIES, exc, body_preview, wait,
+            )
             last_exc = exc
-            wait = _RETRY_BACKOFF_BASE ** attempt
-            logger.warning("NCBI request to %s failed (attempt %d/%d): %s; retrying in %ds",
-                           url, attempt + 1, _MAX_RETRIES, exc, wait)
-            time.sleep(wait)
+        except requests.exceptions.RequestException as exc:
+            logger.warning(
+                "NCBI request to %s failed (attempt %d/%d): %s; retrying in %ds",
+                url, attempt + 1, _MAX_RETRIES, exc, wait,
+            )
+            last_exc = exc
+        time.sleep(wait)
     assert last_exc is not None
     raise last_exc
 
@@ -115,6 +125,31 @@ def get_geo_accessions_for_pmids(pmids: List[str]) -> Dict[str, List[str]]:
         accessions = {uid_to_accession[u] for u in uids if u in uid_to_accession}
         output[pmid] = sorted(accessions)
     return output
+
+
+def get_geo_accessions_for_pmids_with_split(pmids: List[str]) -> Dict[str, List[str]]:
+    """Like get_geo_accessions_for_pmids, but if NCBI returns an unrecoverable
+    failure for the batch we split the PMID list in half and retry each half.
+    Recurses down to single-PMID granularity; a single PMID that still fails is
+    logged at ERROR and dropped from the result dict (caller treats that the
+    same as 'no GEO links found' for this run; next nightly run will retry it).
+    Never raises for NCBI-side failures."""
+    if not pmids:
+        return {}
+    try:
+        return get_geo_accessions_for_pmids(pmids)
+    except Exception as exc:
+        if len(pmids) == 1:
+            logger.error("elink lookup for PMID %s gave up after retries: %s", pmids[0], exc)
+            return {}
+        mid = len(pmids) // 2
+        logger.warning(
+            "elink batch of %d PMIDs failed after retries; splitting into %d + %d. Cause: %s",
+            len(pmids), mid, len(pmids) - mid, exc,
+        )
+        left = get_geo_accessions_for_pmids_with_split(pmids[:mid])
+        right = get_geo_accessions_for_pmids_with_split(pmids[mid:])
+        return {**left, **right}
 
 
 def _cli() -> None:  # pragma: no cover

--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/get_geo_links.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/get_geo_links.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 import time
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import requests
 
@@ -40,7 +40,7 @@ def _throttle() -> None:
 
 
 def _get_with_retry(url: str, params: Dict[str, str]) -> dict:
-    last_exc = None
+    last_exc: Optional[requests.exceptions.RequestException] = None
     for attempt in range(_MAX_RETRIES):
         wait = _RETRY_BACKOFF_BASE ** attempt
         r = None

--- a/tests/lit_processing/data_ingest/pubmed_ingest/test_get_geo_links.py
+++ b/tests/lit_processing/data_ingest/pubmed_ingest/test_get_geo_links.py
@@ -7,6 +7,7 @@ import requests
 from agr_literature_service.lit_processing.data_ingest.pubmed_ingest.get_geo_links import (
     get_geo_accessions_for_pmid,
     get_geo_accessions_for_pmids,
+    get_geo_accessions_for_pmids_with_split,
 )
 
 
@@ -178,6 +179,77 @@ class TestGetGeoAccessionsForPmids:
             result = get_geo_accessions_for_pmids(["111", "222"])
             assert mock_get.call_count == 1
         assert result == {"111": [], "222": []}
+
+
+class TestGetWithRetryJsonDecode:
+
+    def test_get_with_retry_logs_body_preview_on_json_decode_error(self, caplog):
+        bad_text = '{"linksets":[{"control":"\\x00\\x01"}]}'
+        bad_resp = MagicMock()
+        bad_resp.status_code = 200
+        bad_resp.text = bad_text
+        bad_resp.json.side_effect = requests.exceptions.JSONDecodeError(
+            "Invalid control character at", bad_text, 85)
+        bad_resp.raise_for_status = MagicMock()
+
+        good_elink = _mock_response({"linksets": [
+            {"dbfrom": "pubmed", "ids": ["1"], "linksetdbs": []}
+        ]})
+
+        caplog.set_level("WARNING",
+                         logger="agr_literature_service.lit_processing."
+                                "data_ingest.pubmed_ingest.get_geo_links")
+        with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
+                   "get_geo_links.time.sleep"), \
+             patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
+                   "get_geo_links.requests.get",
+                   side_effect=[bad_resp, good_elink]):
+            get_geo_accessions_for_pmids(["1"])
+
+        body_logs = [r.message for r in caplog.records if "body[:500]=" in r.message]
+        assert body_logs, f"expected body[:500]= log line, got: {[r.message for r in caplog.records]}"
+        assert "control" in body_logs[0]  # snippet of the bad body was captured
+
+
+class TestGetGeoAccessionsForPmidsWithSplit:
+
+    def test_returns_empty_dict_for_empty_input(self):
+        assert get_geo_accessions_for_pmids_with_split([]) == {}
+
+    def test_returns_primitive_result_on_clean_run(self):
+        with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
+                   "get_geo_links.get_geo_accessions_for_pmids",
+                   return_value={"1": ["GSE1"], "2": []}) as inner:
+            result = get_geo_accessions_for_pmids_with_split(["1", "2"])
+        assert result == {"1": ["GSE1"], "2": []}
+        assert inner.call_count == 1
+
+    def test_splits_on_batch_failure_and_merges_halves(self, caplog):
+        caplog.set_level("WARNING",
+                         logger="agr_literature_service.lit_processing."
+                                "data_ingest.pubmed_ingest.get_geo_links")
+        with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
+                   "get_geo_links.get_geo_accessions_for_pmids",
+                   side_effect=[
+                       RuntimeError("boom"),
+                       {"1": ["GSEA"], "2": []},
+                       {"3": [], "4": ["GSEB"]},
+                   ]) as inner:
+            result = get_geo_accessions_for_pmids_with_split(["1", "2", "3", "4"])
+        assert result == {"1": ["GSEA"], "2": [], "3": [], "4": ["GSEB"]}
+        assert inner.call_count == 3
+        assert any("splitting into 2 + 2" in r.message for r in caplog.records)
+
+    def test_logs_and_drops_single_pmid_dead_end(self, caplog):
+        caplog.set_level("ERROR",
+                         logger="agr_literature_service.lit_processing."
+                                "data_ingest.pubmed_ingest.get_geo_links")
+        with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
+                   "get_geo_links.get_geo_accessions_for_pmids",
+                   side_effect=RuntimeError("permanently bad")):
+            result = get_geo_accessions_for_pmids_with_split(["111"])
+        assert result == {}
+        assert any("PMID 111 gave up" in r.message for r in caplog.records)
 
 
 @pytest.mark.webtest


### PR DESCRIPTION
## Summary
- When NCBI elink retries are exhausted on a 200-PMID batch (mix of `500 Server Error` and `Invalid control character` JSON-decode failures observed in prod 2026-05-27), the previous code silently dropped all 200 PMIDs for the run. This PR adds binary split-and-retry so the batch's good PMIDs are still resolved and any single persistently-bad PMID is isolated and logged.
- On `JSONDecodeError` inside `_get_with_retry`, log a truncated `body[:500]=...` preview of the response so the next occurrence can actually be diagnosed.
- New public function `get_geo_accessions_for_pmids_with_split` is the entry point used by `backfill_geo_links.py`. The original `get_geo_accessions_for_pmids` primitive is unchanged.

## Test plan
- [x] `flake8` clean on all three modified files
- [x] `pytest tests/lit_processing/data_ingest/pubmed_ingest/test_get_geo_links.py` — 15 tests pass (11 existing + 4 new: JSON-decode body preview log, split + merge of halves, single-PMID dead-end logged + dropped, no-op passthrough)
- [x] `pytest tests/lit_processing/data_ingest/pubmed_ingest/test_backfill_geo_links.py` — 8 tests pass (no regression on the caller)
- [ ] End-to-end on the cron box: next nightly run (or manual `--since-days N`). Look for `WARNING ... splitting into N/2 + N/2` (recovery happened) and any `ERROR ... PMID <id> gave up` (isolated bad PMID worth investigating). The surrounding batch's good PMIDs should now appear in the final `xrefs_added=` summary instead of being dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)