### PR TITLE
auto-create users from created_by/updated_by on all writes

### DIFF
--- a/agr_literature_service/api/models/audited_model.py
+++ b/agr_literature_service/api/models/audited_model.py
@@ -4,7 +4,7 @@ import pytz
 from sqlalchemy import Column, ForeignKey, DateTime, event
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.inspection import inspect as sa_inspect
-from agr_literature_service.api.user import get_global_user_id
+from agr_literature_service.api.user import get_global_user_id, ensure_user_exists_on_connection
 
 # Internal flag to track if we should skip auto-updating updated_by and date_updated
 # Used during validation operations to prevent changing these fields
@@ -126,6 +126,13 @@ def _set_created_and_updated(mapper, connection, target):
         target.created_by, target.updated_by, get_default_user_value()
     )
 
+    # Auto-create the users referenced by created_by/updated_by so an explicitly
+    # supplied "created by"/"updated by" name (e.g. from an admin-token tag load)
+    # does not violate the users.id foreign key. Idempotent via ON CONFLICT.
+    ensure_user_exists_on_connection(connection, target.created_by)
+    if target.updated_by != target.created_by:
+        ensure_user_exists_on_connection(connection, target.updated_by)
+
 
 @event.listens_for(AuditedModel, "before_update", propagate=True)
 def _set_updated(mapper, connection, target):
@@ -148,3 +155,9 @@ def _set_updated(mapper, connection, target):
     if not state.attrs.updated_by.history.has_changes():
         uid = get_global_user_id() or get_default_user_value()
         target.updated_by = uid
+
+    # Auto-create the users referenced by the (possibly caller-supplied)
+    # updated_by/created_by values before the UPDATE hits the FK constraint.
+    ensure_user_exists_on_connection(connection, target.updated_by)
+    if state.attrs.created_by.history.has_changes():
+        ensure_user_exists_on_connection(connection, target.created_by)

--- a/agr_literature_service/api/models/audited_model.py
+++ b/agr_literature_service/api/models/audited_model.py
@@ -128,10 +128,14 @@ def _set_created_and_updated(mapper, connection, target):
 
     # Auto-create the users referenced by created_by/updated_by so an explicitly
     # supplied "created by"/"updated by" name (e.g. from an admin-token tag load)
-    # does not violate the users.id foreign key. Idempotent via ON CONFLICT.
-    ensure_user_exists_on_connection(connection, target.created_by)
-    if target.updated_by != target.created_by:
-        ensure_user_exists_on_connection(connection, target.updated_by)
+    # does not violate the users.id foreign key. Skip the resolved global/default
+    # user, which is already guaranteed to exist (it is created at request setup
+    # in set_global_user_*); this keeps the redundant ON CONFLICT insert — and the
+    # users.user_id identity-sequence burn — off the hot path for normal traffic.
+    already_ensured = get_global_user_id()
+    for uid in {target.created_by, target.updated_by}:
+        if uid and uid != already_ensured:
+            ensure_user_exists_on_connection(connection, uid)
 
 
 @event.listens_for(AuditedModel, "before_update", propagate=True)
@@ -158,6 +162,12 @@ def _set_updated(mapper, connection, target):
 
     # Auto-create the users referenced by the (possibly caller-supplied)
     # updated_by/created_by values before the UPDATE hits the FK constraint.
-    ensure_user_exists_on_connection(connection, target.updated_by)
+    # Skip the already-ensured global/default user so an ordinary update (where
+    # updated_by is just the current user) issues no redundant insert.
+    already_ensured = get_global_user_id()
+    to_ensure = {target.updated_by}
     if state.attrs.created_by.history.has_changes():
-        ensure_user_exists_on_connection(connection, target.created_by)
+        to_ensure.add(target.created_by)
+    for uid in to_ensure:
+        if uid and uid != already_ensured:
+            ensure_user_exists_on_connection(connection, uid)

--- a/agr_literature_service/api/user.py
+++ b/agr_literature_service/api/user.py
@@ -2,10 +2,21 @@ from contextvars import ContextVar
 from typing import Optional, Dict, Any
 from fastapi import HTTPException
 from sqlalchemy import text
+from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session
 
 from agr_literature_service.api.crud import user_crud
 from agr_literature_service.api.models.user_model import UserModel
