### PR TITLE
protect curator-added reference_email rows from automation

### DIFF
--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -70,6 +70,7 @@ from agr_literature_service.lit_processing.data_ingest.utils.db_write_utils impo
 from agr_literature_service.lit_processing.utils.report_utils import send_report
 from agr_literature_service.api.crud.user_utils import map_to_user_id
 from agr_literature_service.api.crud.person_crud import normalize_email
+from agr_literature_service.api.user import get_global_user_id
 
 logger = logging.getLogger(__name__)
 
@@ -509,6 +510,12 @@ def get_reference_emails(db: Session, curie_or_reference_id: str):
     ]
 
 
+# Prefix of a real-human (person-backed) user id. Curator-added
+# reference_email rows carry an updated_by that starts with this; only a real
+# human acting under such an id may remove or overwrite them.
+CURATOR_USER_ID_PREFIX = "AGRKB:103"
+
+
 def set_reference_emails(
     db: Session, curie_or_reference_id: str, email_addresses: List[str]
 ):
@@ -518,9 +525,20 @@ def set_reference_emails(
     reference_email rows are independent string snapshots — they do not need
     a backing person_email row and never reference one. Uniqueness is enforced
     case-insensitively at the DB level by uq_reference_email_reference_email_lower.
+
+    Curator-added rows (``updated_by`` starting with 'AGRKB:103', i.e. a real
+    human with a person-table id) may only be removed or overwritten by another
+    real human. When the acting user is not such a human — e.g. the automated
+    email-extraction pipeline, which runs as 'default_user' / a program-name
+    automation user — those rows are preserved: they are never deleted, and an
+    incoming address that duplicates one of them is skipped so the curator's
+    snapshot stays intact.
     """
     reference = get_reference(db, curie_or_reference_id)
     ref_id = reference.reference_id
+
+    acting_user_id = get_global_user_id() or ""
+    acting_user_is_curator = acting_user_id.startswith(CURATOR_USER_ID_PREFIX)
 
     cleaned: List[str] = []
     seen: set = set()  # holds lower-cased addresses for case-insensitive dedup
@@ -546,11 +564,39 @@ def set_reference_emails(
         seen.add(key)
         cleaned.append(norm)
 
-    db.query(ReferenceEmailModel).filter(
-        ReferenceEmailModel.reference_id == ref_id
-    ).delete(synchronize_session=False)
+    protected_keys: set = set()
+    if acting_user_is_curator:
+        # A real human owns the emails and may drop any of them: full replace.
+        db.query(ReferenceEmailModel).filter(
+            ReferenceEmailModel.reference_id == ref_id
+        ).delete(synchronize_session=False)
+    else:
+        # Non-human (pipeline / automation): never touch curator-added rows.
+        curator_like = f"{CURATOR_USER_ID_PREFIX}%"
+        protected_rows = (
+            db.query(ReferenceEmailModel)
+            .filter(
+                ReferenceEmailModel.reference_id == ref_id,
+                ReferenceEmailModel.updated_by.like(curator_like),
+            )
+            .all()
+        )
+        protected_keys = {row.email_address.lower() for row in protected_rows}
+
+        # Delete only the non-curator rows for this reference.
+        db.query(ReferenceEmailModel).filter(
+            ReferenceEmailModel.reference_id == ref_id,
+            or_(
+                ReferenceEmailModel.updated_by.is_(None),
+                ~ReferenceEmailModel.updated_by.like(curator_like),
+            ),
+        ).delete(synchronize_session=False)
 
     for normalized_email in cleaned:
+        # Skip addresses already held by a protected curator row to avoid
+        # both a duplicate and a unique-constraint violation.
+        if normalized_email.lower() in protected_keys:
+            continue
         db.add(
             ReferenceEmailModel(
                 reference_id=ref_id, email_address=normalized_email

--- a/tests/api/test_reference.py
+++ b/tests/api/test_reference.py
@@ -1154,8 +1154,14 @@ class TestReferenceEmails:
         'AGRKB:103%') and must not re-insert an incoming address that
         duplicates a protected one."""
         from agr_literature_service.api.models import ReferenceEmailModel
+        from agr_literature_service.api.user import add_user_if_not_exists
         curie = test_reference.new_ref_curie
         ref_id = db.query(ReferenceModel).filter(ReferenceModel.curie == curie).one().reference_id
+
+        # The created_by/updated_by values are FK-constrained to users.id;
+        # make sure both the curator and pipeline users exist before seeding.
+        add_user_if_not_exists(db, "AGRKB:103000000000001")
+        add_user_if_not_exists(db, "default_user")
 
         # Seed a curator-added row and a pipeline-added row.
         db.add(ReferenceEmailModel(
@@ -1197,10 +1203,15 @@ class TestReferenceEmails:
         emails and may drop curator-added rows via a full replace."""
         from agr_literature_service.api.crud.reference_crud import set_reference_emails
         from agr_literature_service.api.models import ReferenceEmailModel
-        from agr_literature_service.api.user import set_global_user_id, _current_user_id
+        from agr_literature_service.api.user import (
+            set_global_user_id, _current_user_id, add_user_if_not_exists
+        )
 
         curie = test_reference.new_ref_curie
         ref_id = db.query(ReferenceModel).filter(ReferenceModel.curie == curie).one().reference_id
+
+        # created_by/updated_by are FK-constrained to users.id.
+        add_user_if_not_exists(db, "AGRKB:103000000000001")
 
         db.add(ReferenceEmailModel(
             reference_id=ref_id,

--- a/tests/api/test_reference.py
+++ b/tests/api/test_reference.py
@@ -1146,3 +1146,83 @@ class TestReferenceEmails:
                 headers=auth_headers,
             )
             assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_non_human_replace_preserves_curator_added_rows(self, db, auth_headers, test_reference):  # noqa
+        """When the acting user is not a real human (the email-extraction
+        pipeline / a service account, here the access-token 'default_user'),
+        a replace must never delete curator-added rows (updated_by like
+        'AGRKB:103%') and must not re-insert an incoming address that
+        duplicates a protected one."""
+        from agr_literature_service.api.models import ReferenceEmailModel
+        curie = test_reference.new_ref_curie
+        ref_id = db.query(ReferenceModel).filter(ReferenceModel.curie == curie).one().reference_id
+
+        # Seed a curator-added row and a pipeline-added row.
+        db.add(ReferenceEmailModel(
+            reference_id=ref_id,
+            email_address="curator@example.com",
+            created_by="AGRKB:103000000000001",
+            updated_by="AGRKB:103000000000001",
+        ))
+        db.add(ReferenceEmailModel(
+            reference_id=ref_id,
+            email_address="pipeline@example.com",
+            created_by="default_user",
+            updated_by="default_user",
+        ))
+        db.commit()
+
+        with TestClient(app) as client:
+            # Pipeline re-runs with a fresh set; one address collides (case
+            # variant) with the protected curator row.
+            res = client.put(
+                f"/reference/{curie}/emails",
+                json=["Curator@Example.com", "newauthor@example.com"],
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_200_OK
+
+            listing = client.get(
+                f"/reference/{curie}/emails", headers=auth_headers
+            ).json()
+            addrs = sorted(row["email_address"].lower() for row in listing)
+            # curator row survives (single copy, original casing), the old
+            # pipeline row is replaced, and the new pipeline address is added.
+            assert addrs == ["curator@example.com", "newauthor@example.com"]
+            curator_row = [r for r in listing if r["email_address"] == "curator@example.com"]
+            assert len(curator_row) == 1
+
+    def test_human_curator_can_replace_curator_added_rows(self, db, test_reference):  # noqa
+        """A real human (acting user id starting with 'AGRKB:103') owns the
+        emails and may drop curator-added rows via a full replace."""
+        from agr_literature_service.api.crud.reference_crud import set_reference_emails
+        from agr_literature_service.api.models import ReferenceEmailModel
+        from agr_literature_service.api.user import set_global_user_id, _current_user_id
+
+        curie = test_reference.new_ref_curie
+        ref_id = db.query(ReferenceModel).filter(ReferenceModel.curie == curie).one().reference_id
+
+        db.add(ReferenceEmailModel(
+            reference_id=ref_id,
+            email_address="curator@example.com",
+            created_by="AGRKB:103000000000001",
+            updated_by="AGRKB:103000000000001",
+        ))
+        db.commit()
+
+        token = _current_user_id.set(None)  # capture/reset around the test
+        try:
+            # Act as a real human curator.
+            set_global_user_id(db, "AGRKB:103000000000099")
+            set_reference_emails(db, curie, ["newonly@example.com"])
+        finally:
+            _current_user_id.reset(token)
+
+        listing = (
+            db.query(ReferenceEmailModel)
+            .filter(ReferenceEmailModel.reference_id == ref_id)
+            .all()
+        )
+        addrs = sorted(row.email_address.lower() for row in listing)
+        # Full replace: the curator row is dropped, only the new address remains.
+        assert addrs == ["newonly@example.com"]


### PR DESCRIPTION
set_reference_emails now keys its replace behavior off the acting user (get_global_user_id). A real human curator (id starts with 'AGRKB:103', person-backed) keeps full control — add/update/delete via a clean full replace. A non-human actor (the email-extraction pipeline / service accounts running as default_user) can no longer remove or overwrite curator-added rows: rows whose updated_by starts with 'AGRKB:103' are preserved, and an incoming address duplicating one is skipped.