### PR TITLE
chore(SCRUM-6189): stop automated_scripts (cron) before alembic migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ alembic-create-migration:
 alembic-apply-latest-migration:
 	docker-compose --env-file ${ENV_FILE} rm -svf dbz_connector dbz_kafka dbz_zookeeper dbz_ksql_server dbz_setup
 	docker-compose --env-file ${ENV_FILE} rm -s -f api
+	docker-compose --env-file ${ENV_FILE} rm -s -f automated_scripts
 	docker-compose --env-file ${ENV_FILE} build dev_app
 	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app alembic upgrade head
 	$(MAKE) ENV_FILE=${ENV_FILE} restart-api-and-automated-scripts


### PR DESCRIPTION
## Summary

[SCRUM-6189](https://agr-jira.atlassian.net/browse/SCRUM-6189)

When applying an Alembic migration the database should be quiesced. The `alembic-apply-latest-migration` target already stops Debezium (CDC) and the `api` before running `alembic upgrade head`, but it left the `automated_scripts` container running. That container runs `cron` (`CMD ... cron && tail -f /dev/null`) and executes the automated ingest/processing pipelines, which can write to the database mid-migration.

This adds a step to stop `automated_scripts` (the cron pipelines) alongside `api` and `debezium` before the migration. It is restarted afterward via the existing `restart-api-and-automated-scripts` step (and Debezium via `restart-debezium-aws`), so the full flow is now: stop api + automated_scripts (cron) + debezium → apply migration → restart all three.

## Change

```diff
 alembic-apply-latest-migration:
 	docker-compose --env-file ${ENV_FILE} rm -svf dbz_connector dbz_kafka dbz_zookeeper dbz_ksql_server dbz_setup
 	docker-compose --env-file ${ENV_FILE} rm -s -f api
+	docker-compose --env-file ${ENV_FILE} rm -s -f automated_scripts
 	docker-compose --env-file ${ENV_FILE} build dev_app
 	docker-compose --env-file ${ENV_FILE} run --service-ports --rm dev_app alembic upgrade head
 	$(MAKE) ENV_FILE=${ENV_FILE} restart-api-and-automated-scripts
 	$(MAKE) ENV_FILE=${ENV_FILE} restart-debezium-aws
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6189]: https://agr-jira.atlassian.net/browse/SCRUM-6189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