### PR TITLE
nclude indexing_priority tables in Debezium publication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,13 @@ restart-debezium-aws:
 stop-debezium:
 	docker-compose --env-file ${ENV_FILE} rm -svf dbz_connector dbz_kafka dbz_zookeeper dbz_ksql_server dbz_setup
 
+# Non-destructive self-heal: add any tables in table.include.list that are missing from the
+# existing Debezium publication (e.g. indexing_priority, manual_indexing_tag), so a running
+# deployment starts streaming them without a full reindex. Safe to run repeatedly.
+heal-debezium-publication:
+	docker-compose --env-file ${ENV_FILE} build dbz_setup
+	docker-compose --env-file ${ENV_FILE} run --rm dbz_setup bash /heal_publication.sh
+
 restart-api:
 	docker-compose --env-file ${ENV_FILE} build --no-cache api
 	docker-compose --env-file ${ENV_FILE} rm -s -f api

--- a/debezium/heal_publication.sh
+++ b/debezium/heal_publication.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Idempotent self-heal for the Debezium logical-replication publication.
+#
+# The unified connector (postgres-source-unified.json) uses
+# publication.autocreate.mode=filtered. That mode creates the publication ONLY
+# when it does not already exist; it never adds newly-included tables to a
+# pre-existing publication. So when a table is added to the connector's
+# table.include.list (e.g. indexing_priority, manual_indexing_tag), Postgres
+# keeps publishing the old table set and the new table's row changes never
+# stream into the index.
+#
+# A full reindex (setup.sh) fixes this because it drops and recreates the
+# publication. This script is the non-destructive alternative: it adds any
+# missing tables to the EXISTING publication so a running deployment starts
+# streaming them immediately, without a full reindex. It is safe to run
+# repeatedly.
+#
+# Keep the table list below in sync with "table.include.list" in
+# postgres-source-unified.json.
+
+set -euo pipefail
+
+PUBLICATION="${DEBEZIUM_PUBLICATION:-debezium_unified}"
+
+export PGPASSWORD=${PSQL_PASSWORD}
+
+echo "Healing publication '${PUBLICATION}' on ${PSQL_HOST}:${PSQL_PORT}/${PSQL_DATABASE} ..."
+
+psql -h "${PSQL_HOST}" -U "${PSQL_USERNAME}" -p "${PSQL_PORT}" -d "${PSQL_DATABASE}" \
+    -v ON_ERROR_STOP=1 -c "DO \$\$
+DECLARE
+  tbl text;
+  sch text := 'public';
+  pub text := '${PUBLICATION}';
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = pub) THEN
+    RAISE NOTICE 'Publication % does not exist; run setup.sh to create it.', pub;
+    RETURN;
+  END IF;
+  IF (SELECT puballtables FROM pg_publication WHERE pubname = pub) THEN
+    RAISE NOTICE 'Publication % is FOR ALL TABLES; nothing to add.', pub;
+    RETURN;
+  END IF;
+  FOREACH tbl IN ARRAY ARRAY[
+    'citation','reference','resource','mod_corpus_association','topic_entity_tag_source',
+    'mod_referencetype','mod','referencetype','copyright_license','cross_reference','author',
+    'obsolete_reference_curie','reference_mod_referencetype','topic_entity_tag','workflow_tag',
+    'reference_relation','mesh_detail','reference_email','indexing_priority','manual_indexing_tag'
+  ]
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_publication_tables
+      WHERE pubname = pub AND schemaname = sch AND tablename = tbl
+    ) THEN
+      EXECUTE format('ALTER PUBLICATION %I ADD TABLE %I.%I', pub, sch, tbl);
+      RAISE NOTICE 'Added %.% to publication %', sch, tbl, pub;
+    END IF;
+  END LOOP;
+END\$\$;"
+
+echo "Publication '${PUBLICATION}' heal complete."

--- a/debezium/setup.sh
+++ b/debezium/setup.sh
@@ -50,6 +50,14 @@ export PGPASSWORD=${PSQL_PASSWORD}
 # Drop replication slots (both old and new)
 psql -h ${PSQL_HOST} -U ${PSQL_USERNAME} -p ${PSQL_PORT} -d ${PSQL_DATABASE} -c "DO \$\$DECLARE slot text; BEGIN FOREACH slot IN ARRAY ARRAY['debezium_unified','debezium_extract_fields','debezium_joined_tables','debezium_mod','debezium_referencetype','debezium_reference','debezium_citation','debezium_mod_referencetype','debezium_topic_entity_tag_source','debezium_copyright_license','debezium_mod_corpus_association','debezium_resource'] LOOP IF EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = slot) THEN PERFORM pg_drop_replication_slot(slot); END IF; END LOOP; END\$\$;"
 
+# Drop publications so the connector recreates them from the CURRENT table.include.list.
+# The connector uses publication.autocreate.mode=filtered, which only creates a publication
+# when it does not already exist -- it does NOT add newly-included tables to a pre-existing
+# publication. Without dropping them here, tables added to table.include.list after the
+# publication was first created (e.g. indexing_priority, manual_indexing_tag) never get
+# published, so their row changes never stream into the index.
+psql -h ${PSQL_HOST} -U ${PSQL_USERNAME} -p ${PSQL_PORT} -d ${PSQL_DATABASE} -c "DO \$\$DECLARE pub text; BEGIN FOREACH pub IN ARRAY ARRAY['debezium_unified','debezium_extract_fields','debezium_joined_tables','debezium_mod','debezium_referencetype','debezium_reference','debezium_citation','debezium_mod_referencetype','debezium_topic_entity_tag_source','debezium_copyright_license','debezium_mod_corpus_association','debezium_resource'] LOOP EXECUTE format('DROP PUBLICATION IF EXISTS %I', pub); END LOOP; END\$\$;"
+
 # Create single unified connector
 curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/ -d @<(envsubst '$PSQL_HOST$PSQL_USERNAME$PSQL_PORT$PSQL_DATABASE$PSQL_PASSWORD' < /postgres-source-unified.json)
 sleep ${CONNECTOR_SETUP_SLEEP}

--- a/docker/debezium_setup.dockerfile
+++ b/docker/debezium_setup.dockerfile
@@ -4,10 +4,11 @@ RUN apk add --no-cache bash curl gettext postgresql-client jq
 
 COPY debezium/setup.sh /setup.sh
 COPY debezium/status_manager.sh /status_manager.sh
+COPY debezium/heal_publication.sh /heal_publication.sh
 COPY debezium/*.json /
 COPY debezium/*.ksql /
 
-RUN chmod +x /setup.sh /status_manager.sh
+RUN chmod +x /setup.sh /status_manager.sh /heal_publication.sh
 
 CMD ["bash", "/setup.sh"]
 


### PR DESCRIPTION
The unified connector uses publication.autocreate.mode=filtered, which creates the publication only when absent and never adds newly-included tables to a pre-existing one. So indexing_priority and manual_indexing_tag (added to table.include.list later) were never published, and their row changes — including curator_indexing_priority — never streamed into the search index.

- setup.sh: drop publications alongside replication slots so the connector rebuilds them against the current table.include.list on every reindex.
- heal_publication.sh: idempotent, non-destructive self-heal that ALTERs the existing publication to add any missing tables, so a running deployment starts streaming them without a full reindex.
- debezium_setup.dockerfile: ship heal_publication.sh in the dbz_setup image.
- Makefile: add heal-debezium-publication target.