### PR TITLE
fix(geo): attribute GEO links via esummary pubmedids, not per-id elink

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/get_geo_links.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/get_geo_links.py
@@ -8,16 +8,12 @@ import logging
 import os
 import sys
 import time
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 import requests
 
 ELINK_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
 ESUMMARY_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
-
-# elink takes the PMID list as a repeated `&id=` param (value is a list); other
-# params are plain strings. See get_geo_accessions_for_pmids for why.
-ParamsType = Dict[str, Union[str, List[str]]]
 
 # Conservative throttle: 3 req/s without an API key, 10 req/s with one.
 _THROTTLE_SECONDS_NO_KEY = 0.34
@@ -43,7 +39,7 @@ def _throttle() -> None:
     time.sleep(delay)
 
 
-def _get_with_retry(url: str, params: ParamsType) -> dict:
+def _get_with_retry(url: str, params: Dict[str, str]) -> dict:
     last_exc: Optional[requests.exceptions.RequestException] = None
     for attempt in range(_MAX_RETRIES):
         wait = _RETRY_BACKOFF_BASE ** attempt
@@ -81,58 +77,58 @@ def get_geo_accessions_for_pmids(pmids: List[str]) -> Dict[str, List[str]]:
     if not pmids:
         return {}
 
-    # NCBI elink MERGES comma-joined ids into a single linkset (all source PMIDs
-    # in one `ids` array, all links pooled with no per-PMID attribution). Passing
-    # the list to requests sends repeated `&id=` params instead, which makes elink
-    # return one linkset per PMID so links stay correctly attributed.
-    elink_params: ParamsType = {
+    # elink is asked for the whole batch with comma-joined ids. NCBI merges these
+    # into a single linkset (all source PMIDs pooled, no per-PMID attribution),
+    # which is fine here: we only use elink to discover the set of candidate GDS
+    # UIDs for the batch. The expensive alternative -- repeated `&id=` params to
+    # force one linkset per PMID -- makes NCBI drop the chunked response for
+    # batches of ~100, so we recover per-PMID attribution from esummary instead
+    # (each GDS record carries its own `pubmedids`).
+    elink_params = {
         "dbfrom": "pubmed",
         "db": "gds",
         "linkname": "pubmed_gds",
         "retmode": "json",
-        "id": pmids,
+        "id": ",".join(pmids),
     }
     elink_params.update(_base_params())
     elink_data = _get_with_retry(ELINK_URL, elink_params)
     _throttle()
 
-    pmid_to_uids: Dict[str, List[str]] = {p: [] for p in pmids}
-    all_uids: List[str] = []
+    candidate_uids: set = set()
     for linkset in elink_data.get("linksets", []) or []:
-        source_ids = linkset.get("ids") or []
-        if not source_ids:
-            continue
-        source_pmid = str(source_ids[0])
         for ldb in linkset.get("linksetdbs", []) or []:
             if ldb.get("linkname") != "pubmed_gds":
                 continue
             for uid in ldb.get("links", []) or []:
-                uid_str = str(uid)
-                pmid_to_uids.setdefault(source_pmid, []).append(uid_str)
-                all_uids.append(uid_str)
+                candidate_uids.add(str(uid))
 
-    if not all_uids:
-        return {p: [] for p in pmids}
+    output: Dict[str, List[str]] = {p: [] for p in pmids}
+    if not candidate_uids:
+        return output
 
-    unique_uids = sorted(set(all_uids))
-    esummary_params: ParamsType = {"db": "gds", "id": ",".join(unique_uids), "retmode": "json"}
+    unique_uids = sorted(candidate_uids)
+    esummary_params = {"db": "gds", "id": ",".join(unique_uids), "retmode": "json"}
     esummary_params.update(_base_params())
     esummary_data = _get_with_retry(ESUMMARY_URL, esummary_params)
     _throttle()
 
-    uid_to_accession: Dict[str, str] = {}
+    # Attribute each GSE accession back to the specific PMID(s) in our batch using
+    # the record's own `pubmedids` reverse-link (GPL/GSM/GDS accessions are dropped).
+    pmid_set = set(pmids)
+    per_pmid: Dict[str, set] = {p: set() for p in pmids}
     result_block = esummary_data.get("result", {}) or {}
     for uid in unique_uids:
         record = result_block.get(uid) or {}
         accession = record.get("accession")
-        if isinstance(accession, str) and accession.startswith("GSE"):
-            uid_to_accession[uid] = accession
+        if not (isinstance(accession, str) and accession.startswith("GSE")):
+            continue
+        for pm in record.get("pubmedids", []) or []:
+            pm_str = str(pm)
+            if pm_str in pmid_set:
+                per_pmid[pm_str].add(accession)
 
-    output: Dict[str, List[str]] = {}
-    for pmid, uids in pmid_to_uids.items():
-        accessions = {uid_to_accession[u] for u in uids if u in uid_to_accession}
-        output[pmid] = sorted(accessions)
-    return output
+    return {pmid: sorted(per_pmid[pmid]) for pmid in pmids}
 
 
 def get_geo_accessions_for_pmids_with_split(pmids: List[str]) -> Dict[str, List[str]]:

--- a/tests/lit_processing/data_ingest/pubmed_ingest/test_get_geo_links.py
+++ b/tests/lit_processing/data_ingest/pubmed_ingest/test_get_geo_links.py
@@ -35,9 +35,12 @@ ELINK_TWO_LINKS = {
 ESUMMARY_MIXED = {
     "result": {
         "uids": ["200073427", "200050899", "100012345"],
-        "200073427": {"uid": "200073427", "accession": "GSE73427", "entrytype": "GSE"},
-        "200050899": {"uid": "200050899", "accession": "GSE50899", "entrytype": "GSE"},
-        "100012345": {"uid": "100012345", "accession": "GPL12345", "entrytype": "GPL"},
+        "200073427": {"uid": "200073427", "accession": "GSE73427", "entrytype": "GSE",
+                      "pubmedids": ["32606685"]},
+        "200050899": {"uid": "200050899", "accession": "GSE50899", "entrytype": "GSE",
+                      "pubmedids": ["32606685"]},
+        "100012345": {"uid": "100012345", "accession": "GPL12345", "entrytype": "GPL",
+                      "pubmedids": ["32606685"]},
     }
 }
 
@@ -49,8 +52,10 @@ class TestGetGeoAccessionsForPmid:
         esummary = _mock_response({
             "result": {
                 "uids": ["200073427", "200050899"],
-                "200073427": {"uid": "200073427", "accession": "GSE73427", "entrytype": "GSE"},
-                "200050899": {"uid": "200050899", "accession": "GSE50899", "entrytype": "GSE"},
+                "200073427": {"uid": "200073427", "accession": "GSE73427", "entrytype": "GSE",
+                              "pubmedids": ["32606685"]},
+                "200050899": {"uid": "200050899", "accession": "GSE50899", "entrytype": "GSE",
+                              "pubmedids": ["32606685"]},
             }
         })
         with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
@@ -99,8 +104,8 @@ class TestGetGeoAccessionsForPmid:
         esummary_dup = {
             "result": {
                 "uids": ["1", "2"],
-                "1": {"uid": "1", "accession": "GSE111", "entrytype": "GSE"},
-                "2": {"uid": "2", "accession": "GSE111", "entrytype": "GSE"},
+                "1": {"uid": "1", "accession": "GSE111", "entrytype": "GSE", "pubmedids": ["1"]},
+                "2": {"uid": "2", "accession": "GSE111", "entrytype": "GSE", "pubmedids": ["1"]},
             }
         }
         with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
@@ -112,8 +117,10 @@ class TestGetGeoAccessionsForPmid:
         elink = _mock_response(ELINK_TWO_LINKS)
         esummary = _mock_response({
             "result": {"uids": ["200073427", "200050899"],
-                       "200073427": {"uid": "200073427", "accession": "GSE73427", "entrytype": "GSE"},
-                       "200050899": {"uid": "200050899", "accession": "GSE50899", "entrytype": "GSE"}}
+                       "200073427": {"uid": "200073427", "accession": "GSE73427", "entrytype": "GSE",
+                                     "pubmedids": ["32606685"]},
+                       "200050899": {"uid": "200050899", "accession": "GSE50899", "entrytype": "GSE",
+                                     "pubmedids": ["32606685"]}}
         })
         with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
                    "get_geo_links.time.sleep"), \
