### PR TITLE
feat(ml_model): make ml_model table audited (SCRUM-6090)

### DIFF
--- a/agr_literature_service/api/crud/ml_model_crud.py
+++ b/agr_literature_service/api/crud/ml_model_crud.py
@@ -174,7 +174,11 @@ def get_model_schema_from_orm(model: MLModel):
         "data_novelty": model.data_novelty,
         "negated": model.negated,
         "file_classes": model.file_classes,
-        "description": model.description
+        "description": model.description,
+        "date_created": model.date_created,
+        "date_updated": model.date_updated,
+        "created_by": model.created_by,
+        "updated_by": model.updated_by
     }
     return MLModelSchemaShow(**model_data)
 

--- a/agr_literature_service/api/models/ml_model_model.py
+++ b/agr_literature_service/api/models/ml_model_model.py
@@ -1,9 +1,10 @@
 from sqlalchemy import Column, Integer, String, Float, ForeignKey, UniqueConstraint, Boolean, ARRAY
 from sqlalchemy.orm import relationship, mapped_column, Mapped
 from agr_literature_service.api.database.base import Base
+from agr_literature_service.api.models.audited_model import AuditedModel
 
 
-class MLModel(Base):
+class MLModel(AuditedModel, Base):
     __tablename__ = 'ml_model'
 
     ml_model_id = Column(

--- a/agr_literature_service/api/schemas/ml_model_schemas.py
+++ b/agr_literature_service/api/schemas/ml_model_schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict
@@ -37,6 +38,10 @@ class MLModelSchemaPost(MLModelSchemaBase):
 class MLModelSchemaShow(MLModelSchemaBase):
     """Schema used when returning ML model with its primary key."""
     ml_model_id: int
+    date_created: Optional[datetime] = None
+    date_updated: Optional[datetime] = None
+    created_by: Optional[str] = None
+    updated_by: Optional[str] = None
 
 
 class MLModelSchemaShowWithNames(MLModelSchemaShow):

--- a/alembic/versions/20260617_f1a2b3c4d5e6_make_ml_model_audited.py
+++ b/alembic/versions/20260617_f1a2b3c4d5e6_make_ml_model_audited.py
@@ -1,0 +1,69 @@
+"""make ml_model audited
+
+Adds the four audit columns (date_created, date_updated, created_by, updated_by)
+to the existing ml_model table so MLModel becomes an AuditedModel. Existing rows
+have their date_created backfilled from the linked dataset's date_created, falling
+back to now() for rows without a dataset; date_updated mirrors date_created.
+created_by / updated_by are left NULL for pre-existing rows (no reliable historical
+user). No versioning (*_version table) is added.
+
+Revision ID: f1a2b3c4d5e6
+Revises: d4e9c2b7a8f1
+Create Date: 2026-06-17
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f1a2b3c4d5e6'
+down_revision = 'd4e9c2b7a8f1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add audit columns (date_created nullable for now so the backfill can run).
+    op.add_column('ml_model', sa.Column('date_created', sa.DateTime(), nullable=True))
+    op.add_column('ml_model', sa.Column('date_updated', sa.DateTime(), nullable=True))
+    op.add_column('ml_model', sa.Column('created_by', sa.String(), nullable=True))
+    op.add_column('ml_model', sa.Column('updated_by', sa.String(), nullable=True))
+
+    op.create_foreign_key(
+        'ml_model_created_by_fkey', 'ml_model', 'users', ['created_by'], ['id']
+    )
+    op.create_foreign_key(
+        'ml_model_updated_by_fkey', 'ml_model', 'users', ['updated_by'], ['id']
+    )
+
+    op.create_index(op.f('ix_ml_model_date_created'), 'ml_model', ['date_created'], unique=False)
+    op.create_index(op.f('ix_ml_model_date_updated'), 'ml_model', ['date_updated'], unique=False)
+
+    # Backfill date_created from the linked dataset's creation date, falling back
+    # to now() for rows without a dataset; date_updated mirrors date_created.
+    op.execute(
+        """
+        UPDATE ml_model m
+        SET date_created = COALESCE(
+            (SELECT d.date_created FROM dataset d WHERE d.dataset_id = m.dataset_id),
+            now()
+        )
+        WHERE m.date_created IS NULL
+        """
+    )
+    op.execute("UPDATE ml_model SET date_updated = date_created WHERE date_updated IS NULL")
+
+    # date_created is NOT NULL on AuditedModel.
+    op.alter_column('ml_model', 'date_created', existing_type=sa.DateTime(), nullable=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_ml_model_date_updated'), table_name='ml_model')
+    op.drop_index(op.f('ix_ml_model_date_created'), table_name='ml_model')
+    op.drop_constraint('ml_model_updated_by_fkey', 'ml_model', type_='foreignkey')
+    op.drop_constraint('ml_model_created_by_fkey', 'ml_model', type_='foreignkey')
+    op.drop_column('ml_model', 'updated_by')
+    op.drop_column('ml_model', 'created_by')
+    op.drop_column('ml_model', 'date_updated')
+    op.drop_column('ml_model', 'date_created')

--- a/tests/api/test_ml_model.py
+++ b/tests/api/test_ml_model.py
@@ -93,6 +93,14 @@ class TestMLModel:
         assert ml_model.version_num == 1
         assert ml_model.data_novelty == "ATP:0000062"
         assert ml_model.file_classes == ["main"]
+        # audit fields are auto-stamped on create (AuditedModel)
+        assert ml_model.date_created is not None
+        assert ml_model.date_updated is not None
+        assert ml_model.created_by is not None
+        assert ml_model.updated_by is not None
+        # and surfaced in the response schema
+        assert test_ml_model["date_created"] is not None
+        assert test_ml_model["created_by"] is not None
 
     def test_get_all_models_no_filter(self, test_ml_model, test_ml_model2, test_mod, auth_headers):  # noqa
         with TestClient(app) as client:


### PR DESCRIPTION
## Summary

Implements [SCRUM-6090](https://agr-jira.atlassian.net/browse/SCRUM-6090) — *Make model table audited*.

Makes the `ml_model` table an audited object: it now carries `date_created`, `date_updated`, `created_by`, and `updated_by`, auto-stamped via the existing `AuditedModel` `before_insert`/`before_update` listeners. Existing rows have their `date_created` backfilled from the linked dataset's creation date.

## Changes

- **`api/models/ml_model_model.py`** — `MLModel` now inherits `AuditedModel`.
- **`alembic/versions/20260617_f1a2b3c4d5e6_make_ml_model_audited.py`** — new migration:
  - adds the four audit columns (FKs to `users.id`, indexes on the date columns);
  - backfills `date_created` from `dataset.date_created`, falling back to `now()` for rows without a dataset; `date_updated` mirrors `date_created`;
  - `created_by`/`updated_by` left NULL for pre-existing rows (no reliable historical user);
  - then sets `date_created` NOT NULL. No versioning (`*_version`) table is added — audit columns only, per the ticket.
- **`api/schemas/ml_model_schemas.py`** — audit fields exposed on `MLModelSchemaShow` (read-only), not on the base/POST schema.
- **`api/crud/ml_model_crud.py`** — `get_model_schema_from_orm()` carries the four fields through.
- **`tests/api/test_ml_model.py`** — `test_upload_model` asserts the fields are stamped on create and returned in the response.

## Verification

- **Static**: flake8 clean on all changed files; mypy clean (`--config-file mypy.config`).
- **Migration + backfill** (run against the test Postgres): seeded rows at the prior revision, then applied only this migration — 4 columns added (`date_created` NOT NULL), both indexes present, FKs → `users.id`; linked row backfilled to `dataset.date_created`, unlinked row to `now()`, `date_updated` == `date_created`. `downgrade` cleanly drops all four columns.
- **Listener**: a real ORM `MLModel` insert stamps `date_created`/`date_updated` and `created_by`/`updated_by` (= `default_user`, auto-created in `users`).

> Note: the full `make run-test-bash` could not complete locally due to a pre-existing `dev_app` image build failure (`libreadline7.deb` deps) and the auth tests requiring a live Cognito endpoint — both unrelated to this change. The deliverables were validated directly against the test Postgres via the `test_runner` image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6090]: https://agr-jira.atlassian.net/browse/SCRUM-6090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