### PR TITLE
fix(SCRUM-6164): update file uploader for new API return format

### DIFF
--- a/file_uploader/upload_files.sh
+++ b/file_uploader/upload_files.sh
@@ -49,11 +49,15 @@ upload_file () {
   if [[ ${pdf_type} != "null" ]]; then
     url="${url}&pdf_type=${pdf_type}"
   fi
-  response=$(curl -s --request POST --url ${url} \
+  # Append the HTTP status code on its own trailing line so we can inspect it
+  # separately from the (single-line) JSON body returned by the API.
+  http_response=$(curl -s -w "\n%{http_code}" --request POST --url ${url} \
     -H 'accept: application/json' \
     -H "Authorization: Bearer ${COGNITO_ACCESS_TOKEN}" \
     -H 'Content-Type: multipart/form-data' \
     -F "file=@\"${filepath}\";type=text/plain")
+  http_code=$(echo "$http_response" | tail -n1)
+  response=$(echo "$http_response" | sed '$d')
 
   # Check if the response contains a "detail" field with specific phrases
   detail_message=$(echo "$response" | jq -r '.detail // empty')
@@ -63,7 +67,12 @@ upload_file () {
     return
   fi
 
-  if [[ "${response}" == "\"success\"" ]]; then
+  # The new API returns HTTP 201 with an array of the created referencefile
+  # objects on success, or an error status with an object containing a "detail"
+  # field on failure. Require a 2xx status code AND a non-empty JSON array
+  # before reporting success.
+  num_created=$(echo "$response" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null)
+  if [[ "${http_code}" =~ ^2[0-9][0-9]$ && "${num_created}" =~ ^[0-9]+$ && "${num_created}" -gt 0 ]]; then
     upload_status="success"
     response="empty response"
   else


### PR DESCRIPTION
## Summary
The `POST /reference/referencefile/file_upload/` endpoint was migrated to strict REST in SCRUM-5716 and now returns **HTTP 201 with an array of the created referencefile objects** instead of the literal JSON string `"success"`. The uploader script's success check still matched `"success"`, so every successful upload was mislabeled as `error`.

## Changes
- `file_uploader/upload_files.sh`:
  - Capture the HTTP status code via `curl -w "\n%{http_code}"` and split it from the JSON body.
  - Determine success from a **2xx status code AND a non-empty JSON array** of created objects, replacing the obsolete `== "\"success\""` check.
  - **Printed log output is unchanged** (`API_CALL_STATUS` / `RESPONSE` / `FILE`) so downstream log-parsing scripts continue to work — the `RESPONSE:` value is byte-for-byte identical to the previous version (`empty response` on success, raw API body on error).

## Testing
- `bash -n` syntax check passes.
- Simulated the parser against success arrays, `detail` errors, the token-expiry error, server errors, and empty bodies — all classify correctly and the token-refresh retry path still fires.
- Existing `tests/file_uploader/test_upload_files.py` (`--test-extraction` mode) is unaffected.

Jira: SCRUM-6164

🤖 Generated with [Claude Code](https://claude.com/claude-code)