@@ -136,70 +143,65 @@ class TestGetGeoAccessionsForPmid:
 class TestGetGeoAccessionsForPmids:
 
     def test_groups_links_per_source_pmid(self):
-        elink_multi = {
+        # elink merges the batch into one linkset (no per-PMID attribution); we
+        # only use it to gather candidate GDS UIDs. Attribution comes from each
+        # esummary record's own `pubmedids`.
+        elink_merged = {
             "linksets": [
-                {"dbfrom": "pubmed", "ids": ["111"],
-                 "linksetdbs": [{"dbto": "gds", "linkname": "pubmed_gds", "links": ["1", "2"]}]},
-                {"dbfrom": "pubmed", "ids": ["222"],
-                 "linksetdbs": [{"dbto": "gds", "linkname": "pubmed_gds", "links": ["3"]}]},
-                {"dbfrom": "pubmed", "ids": ["333"],
-                 "linksetdbs": []},
+                {"dbfrom": "pubmed", "ids": ["111", "222", "333"],
+                 "linksetdbs": [{"dbto": "gds", "linkname": "pubmed_gds",
+                                 "links": ["1", "2", "3"]}]},
             ]
         }
         esummary_multi = {
             "result": {
                 "uids": ["1", "2", "3"],
-                "1": {"uid": "1", "accession": "GSE1", "entrytype": "GSE"},
-                "2": {"uid": "2", "accession": "GSE2", "entrytype": "GSE"},
-                "3": {"uid": "3", "accession": "GSE3", "entrytype": "GSE"},
+                "1": {"uid": "1", "accession": "GSE1", "entrytype": "GSE", "pubmedids": ["111"]},
+                "2": {"uid": "2", "accession": "GSE2", "entrytype": "GSE", "pubmedids": ["111"]},
+                "3": {"uid": "3", "accession": "GSE3", "entrytype": "GSE", "pubmedids": ["222"]},
             }
         }
         with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
                    "get_geo_links.requests.get",
-                   side_effect=[_mock_response(elink_multi), _mock_response(esummary_multi)]):
+                   side_effect=[_mock_response(elink_merged), _mock_response(esummary_multi)]):
             result = get_geo_accessions_for_pmids(["111", "222", "333"])
         assert result == {"111": ["GSE1", "GSE2"], "222": ["GSE3"], "333": []}
 