+
+# Idempotent insert of an automation user row. ``automation_username`` is set to
+# the same value as ``id`` (with ``person_id`` NULL) to satisfy the table CHECK:
+# (person_id IS NULL) <> (automation_username IS NULL). ON CONFLICT makes it a
+# no-op when the user already exists, so it is safe to call on a hot path.
+_SQL_INSERT_AUTOMATION_USER = text("""
+    INSERT INTO users (id, automation_username, person_id)
+    VALUES (:uid, :uid, NULL)
+    ON CONFLICT (id) DO NOTHING
+""")
 
 # String primary key (users.id) of the "current user" for this request.
 # A ContextVar isolates the value per asyncio task and per FastAPI threadpool
@@ -54,6 +65,27 @@ def add_user_if_not_exists(db: Session, user_id: str) -> None:
     Back-compat helper. New IDs are treated as automation users.
     """
     _ensure_automation_user(db, user_id)
+
+
+def ensure_user_exists_on_connection(connection: Connection, user_id: Optional[str]) -> None:
+    """
+    Idempotently create an automation ``users`` row for ``user_id`` using a raw
+    Connection rather than a Session.
+
+    This is the Connection-based counterpart to ``add_user_if_not_exists`` and is
+    meant to be called from SQLAlchemy ``before_insert`` / ``before_update`` event
+    listeners (see ``AuditedModel``), where only the in-flight Connection — not a
+    Session — is available. Because it emits ``INSERT ... ON CONFLICT DO NOTHING``
+    on the same Connection (and therefore the same transaction) that is flushing
+    the audited row, the ``created_by`` / ``updated_by`` foreign keys are satisfied
+    without an extra commit.
+
+    This lets an admin-token "created by"/"updated by" name supplied to *any*
+    write endpoint auto-create its ``users`` record instead of failing the FK.
+    """
+    if not user_id:
+        return
+    connection.execute(_SQL_INSERT_AUTOMATION_USER, {"uid": user_id})
 
 
 def set_global_user_from_cognito(db: Session, cognito_user: Optional[Dict[str, Any]]) -> None:

--- a/tests/api/test_audited_model.py
+++ b/tests/api/test_audited_model.py
@@ -195,6 +195,36 @@ def test_insert_autocreates_distinct_created_and_updated_users(db): # noqa
     assert db.query(UserModel).filter_by(id=updater).one_or_none() is not None
 
 
+def test_insert_skips_autocreate_for_global_user(db, monkeypatch): # noqa
+    """
+    Hot-path optimization: when created_by/updated_by resolve to the already-
+    ensured global user, no redundant ON CONFLICT insert is issued (so the
+    users.user_id identity sequence is not burned on every ordinary write).
+    """
+    import agr_literature_service.api.models.audited_model as am
+    _ensure_user(db, "SPY_GLOBAL")
+    set_global_user_id(db, "SPY_GLOBAL")
+
+    calls = []
+    orig = am.ensure_user_exists_on_connection
+
+    def spy(connection, uid): # noqa
+        calls.append(uid)
+        return orig(connection, uid)
+
+    monkeypatch.setattr(am, "ensure_user_exists_on_connection", spy)
+
+    # No explicit created_by/updated_by -> both resolve to the global user.
+    obj = AuditedDummy(name="india")
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+
+    assert obj.created_by == "SPY_GLOBAL"
+    assert obj.updated_by == "SPY_GLOBAL"
+    assert calls == []  # nothing auto-created; global user already ensured
+
+
 def test_update_autocreates_missing_updated_by_user(db): # noqa
     """A caller-supplied updated_by on UPDATE is auto-created before the FK check."""
     obj = AuditedDummy(name="hotel")

--- a/tests/api/test_audited_model.py
+++ b/tests/api/test_audited_model.py
@@ -149,3 +149,67 @@ def test_update_uses_default_user_when_global_unset(db): # noqa
 
     assert obj.updated_by == "default_user"
     assert _is_recent(obj.date_updated)
+
+
+def test_insert_autocreates_missing_created_by_user(db): # noqa
+    """
+    An explicit created_by/updated_by that does not yet exist in `users` is
+    auto-created by the before_insert listener (no FK violation, no manual
+    pre-creation). This is what lets an admin-token tag load attribute records
+    to a named curator on any write endpoint.
+    """
+    new_uid = "LOADER_NEW_CREATOR"
+    # Make sure it does not already exist.
+    assert db.query(UserModel).filter_by(id=new_uid).one_or_none() is None
+
+    obj = AuditedDummy(name="foxtrot", created_by=new_uid)
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+
+    assert obj.created_by == new_uid
+    # updated_by mirrors created_by when not supplied (impute_audit_user_ids).
+    assert obj.updated_by == new_uid
+    # The users row was created as an automation user.
+    user = db.query(UserModel).filter_by(id=new_uid).one_or_none()
+    assert user is not None
+    assert user.automation_username == new_uid
+    assert user.person_id is None
+
+
+def test_insert_autocreates_distinct_created_and_updated_users(db): # noqa
+    """Both created_by and updated_by are auto-created when they differ."""
+    creator = "LOADER_CREATOR_X"
+    updater = "LOADER_UPDATER_Y"
+    for uid in (creator, updater):
+        assert db.query(UserModel).filter_by(id=uid).one_or_none() is None
+
+    obj = AuditedDummy(name="golf", created_by=creator, updated_by=updater)
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+
+    assert obj.created_by == creator
+    assert obj.updated_by == updater
+    assert db.query(UserModel).filter_by(id=creator).one_or_none() is not None
+    assert db.query(UserModel).filter_by(id=updater).one_or_none() is not None
+
+
+def test_update_autocreates_missing_updated_by_user(db): # noqa
+    """A caller-supplied updated_by on UPDATE is auto-created before the FK check."""
+    obj = AuditedDummy(name="hotel")
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+
+    new_updater = "LOADER_UPDATER_ON_PATCH"
+    assert db.query(UserModel).filter_by(id=new_updater).one_or_none() is None
+
+    obj.name = "hotel-2"
+    obj.updated_by = new_updater
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+
+    assert obj.updated_by == new_updater
+    assert db.query(UserModel).filter_by(id=new_updater).one_or_none() is not None

--- a/tests/api/test_audited_model.py
+++ b/tests/api/test_audited_model.py
@@ -7,7 +7,7 @@ from agr_literature_service.api.database.base import Base
 from agr_literature_service.api.models.audited_model import AuditedModel
 from agr_literature_service.api.models.user_model import UserModel
 from agr_literature_service.api.crud import user_crud
-from agr_literature_service.api.user import set_global_user_id
+from agr_literature_service.api.user import set_global_user_id, ensure_user_exists_on_connection
 
 from ..fixtures import db  # noqa: F401
 
@@ -149,6 +149,36 @@ def test_update_uses_default_user_when_global_unset(db): # noqa
 
     assert obj.updated_by == "default_user"
     assert _is_recent(obj.date_updated)
+
+
+def test_ensure_user_exists_on_connection_creates_automation_user(db): # noqa
+    """The Connection-based helper materializes an automation users row."""
+    uid = "CONN_HELPER_NEW"
+    ensure_user_exists_on_connection(db.connection(), uid)
+
+    # Visible within the same transaction.
+    user = db.query(UserModel).filter_by(id=uid).one_or_none()
+    assert user is not None
+    assert user.automation_username == uid
+    assert user.person_id is None
+
+
+def test_ensure_user_exists_on_connection_is_idempotent(db): # noqa
+    """Calling twice for the same id is a no-op (ON CONFLICT) — no IntegrityError."""
+    uid = "CONN_HELPER_IDEMPOTENT"
+    conn = db.connection()
+    ensure_user_exists_on_connection(conn, uid)
+    ensure_user_exists_on_connection(conn, uid)
+
+    assert db.query(UserModel).filter_by(id=uid).count() == 1
+
+
+@pytest.mark.parametrize("empty_value", [None, ""])
+def test_ensure_user_exists_on_connection_noop_for_empty(db, empty_value): # noqa
+    """None / empty id is guarded and inserts nothing."""
+    before = db.query(UserModel).count()
+    ensure_user_exists_on_connection(db.connection(), empty_value)
+    assert db.query(UserModel).count() == before
 
 
 def test_insert_autocreates_missing_created_by_user(db): # noqa


### PR DESCRIPTION
Auto-create the users referenced by created_by/updated_by at the AuditedModel before_insert/before_update listener level, so an explicit "created by"/"updated by" name supplied to any POST/PATCH/write endpoint (e.g. an admin-token tag load) no longer violates the users.id foreign key. Previously this auto-create was wired only into the topic-entity-tag CRUD.

Add ensure_user_exists_on_connection() in api/user.py: a Connection-based counterpart to add_user_if_not_exists that emits INSERT ... ON CONFLICT DO NOTHING on the in-flight flush connection, satisfying the FK within the same transaction without an extra commit.