### PR TITLE
fix(geo): preserve per-PMID attribution in batched elink calls

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/get_geo_links.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/get_geo_links.py
@@ -8,12 +8,16 @@ import logging
 import os
 import sys
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import requests
 
 ELINK_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
 ESUMMARY_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
+
+# elink takes the PMID list as a repeated `&id=` param (value is a list); other
+# params are plain strings. See get_geo_accessions_for_pmids for why.
+ParamsType = Dict[str, Union[str, List[str]]]
 
 # Conservative throttle: 3 req/s without an API key, 10 req/s with one.
 _THROTTLE_SECONDS_NO_KEY = 0.34
@@ -39,7 +43,7 @@ def _throttle() -> None:
     time.sleep(delay)
 
 
-def _get_with_retry(url: str, params: Dict[str, str]) -> dict:
+def _get_with_retry(url: str, params: ParamsType) -> dict:
     last_exc: Optional[requests.exceptions.RequestException] = None
     for attempt in range(_MAX_RETRIES):
         wait = _RETRY_BACKOFF_BASE ** attempt
@@ -77,12 +81,16 @@ def get_geo_accessions_for_pmids(pmids: List[str]) -> Dict[str, List[str]]:
     if not pmids:
         return {}
 
-    elink_params = {
+    # NCBI elink MERGES comma-joined ids into a single linkset (all source PMIDs
+    # in one `ids` array, all links pooled with no per-PMID attribution). Passing
+    # the list to requests sends repeated `&id=` params instead, which makes elink
+    # return one linkset per PMID so links stay correctly attributed.
+    elink_params: ParamsType = {
         "dbfrom": "pubmed",
         "db": "gds",
         "linkname": "pubmed_gds",
         "retmode": "json",
-        "id": ",".join(pmids),
+        "id": pmids,
     }
     elink_params.update(_base_params())
     elink_data = _get_with_retry(ELINK_URL, elink_params)
@@ -107,7 +115,7 @@ def get_geo_accessions_for_pmids(pmids: List[str]) -> Dict[str, List[str]]:
         return {p: [] for p in pmids}
 
     unique_uids = sorted(set(all_uids))
-    esummary_params = {"db": "gds", "id": ",".join(unique_uids), "retmode": "json"}
+    esummary_params: ParamsType = {"db": "gds", "id": ",".join(unique_uids), "retmode": "json"}
     esummary_params.update(_base_params())
     esummary_data = _get_with_retry(ESUMMARY_URL, esummary_params)
     _throttle()

--- a/tests/lit_processing/data_ingest/pubmed_ingest/test_get_geo_links.py
+++ b/tests/lit_processing/data_ingest/pubmed_ingest/test_get_geo_links.py
@@ -160,6 +160,49 @@ class TestGetGeoAccessionsForPmids:
             result = get_geo_accessions_for_pmids(["111", "222", "333"])
         assert result == {"111": ["GSE1", "GSE2"], "222": ["GSE3"], "333": []}
 
+    def test_elink_sends_id_as_list_for_per_pmid_attribution(self):
+        """elink MERGES comma-joined ids into a single linkset, losing per-PMID
+        attribution. Passing the PMID list (repeated `&id=` params) makes NCBI
+        return one linkset per PMID. Pin that `id` is sent as a list."""
+        elink_empty = {
+            "linksets": [
+                {"dbfrom": "pubmed", "ids": ["111"], "linksetdbs": []},
+                {"dbfrom": "pubmed", "ids": ["222"], "linksetdbs": []},
+                {"dbfrom": "pubmed", "ids": ["333"], "linksetdbs": []},
+            ]
+        }
+        with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
+                   "get_geo_links.requests.get",
+                   side_effect=[_mock_response(elink_empty)]) as mock_get:
+            get_geo_accessions_for_pmids(["111", "222", "333"])
+            params = mock_get.call_args.kwargs["params"]
+            assert params["id"] == ["111", "222", "333"]
+
+    def test_does_not_misattribute_links_across_separate_linksets(self):
+        """Regression: with per-PMID linksets, a PMID with no GEO link must not
+        inherit another PMID's links. Previously a single merged linkset pooled
+        all links onto the first PMID, starving every other PMID in the batch."""
+        elink_per_pmid = {
+            "linksets": [
+                {"dbfrom": "pubmed", "ids": ["31000000"], "linksetdbs": []},
+                {"dbfrom": "pubmed", "ids": ["33526011"],
+                 "linksetdbs": [{"dbto": "gds", "linkname": "pubmed_gds",
+                                 "links": ["200147729"]}]},
+            ]
+        }
+        esummary = {
+            "result": {
+                "uids": ["200147729"],
+                "200147729": {"uid": "200147729", "accession": "GSE147729",
+                              "entrytype": "GSE"},
+            }
+        }
+        with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
+                   "get_geo_links.requests.get",
+                   side_effect=[_mock_response(elink_per_pmid), _mock_response(esummary)]):
+            result = get_geo_accessions_for_pmids(["31000000", "33526011"])
+        assert result == {"31000000": [], "33526011": ["GSE147729"]}
+
     def test_returns_empty_dict_for_empty_input(self):
         with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
                    "get_geo_links.requests.get") as mock_get:


### PR DESCRIPTION
## Problem

Running `backfill_geo_links.py` produced **no** `GEO:GSE...` cross-reference for papers that genuinely have a GEO Series (e.g. PMID:33526011 → GSE147729), while "other" GEO xrefs appeared on the wrong references.

## Root cause

`get_geo_accessions_for_pmids()` sent each batch of PMIDs to NCBI elink as a **comma-joined** `id` param. NCBI **merges comma-joined ids into a single linkset** — all source PMIDs land in one `ids` array and all GDS links are pooled with no per-PMID attribution. The parser then took only `ids[0]` (the first PMID of the batch) and attributed *every* pooled link to it. Result:

- Every other PMID in the batch (including 33526011) received **no** GEO xref.
- The batch-leader reference got a pile of links, mostly **mis-attributed** to the wrong paper.

Verified against live NCBI: `id=A,B` → one merged linkset; `id=A&id=B` → one linkset per PMID with correct links.

## Fix

Pass the PMID **list** to `requests` instead of comma-joining it, so elink receives repeated `&id=` params and returns one linkset per PMID. The existing parser handles this unchanged. Broadened the params type hints (`ParamsType`) for mypy.

## Tests

- Pin that elink is called with `id` as a list (preserves attribution).
- Regression test proving a link-less PMID no longer inherits another PMID's links.

## Note on existing data

Out of scope here — previously inserted mis-attributed GEO xrefs will be removed manually, then the corrected backfill re-run.

## Verification

- 18 unit tests pass; flake8 clean; mypy clean on the changed file.
- Live: `python -m ...get_geo_links 31000000 33526011` → empty for 31000000, `GSE147729` for 33526011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)