-    def test_elink_sends_id_as_list_for_per_pmid_attribution(self):
-        """elink MERGES comma-joined ids into a single linkset, losing per-PMID
-        attribution. Passing the PMID list (repeated `&id=` params) makes NCBI
-        return one linkset per PMID. Pin that `id` is sent as a list."""
+    def test_elink_sends_comma_joined_ids(self):
+        """elink is queried for the whole batch with comma-joined ids (the cheap,
+        reliable form). Repeated `&id=` params force per-PMID linksets but make
+        NCBI drop the response at scale, so we keep comma-joined and attribute via
+        esummary `pubmedids` instead."""
         elink_empty = {
-            "linksets": [
-                {"dbfrom": "pubmed", "ids": ["111"], "linksetdbs": []},
-                {"dbfrom": "pubmed", "ids": ["222"], "linksetdbs": []},
-                {"dbfrom": "pubmed", "ids": ["333"], "linksetdbs": []},
-            ]
+            "linksets": [{"dbfrom": "pubmed", "ids": ["111", "222", "333"], "linksetdbs": []}]
         }
         with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
                    "get_geo_links.requests.get",
                    side_effect=[_mock_response(elink_empty)]) as mock_get:
             get_geo_accessions_for_pmids(["111", "222", "333"])
             params = mock_get.call_args.kwargs["params"]
-            assert params["id"] == ["111", "222", "333"]
+            assert params["id"] == "111,222,333"
 
-    def test_does_not_misattribute_links_across_separate_linksets(self):
-        """Regression: with per-PMID linksets, a PMID with no GEO link must not
-        inherit another PMID's links. Previously a single merged linkset pooled
-        all links onto the first PMID, starving every other PMID in the batch."""
-        elink_per_pmid = {
-            "linksets": [
-                {"dbfrom": "pubmed", "ids": ["31000000"], "linksetdbs": []},
-                {"dbfrom": "pubmed", "ids": ["33526011"],
-                 "linksetdbs": [{"dbto": "gds", "linkname": "pubmed_gds",
-                                 "links": ["200147729"]}]},
-            ]
+    def test_attributes_via_pubmedids_not_merged_elink_linkset(self):
+        """Regression for the merged-linkset bug: elink pools all batch links into
+        one linkset with no per-PMID attribution. A GSE must be attributed only to
+        the PMID(s) named in its esummary `pubmedids`, and only to PMIDs actually
+        in the batch (33526011's record also cites an out-of-batch PMID)."""
+        elink_merged = {
+            "linksets": [{"dbfrom": "pubmed", "ids": ["31000000", "33526011"],
+                          "linksetdbs": [{"dbto": "gds", "linkname": "pubmed_gds",
+                                          "links": ["200147729"]}]}]
         }
         esummary = {
             "result": {
                 "uids": ["200147729"],
                 "200147729": {"uid": "200147729", "accession": "GSE147729",
-                              "entrytype": "GSE"},
+                              "entrytype": "GSE", "pubmedids": ["33526011", "36514338"]},
             }
         }
         with patch("agr_literature_service.lit_processing.data_ingest.pubmed_ingest."
                    "get_geo_links.requests.get",
-                   side_effect=[_mock_response(elink_per_pmid), _mock_response(esummary)]):
+                   side_effect=[_mock_response(elink_merged), _mock_response(esummary)]):
             result = get_geo_accessions_for_pmids(["31000000", "33526011"])
         assert result == {"31000000": [], "33526011": ["GSE147729"]}
 


### PR DESCRIPTION
## Problem

After #1188 (which fixed GEO link mis-attribution by sending PMIDs as repeated `&id=` params), the weekly `backfill_geo_links` cron started failing:

```
elink batch of 100 PMIDs failed after retries; ... InvalidChunkLength(got length b'', 0 bytes read)
```

## Root cause

Repeated `&id=` params force NCBI elink to compute **one linkset per PMID**, which is far heavier than a single merged lookup. NCBI drops the chunked HTTP response for batches of ~100. Reproduced cleanly: 10 PMIDs succeed, 100 fail 3/3, while the old comma-joined form succeeds. POST does not help — it's the per-id computation, not transport.

## Fix

Revert elink to the cheap, reliable **comma-joined** call (the form that ran for ages without chunk errors) and use it only to collect the batch's candidate GDS UIDs — its merged attribution is ignored. Recover correct per-PMID attribution from each GDS record's own **`pubmedids`** field in the esummary response we already fetch, filtered to PMIDs in the batch.

- Same number of NCBI calls as the original.
- Reliable at any batch size.
- Correct per-PMID attribution (the bug #1188 set out to fix stays fixed).

## Tests

- Pin that elink is queried with comma-joined `id`.
- Regression test: a GSE is attributed only to the batch PMID(s) named in its `pubmedids` (ignoring out-of-batch citations), reproducing the merged-linkset scenario.
- Updated esummary mocks to carry `pubmedids`.

## Verification

- 17 unit tests pass; flake8 clean; mypy clean on the changed file.
- Live: a 100-PMID batch that previously failed now completes in one elink + esummary call with correct links (`33526011→GSE147729`, `33526076→GSE164204`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)