### PR TITLE
auto-create companion entity tag for positive mixed tags AND match entity_type by ATP hierarchy in validation

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -171,12 +171,13 @@ def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost,
             # reference-merge copies, which pass validate_on_insert=False. SGD is excluded
             # (it has its own data_novelty/display handling).
             is_mixed = (topic_entity_tag_data.get("entity") is not None
+                        and topic_entity_tag_data.get("entity_type") is not None
                         and topic_entity_tag_data.get("entity_type") != topic_entity_tag_data["topic"])
             is_positive = topic_entity_tag_data.get("negated") is False
             is_sgd = source.secondary_data_provider.abbreviation == "SGD"
             if is_mixed and is_positive and not is_sgd:
                 logger.info("Creating companion entity tag for mixed topic+entity tag")
-                create_entity_tag_for_mixed_tag(db, topic_entity_tag_data, source, reference_id)
+                create_entity_tag_for_mixed_tag(db, topic_entity_tag_data, reference_id)
         logger.info("create_tag completed successfully")
         return (new_db_obj.topic_entity_tag_id, False)
     except (IntegrityError, HTTPException) as e:
@@ -185,21 +186,36 @@ def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost,
                             detail=f"invalid request: {e}")
 
 
-def create_entity_tag_for_mixed_tag(db: Session, mixed_tag_data: dict,
-                                    source: TopicEntityTagSourceModel, reference_id: int):
+def create_entity_tag_for_mixed_tag(db: Session, mixed_tag_data: dict, reference_id: int):
     """SCRUM-6183: create the companion "pure entity" tag for a just-created positive
     mixed topic+entity tag.
 
     The companion has ``topic == entity_type`` and ``data_novelty`` set to the
     "existing data" term, reusing the originating tag's source and entity fields.
 
-    Idempotent and non-fatal: a duplicate/conflict (409) or insert failure is logged
-    and swallowed so it never rolls back the already-committed parent tag. The caller
-    excludes SGD. The companion is itself ``topic == entity_type`` so it does not
-    re-trigger this logic.
+    Idempotent: if a pure entity tag (``topic == entity_type``) for this
+    reference+entity already exists, nothing is created. The existence check is
+    deliberately ``data_novelty``/source/creator-agnostic so we never create a second,
+    semantically-redundant entity tag for the same entity, and it matches the
+    back-fill's existence check.
+
+    Non-fatal: any failure is logged and rolled back so it never disturbs the
+    already-committed parent tag. The caller excludes SGD. The companion is itself
+    ``topic == entity_type`` so it does not re-trigger this logic.
     """
+    entity_type = mixed_tag_data["entity_type"]
+    entity = mixed_tag_data["entity"]
+    existing = db.query(TopicEntityTagModel).filter(
+        TopicEntityTagModel.reference_id == reference_id,
+        TopicEntityTagModel.entity == entity,
+        TopicEntityTagModel.entity_type == entity_type,
+        TopicEntityTagModel.topic == entity_type,
+    ).first()
+    if existing is not None:
+        logger.info("Companion entity tag already exists; nothing to create")
+        return
     entity_tag_data = copy.copy(mixed_tag_data)
-    entity_tag_data["topic"] = mixed_tag_data["entity_type"]
+    entity_tag_data["topic"] = entity_type
     entity_tag_data["data_novelty"] = EXISTING_DATA_NOVELTY_ATP
     entity_tag_data["negated"] = False
     # The remaining fields describe the topic-specific assertion, not the bare entity,
@@ -209,22 +225,17 @@ def create_entity_tag_for_mixed_tag(db: Session, mixed_tag_data: dict,
                   "validation_by_professional_biocurator"):
         entity_tag_data[field] = None
     try:
-        duplicate_check_result = check_for_duplicate_tags(db, entity_tag_data, source, reference_id)
-        if duplicate_check_result is not None:
-            logger.info("Companion entity tag already exists; nothing to create")
-            return
         new_db_obj = TopicEntityTagModel(**entity_tag_data)
         db.add(new_db_obj)
         db.commit()
         db.refresh(new_db_obj, ['topic_entity_tag_source'])
         validate_tags(db=db, new_tag_obj=new_db_obj)
         logger.info(f"Created companion entity tag {new_db_obj.topic_entity_tag_id}")
-    except HTTPException as e:
+    except Exception as e:
+        # Non-fatal: the parent tag is already committed, so a companion failure must
+        # never surface to the caller. Roll back only the companion's pending work.
         db.rollback()
-        logger.info(f"Skipped companion entity tag (conflict): {e.detail}")
-    except IntegrityError as e:
-        db.rollback()
-        logger.warning(f"Companion entity tag insert failed: {e}")
+        logger.warning(f"Companion entity tag creation failed, skipping: {e}")
 
 
 def set_indexing_status_for_no_tet_data(db: Session, mod_abbreviation, reference_curie, uid):

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -518,6 +518,22 @@ def destroy_tag(db: Session, topic_entity_tag_id: int, mod_access: ModAccess):
     revalidate_all_tags(curie_or_reference_id=str(reference_id), delete_all_first=False, validation_values_only=False)
 
 
+def atp_hierarchy_with_self(atp_id, ancestors: bool):
+    """SCRUM-6188: set containing ``atp_id`` plus its ATP ancestors (``ancestors=True``)
+    or descendants (``ancestors=False``).
+
+    Returns an empty set when ``atp_id`` is None (``entity_type`` is nullable). Always
+    includes ``atp_id`` itself, so an exact-equality match is preserved even when the
+    node has no ancestors/descendants in the ontology graph.
+    """
+    if atp_id is None:
+        return set()
+    related = get_ancestors(onto_node=atp_id) if ancestors else get_descendants(onto_node=atp_id)
+    result = set(related)
+    result.add(atp_id)
+    return result
+
+
 def validate_tags_already_in_db_with_positive_tag(db, new_tag_obj: TopicEntityTagModel, related_tags_in_db,
                                                   calculate_validation_values: bool = True):
     # 1. new tag positive, existing tag positive = validate existing (right) if existing is more generic
@@ -526,10 +542,13 @@ def validate_tags_already_in_db_with_positive_tag(db, new_tag_obj: TopicEntityTa
     more_generic_topics.add(new_tag_obj.topic)
     more_generic_novelty = set(get_ancestors(new_tag_obj.data_novelty))
     more_generic_novelty.add(new_tag_obj.data_novelty)
+    # SCRUM-6188: entity_type matching is ATP-hierarchy-aware (a more specific new tag
+    # validates a more generic existing tag), consistent with topic/data_novelty above.
+    more_generic_entity_types = atp_hierarchy_with_self(new_tag_obj.entity_type, ancestors=True)
     tag_in_db: TopicEntityTagModel
     for tag_in_db in related_tags_in_db:
         if tag_in_db.topic in more_generic_topics:
-            if tag_in_db.entity_type is None or (tag_in_db.entity_type == new_tag_obj.entity_type
+            if tag_in_db.entity_type is None or (tag_in_db.entity_type in more_generic_entity_types
                                                  and tag_in_db.entity == new_tag_obj.entity):
                 if tag_in_db.species is None or tag_in_db.species == new_tag_obj.species:
                     # Check data novelty
@@ -539,7 +558,8 @@ def validate_tags_already_in_db_with_positive_tag(db, new_tag_obj: TopicEntityTa
     # validate pure entity-only tags if the new tag is a mixed topic + entity tag for the same entity
     if new_tag_obj.entity is not None and new_tag_obj.entity_type != new_tag_obj.topic:
         for tag_in_db in related_tags_in_db:
-            if (tag_in_db.topic == tag_in_db.entity_type == new_tag_obj.entity_type
+            if (tag_in_db.topic == tag_in_db.entity_type
+                    and tag_in_db.entity_type in more_generic_entity_types
                     and new_tag_obj.entity == tag_in_db.entity):
                 if tag_in_db.data_novelty in more_generic_novelty:
                     add_validation_to_db(db, tag_in_db, new_tag_obj,
@@ -554,10 +574,13 @@ def validate_tags_already_in_db_with_negative_tag(db, new_tag_obj: TopicEntityTa
     more_specific_topics.add(new_tag_obj.topic)
     more_specific_novelty = set(get_descendants(new_tag_obj.data_novelty))
     more_specific_novelty.add(new_tag_obj.data_novelty)
+    # SCRUM-6188: entity_type matching is ATP-hierarchy-aware (a more generic negative
+    # new tag validates a more specific existing tag), consistent with topic above.
+    more_specific_entity_types = atp_hierarchy_with_self(new_tag_obj.entity_type, ancestors=False)
     tag_in_db: TopicEntityTagModel
     for tag_in_db in related_tags_in_db:
         if tag_in_db.topic in more_specific_topics:
-            if new_tag_obj.entity_type is None or (tag_in_db.entity_type == new_tag_obj.entity_type
+            if new_tag_obj.entity_type is None or (tag_in_db.entity_type in more_specific_entity_types
                                                    and tag_in_db.entity == new_tag_obj.entity):
                 if new_tag_obj.species is None or tag_in_db.species == new_tag_obj.species:
                     if tag_in_db.data_novelty in more_specific_novelty:
@@ -568,7 +591,7 @@ def validate_tags_already_in_db_with_negative_tag(db, new_tag_obj: TopicEntityTa
     if new_tag_obj.topic == new_tag_obj.entity_type:
         for tag_in_db in related_tags_in_db:
             if (tag_in_db.negated is False and tag_in_db.entity_type != tag_in_db.topic
-                    and new_tag_obj.entity_type == tag_in_db.entity_type
+                    and tag_in_db.entity_type in more_specific_entity_types
                     and new_tag_obj.entity == tag_in_db.entity):
                 if tag_in_db.data_novelty in more_specific_novelty:
                     add_validation_to_db(db, tag_in_db, new_tag_obj,
@@ -589,18 +612,22 @@ def validate_new_tag_with_existing_tags(db, new_tag_obj: TopicEntityTagModel, re
     more_generic_topics.add(new_tag_obj.topic)
     more_generic_novelty = set(get_ancestors(new_tag_obj.data_novelty))
     more_generic_novelty.add(new_tag_obj.data_novelty)
+    # SCRUM-6188: entity_type matching is ATP-hierarchy-aware, following the same
+    # generic/specific direction as the topic/data_novelty checks in each branch.
+    more_specific_entity_types = atp_hierarchy_with_self(new_tag_obj.entity_type, ancestors=False)
+    more_generic_entity_types = atp_hierarchy_with_self(new_tag_obj.entity_type, ancestors=True)
     tag_in_db: TopicEntityTagModel
     for tag_in_db in related_validating_tags_in_db:
         if (tag_in_db.negated is False and tag_in_db.topic in more_specific_topics
                 and tag_in_db.data_novelty in more_specific_novelty):
-            if new_tag_obj.entity_type is None or (tag_in_db.entity_type == new_tag_obj.entity_type
+            if new_tag_obj.entity_type is None or (tag_in_db.entity_type in more_specific_entity_types
                                                    and tag_in_db.entity == new_tag_obj.entity):
                 if new_tag_obj.species is None or tag_in_db.species == new_tag_obj.species:
                     add_validation_to_db(db, new_tag_obj, tag_in_db,
                                          calculate_validation_values=calculate_validation_values)
         elif (tag_in_db.negated is True and tag_in_db.topic in more_generic_topics
               and tag_in_db.data_novelty in more_generic_novelty):
-            if tag_in_db.entity_type is None or (tag_in_db.entity_type == new_tag_obj.entity_type
+            if tag_in_db.entity_type is None or (tag_in_db.entity_type in more_generic_entity_types
                                                  and tag_in_db.entity == new_tag_obj.entity):
                 if tag_in_db.species is None or tag_in_db.species == new_tag_obj.species:
                     add_validation_to_db(db, new_tag_obj, tag_in_db,
@@ -609,7 +636,7 @@ def validate_new_tag_with_existing_tags(db, new_tag_obj: TopicEntityTagModel, re
     # validate positive or negative new tag only if existing is positive
     if new_tag_obj.topic == new_tag_obj.entity_type:
         for tag_in_db in related_validating_tags_in_db:
-            if (tag_in_db.entity_type != tag_in_db.topic and new_tag_obj.entity_type == tag_in_db.entity_type
+            if (tag_in_db.entity_type != tag_in_db.topic and tag_in_db.entity_type in more_specific_entity_types
                     and new_tag_obj.entity == tag_in_db.entity and tag_in_db.negated is False):
                 if tag_in_db.data_novelty in more_specific_novelty:
                     add_validation_to_db(db, new_tag_obj, tag_in_db,
@@ -618,7 +645,8 @@ def validate_new_tag_with_existing_tags(db, new_tag_obj: TopicEntityTagModel, re
     # validate only positive new tag if existing is negative
     if new_tag_obj.negated is False and new_tag_obj.entity is not None and new_tag_obj.entity_type != new_tag_obj.topic:
         for tag_in_db in related_validating_tags_in_db:
-            if (tag_in_db.negated is True and tag_in_db.topic == tag_in_db.entity_type == new_tag_obj.entity_type
+            if (tag_in_db.negated is True and tag_in_db.topic == tag_in_db.entity_type
+                    and tag_in_db.entity_type in more_generic_entity_types
                     and new_tag_obj.entity == tag_in_db.entity and tag_in_db.data_novelty in more_generic_novelty):
                 add_validation_to_db(db, new_tag_obj, tag_in_db,
                                      calculate_validation_values=calculate_validation_values)

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -518,7 +518,7 @@ def destroy_tag(db: Session, topic_entity_tag_id: int, mod_access: ModAccess):
     revalidate_all_tags(curie_or_reference_id=str(reference_id), delete_all_first=False, validation_values_only=False)
 
 
-def atp_hierarchy_with_self(atp_id, ancestors: bool):
+def atp_hierarchy_with_self(atp_id: Optional[str], ancestors: bool) -> Set[str]:
     """SCRUM-6188: set containing ``atp_id`` plus its ATP ancestors (``ancestors=True``)
     or descendants (``ancestors=False``).
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -55,6 +55,10 @@ ATP_ID_SOURCE_CURATOR = "professional_biocurator"
 TET_CURIE_FIELDS = ['topic', 'entity_type', 'display_tag', 'entity', 'species']
 TET_SOURCE_CURIE_FIELDS = ['source_evidence_assertion']
 
+# SCRUM-6183: data_novelty term "existing data" used on the companion pure entity
+# tag auto-created from a positive mixed topic+entity tag.
+EXISTING_DATA_NOVELTY_ATP = "ATP:0000334"
+
 
 def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost,
                validate_on_insert: bool = True) -> Tuple[int, bool]:
@@ -160,12 +164,67 @@ def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost,
             logger.info("Starting tag validation")
             validate_tags(db=db, new_tag_obj=new_db_obj)
             logger.info("Tag validation completed")
+            # SCRUM-6183: when a curator creates a positive mixed topic+entity tag, also
+            # create a companion pure entity tag (topic == entity_type) so they don't have
+            # to add it by hand. Gated on validate_on_insert so it only fires for the
+            # interactive create path (the router) and not for bulk reference import or
+            # reference-merge copies, which pass validate_on_insert=False. SGD is excluded
+            # (it has its own data_novelty/display handling).
+            is_mixed = (topic_entity_tag_data.get("entity") is not None
+                        and topic_entity_tag_data.get("entity_type") != topic_entity_tag_data["topic"])
+            is_positive = topic_entity_tag_data.get("negated") is False
+            is_sgd = source.secondary_data_provider.abbreviation == "SGD"
+            if is_mixed and is_positive and not is_sgd:
+                logger.info("Creating companion entity tag for mixed topic+entity tag")
+                create_entity_tag_for_mixed_tag(db, topic_entity_tag_data, source, reference_id)
         logger.info("create_tag completed successfully")
         return (new_db_obj.topic_entity_tag_id, False)
     except (IntegrityError, HTTPException) as e:
         db.rollback()
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                             detail=f"invalid request: {e}")
+
+
+def create_entity_tag_for_mixed_tag(db: Session, mixed_tag_data: dict,
+                                    source: TopicEntityTagSourceModel, reference_id: int):
+    """SCRUM-6183: create the companion "pure entity" tag for a just-created positive
+    mixed topic+entity tag.
+
+    The companion has ``topic == entity_type`` and ``data_novelty`` set to the
+    "existing data" term, reusing the originating tag's source and entity fields.
+
+    Idempotent and non-fatal: a duplicate/conflict (409) or insert failure is logged
+    and swallowed so it never rolls back the already-committed parent tag. The caller
+    excludes SGD. The companion is itself ``topic == entity_type`` so it does not
+    re-trigger this logic.
+    """
+    entity_tag_data = copy.copy(mixed_tag_data)
+    entity_tag_data["topic"] = mixed_tag_data["entity_type"]
+    entity_tag_data["data_novelty"] = EXISTING_DATA_NOVELTY_ATP
+    entity_tag_data["negated"] = False
+    # The remaining fields describe the topic-specific assertion, not the bare entity,
+    # so they are reset on the companion tag.
+    for field in ("note", "confidence_score", "confidence_level", "display_tag",
+                  "ml_model_id", "validation_by_author",
+                  "validation_by_professional_biocurator"):
+        entity_tag_data[field] = None
+    try:
+        duplicate_check_result = check_for_duplicate_tags(db, entity_tag_data, source, reference_id)
+        if duplicate_check_result is not None:
+            logger.info("Companion entity tag already exists; nothing to create")
+            return
+        new_db_obj = TopicEntityTagModel(**entity_tag_data)
+        db.add(new_db_obj)
+        db.commit()
+        db.refresh(new_db_obj, ['topic_entity_tag_source'])
+        validate_tags(db=db, new_tag_obj=new_db_obj)
+        logger.info(f"Created companion entity tag {new_db_obj.topic_entity_tag_id}")
+    except HTTPException as e:
+        db.rollback()
+        logger.info(f"Skipped companion entity tag (conflict): {e.detail}")
+    except IntegrityError as e:
+        db.rollback()
+        logger.warning(f"Companion entity tag insert failed: {e}")
 
 
 def set_indexing_status_for_no_tet_data(db: Session, mod_abbreviation, reference_curie, uid):

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -655,9 +655,19 @@ def validate_new_tag_with_existing_tags(db, new_tag_obj: TopicEntityTagModel, re
 def add_validation_to_db(db: Session, validated_tag: TopicEntityTagModel, validating_tag: TopicEntityTagModel,
                          calculate_validation_values: bool = True):
     logger.info(f"Adding validation: tag {validated_tag.topic_entity_tag_id} validated by tag {validating_tag.topic_entity_tag_id}")
-    db.execute(text(f"INSERT INTO topic_entity_tag_validation (validated_topic_entity_tag_id, "
-                    f"validating_topic_entity_tag_id) VALUES ({validated_tag.topic_entity_tag_id}, "
-                    f"{validating_tag.topic_entity_tag_id})"))
+    # topic_entity_tag_validation is a set-membership join table (composite PK, no other
+    # columns). The overlapping validation rules can re-assert the same (validated,
+    # validating) pair within a single pass -- e.g. a pure-entity companion tag matched by
+    # the originating mixed tag under more than one rule -- so the insert must be idempotent.
+    # A bare INSERT would raise UniqueViolation and abort the whole validation pass.
+    result = db.execute(text("INSERT INTO topic_entity_tag_validation (validated_topic_entity_tag_id, "
+                             "validating_topic_entity_tag_id) VALUES (:validated_id, :validating_id) "
+                             "ON CONFLICT DO NOTHING"),
+                        {"validated_id": validated_tag.topic_entity_tag_id,
+                         "validating_id": validating_tag.topic_entity_tag_id})
+    if result.rowcount == 0:
+        # Pair already recorded; nothing changed, so there is nothing to recompute.
+        return
     if calculate_validation_values:
         logger.info("Committing validation insert and recalculating validation values")
         db.commit()

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -203,31 +203,33 @@ def create_entity_tag_for_mixed_tag(db: Session, mixed_tag_data: dict, reference
     already-committed parent tag. The caller excludes SGD. The companion is itself
     ``topic == entity_type`` so it does not re-trigger this logic.
     """
-    entity_type = mixed_tag_data["entity_type"]
-    entity = mixed_tag_data["entity"]
-    existing = db.query(TopicEntityTagModel).filter(
-        TopicEntityTagModel.reference_id == reference_id,
-        TopicEntityTagModel.entity == entity,
-        TopicEntityTagModel.entity_type == entity_type,
-        TopicEntityTagModel.topic == entity_type,
-    ).first()
-    if existing is not None:
-        logger.info("Companion entity tag already exists; nothing to create")
-        return
-    entity_tag_data = copy.copy(mixed_tag_data)
-    entity_tag_data["topic"] = entity_type
-    entity_tag_data["data_novelty"] = EXISTING_DATA_NOVELTY_ATP
-    entity_tag_data["negated"] = False
-    # The remaining fields describe the topic-specific assertion, not the bare entity,
-    # so they are reset on the companion tag.
-    for field in ("note", "confidence_score", "confidence_level", "display_tag",
-                  "ml_model_id", "validation_by_author",
-                  "validation_by_professional_biocurator"):
-        entity_tag_data[field] = None
+    committed = False
     try:
+        entity_type = mixed_tag_data["entity_type"]
+        entity = mixed_tag_data["entity"]
+        existing = db.query(TopicEntityTagModel).filter(
+            TopicEntityTagModel.reference_id == reference_id,
+            TopicEntityTagModel.entity == entity,
+            TopicEntityTagModel.entity_type == entity_type,
+            TopicEntityTagModel.topic == entity_type,
+        ).first()
+        if existing is not None:
+            logger.info("Companion entity tag already exists; nothing to create")
+            return
+        entity_tag_data = copy.copy(mixed_tag_data)
+        entity_tag_data["topic"] = entity_type
+        entity_tag_data["data_novelty"] = EXISTING_DATA_NOVELTY_ATP
+        entity_tag_data["negated"] = False
+        # The remaining fields describe the topic-specific assertion, not the bare
+        # entity, so they are reset on the companion tag.
+        for field in ("note", "confidence_score", "confidence_level", "display_tag",
+                      "ml_model_id", "validation_by_author",
+                      "validation_by_professional_biocurator"):
+            entity_tag_data[field] = None
         new_db_obj = TopicEntityTagModel(**entity_tag_data)
         db.add(new_db_obj)
         db.commit()
+        committed = True
         db.refresh(new_db_obj, ['topic_entity_tag_source'])
         validate_tags(db=db, new_tag_obj=new_db_obj)
         logger.info(f"Created companion entity tag {new_db_obj.topic_entity_tag_id}")
@@ -235,7 +237,12 @@ def create_entity_tag_for_mixed_tag(db: Session, mixed_tag_data: dict, reference
         # Non-fatal: the parent tag is already committed, so a companion failure must
         # never surface to the caller. Roll back only the companion's pending work.
         db.rollback()
-        logger.warning(f"Companion entity tag creation failed, skipping: {e}")
+        if committed:
+            # The companion row was already written; only the post-insert validation
+            # failed, so the row persists (validation can be recomputed later).
+            logger.warning(f"Companion entity tag written but validation failed: {e}")
+        else:
+            logger.warning(f"Companion entity tag not created, skipping: {e}")
 
 
 def set_indexing_status_for_no_tet_data(db: Session, mod_abbreviation, reference_curie, uid):

--- a/agr_literature_service/lit_processing/oneoff_scripts/SCRUM-6183_backfill_entity_tags_for_mixed_tags.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/SCRUM-6183_backfill_entity_tags_for_mixed_tags.py
@@ -1,0 +1,104 @@
+"""SCRUM-6183: back-populate companion "pure entity" tags for existing POSITIVE
+MIXED topic+entity tags.
+
+For every positive mixed tag (``negated IS FALSE``, ``entity IS NOT NULL`` and
+``topic <> entity_type``) that does not yet have a companion pure entity tag
+(``topic == entity_type`` for the same reference + entity + entity_type), create
+that companion tag with ``data_novelty`` set to the "existing data" term, reusing
+the originating tag's source and entity fields.
+
+Skip rules:
+  1. SGD is excluded (it has its own data_novelty/display handling).
+  2. Mixed tags that already have a companion pure entity tag are skipped
+     (idempotent re-runs); ``create_entity_tag_for_mixed_tag`` re-checks too.
+"""
+
+import logging
+from os import path
+
+from sqlalchemy import text
+
+from agr_literature_service.api.models import (
+    TopicEntityTagModel, TopicEntityTagSourceModel
+)
+from agr_literature_service.api.crud.topic_entity_tag_crud import \
+    create_entity_tag_for_mixed_tag
+from agr_literature_service.api.user import set_global_user_id
+from agr_literature_service.lit_processing.utils.sqlalchemy_utils import \
+    create_postgres_session
+
+
+logging.basicConfig(format='%(message)s')
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+SGD = "SGD"
+
+# Columns carried from the originating mixed tag into the companion. topic,
+# data_novelty and negated (plus the reset fields) are overridden by
+# create_entity_tag_for_mixed_tag; date_created/date_updated are intentionally
+# omitted so the new row gets fresh defaults.
+CARRY_COLUMNS = [
+    "reference_id", "topic", "entity_type", "entity", "entity_id_validation",
+    "species", "entity_published_as", "display_tag", "confidence_level",
+    "confidence_score", "negated", "note", "topic_entity_tag_source_id",
+    "created_by", "updated_by", "data_novelty", "ml_model_id",
+]
+
+
+def backfill():
+    db = create_postgres_session(False)
+    set_global_user_id(db, path.basename(__file__).replace(".py", ""))
+
+    candidate_ids = [r[0] for r in db.execute(text("""
+        SELECT m.topic_entity_tag_id
+          FROM topic_entity_tag m
+          JOIN topic_entity_tag_source s
+            ON m.topic_entity_tag_source_id = s.topic_entity_tag_source_id
+         WHERE m.entity IS NOT NULL
+           AND m.topic <> m.entity_type
+           AND m.negated IS FALSE
+           AND s.data_provider <> :sgd
+           AND NOT EXISTS (
+                 SELECT 1 FROM topic_entity_tag e
+                  WHERE e.reference_id = m.reference_id
+                    AND e.entity = m.entity
+                    AND e.entity_type = m.entity_type
+                    AND e.topic = e.entity_type)
+    """), {"sgd": SGD})]
+
+    logger.info(f"positive mixed tags missing a companion entity tag (excl SGD): "
+                f"{len(candidate_ids)}")
+
+    created = 0
+    for tag_id in candidate_ids:
+        mixed_tag = db.query(TopicEntityTagModel).filter(
+            TopicEntityTagModel.topic_entity_tag_id == tag_id).one_or_none()
+        if mixed_tag is None:
+            continue
+        source = db.query(TopicEntityTagSourceModel).filter(
+            TopicEntityTagSourceModel.topic_entity_tag_source_id
+            == mixed_tag.topic_entity_tag_source_id).one()
+        mixed_tag_data = {col: getattr(mixed_tag, col) for col in CARRY_COLUMNS}
+        before = db.query(TopicEntityTagModel).filter(
+            TopicEntityTagModel.reference_id == mixed_tag.reference_id,
+            TopicEntityTagModel.entity == mixed_tag.entity,
+            TopicEntityTagModel.entity_type == mixed_tag.entity_type,
+            TopicEntityTagModel.topic == mixed_tag.entity_type).count()
+        create_entity_tag_for_mixed_tag(db, mixed_tag_data, source,
+                                        mixed_tag.reference_id)
+        after = db.query(TopicEntityTagModel).filter(
+            TopicEntityTagModel.reference_id == mixed_tag.reference_id,
+            TopicEntityTagModel.entity == mixed_tag.entity,
+            TopicEntityTagModel.entity_type == mixed_tag.entity_type,
+            TopicEntityTagModel.topic == mixed_tag.entity_type).count()
+        if after > before:
+            created += 1
+            logger.info(f"  created companion entity tag for mixed tag {tag_id}")
+
+    logger.info(f"created {created} companion entity tag(s)")
+
+
+if __name__ == "__main__":
+    backfill()

--- a/agr_literature_service/lit_processing/oneoff_scripts/SCRUM-6183_backfill_entity_tags_for_mixed_tags.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/SCRUM-6183_backfill_entity_tags_for_mixed_tags.py
@@ -18,9 +18,7 @@ from os import path
 
 from sqlalchemy import text
 
-from agr_literature_service.api.models import (
-    TopicEntityTagModel, TopicEntityTagSourceModel
-)
+from agr_literature_service.api.models import TopicEntityTagModel
 from agr_literature_service.api.crud.topic_entity_tag_crud import \
     create_entity_tag_for_mixed_tag
 from agr_literature_service.api.user import set_global_user_id
@@ -77,17 +75,13 @@ def backfill():
             TopicEntityTagModel.topic_entity_tag_id == tag_id).one_or_none()
         if mixed_tag is None:
             continue
-        source = db.query(TopicEntityTagSourceModel).filter(
-            TopicEntityTagSourceModel.topic_entity_tag_source_id
-            == mixed_tag.topic_entity_tag_source_id).one()
         mixed_tag_data = {col: getattr(mixed_tag, col) for col in CARRY_COLUMNS}
         before = db.query(TopicEntityTagModel).filter(
             TopicEntityTagModel.reference_id == mixed_tag.reference_id,
             TopicEntityTagModel.entity == mixed_tag.entity,
             TopicEntityTagModel.entity_type == mixed_tag.entity_type,
             TopicEntityTagModel.topic == mixed_tag.entity_type).count()
-        create_entity_tag_for_mixed_tag(db, mixed_tag_data, source,
-                                        mixed_tag.reference_id)
+        create_entity_tag_for_mixed_tag(db, mixed_tag_data, mixed_tag.reference_id)
         after = db.query(TopicEntityTagModel).filter(
             TopicEntityTagModel.reference_id == mixed_tag.reference_id,
             TopicEntityTagModel.entity == mixed_tag.entity,

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -2429,3 +2429,139 @@ class TestTopicEntityTag:
                 "created_by should never change"
             assert updated_tag.date_created == original_date_created, \
                 "date_created should never change"
+
+
+class TestMixedTagCompanionEntityTag:
+    """SCRUM-6183: creating a positive mixed topic+entity tag should also create a
+    companion pure entity tag (topic == entity_type) with data_novelty 'existing data'
+    (ATP:0000334). SGD is excluded; negated and pure-entity tags do not trigger it."""
+
+    EXISTING_DATA_NOVELTY = "ATP:0000334"
+
+    def _post_tag(self, client, auth_headers, payload):  # noqa
+        return client.post(url="/topic_entity_tag/", json=payload, headers=auth_headers)
+
+    def _companions(self, db, reference_id, entity_type, entity):  # noqa
+        return db.query(TopicEntityTagModel).filter(
+            TopicEntityTagModel.reference_id == reference_id,
+            TopicEntityTagModel.topic == entity_type,
+            TopicEntityTagModel.entity_type == entity_type,
+            TopicEntityTagModel.entity == entity,
+            TopicEntityTagModel.data_novelty == self.EXISTING_DATA_NOVELTY,
+        ).all()
+
+    def test_positive_mixed_tag_creates_companion_entity_tag(self, db, auth_headers, test_reference,  # noqa
+                                                             test_topic_entity_tag_source, test_mod):  # noqa
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client:
+            payload = {
+                "reference_curie": test_reference.new_ref_curie,
+                "topic": "ATP:0000122",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
+                "entity_id_validation": "alliance",
+                "entity_published_as": "test",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                "negated": False,
+                "data_novelty": "ATP:0000335",
+                "note": "mixed-tag note",
+                "created_by": "WBPerson1",
+            }
+            resp = self._post_tag(client, auth_headers, payload)
+            assert resp.status_code == status.HTTP_201_CREATED
+            mixed_id = resp.json()["topic_entity_tag_id"]
+            mixed = db.query(TopicEntityTagModel).filter(
+                TopicEntityTagModel.topic_entity_tag_id == mixed_id).one()
+
+            companions = self._companions(db, mixed.reference_id, "ATP:0000005", "WB:WBGene00003001")
+            assert len(companions) == 1
+            companion = companions[0]
+            assert companion.topic == companion.entity_type == "ATP:0000005"
+            assert companion.negated is False
+            assert companion.data_novelty == self.EXISTING_DATA_NOVELTY
+            assert companion.topic_entity_tag_source_id == test_topic_entity_tag_source.new_source_id
+            assert companion.entity_id_validation == "alliance"
+            assert companion.species == "NCBITaxon:6239"
+            # topic-specific fields are reset on the companion
+            assert companion.note is None
+            assert companion.created_by == "WBPerson1"
+
+    def test_negated_mixed_tag_creates_no_companion(self, db, auth_headers, test_reference,  # noqa
+                                                    test_topic_entity_tag_source, test_mod):  # noqa
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client:
+            payload = {
+                "reference_curie": test_reference.new_ref_curie,
+                "topic": "ATP:0000122",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
+                "entity_id_validation": "alliance",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                "negated": True,
+                "data_novelty": "ATP:0000335",
+                "created_by": "WBPerson1",
+            }
+            resp = self._post_tag(client, auth_headers, payload)
+            assert resp.status_code == status.HTTP_201_CREATED
+            mixed = db.query(TopicEntityTagModel).filter(
+                TopicEntityTagModel.topic_entity_tag_id == resp.json()["topic_entity_tag_id"]).one()
+            assert self._companions(db, mixed.reference_id, "ATP:0000005", "WB:WBGene00003001") == []
+
+    def test_pure_entity_tag_creates_no_extra_companion(self, db, auth_headers, test_reference,  # noqa
+                                                        test_topic_entity_tag_source, test_mod):  # noqa
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client:
+            payload = {
+                "reference_curie": test_reference.new_ref_curie,
+                "topic": "ATP:0000005",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
+                "entity_id_validation": "alliance",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                "negated": False,
+                "data_novelty": self.EXISTING_DATA_NOVELTY,
+                "created_by": "WBPerson1",
+            }
+            resp = self._post_tag(client, auth_headers, payload)
+            assert resp.status_code == status.HTTP_201_CREATED
+            mixed = db.query(TopicEntityTagModel).filter(
+                TopicEntityTagModel.topic_entity_tag_id == resp.json()["topic_entity_tag_id"]).one()
+            # the tag itself is the only topic==entity_type row; no recursive companion
+            assert len(self._companions(db, mixed.reference_id, "ATP:0000005", "WB:WBGene00003001")) == 1
+
+    def test_sgd_mixed_tag_creates_no_companion(self, db, auth_headers, test_reference):  # noqa
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client:
+            sgd_mod = client.post(url="/mod/", json={"abbreviation": "SGD", "short_name": "SGD",
+                                                     "full_name": "Saccharomyces Genome Database"},
+                                  headers=auth_headers)
+            assert sgd_mod.status_code in (status.HTTP_201_CREATED, status.HTTP_409_CONFLICT)
+            sgd_source = client.post(url="/topic_entity_tag/source", json={
+                "source_evidence_assertion": "ATP:0000036",
+                "source_method": "abc_literature_system",
+                "validation_type": "professional_biocurator",
+                "description": "SGD curator",
+                "data_provider": "SGD",
+                "secondary_data_provider_abbreviation": "SGD",
+            }, headers=auth_headers)
+            assert sgd_source.status_code == status.HTTP_201_CREATED
+            payload = {
+                "reference_curie": test_reference.new_ref_curie,
+                "topic": "ATP:0000122",
+                "entity_type": "ATP:0000005",
+                "entity": "WB:WBGene00003001",
+                "entity_id_validation": "alliance",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": sgd_source.json()["topic_entity_tag_source_id"],
+                "negated": False,
+                "created_by": "WBPerson1",
+            }
+            resp = self._post_tag(client, auth_headers, payload)
+            assert resp.status_code == status.HTTP_201_CREATED
+            mixed = db.query(TopicEntityTagModel).filter(
+                TopicEntityTagModel.topic_entity_tag_id == resp.json()["topic_entity_tag_id"]).one()
+            # SGD is excluded everywhere, so no companion entity tag is created
+            assert self._companions(db, mixed.reference_id, "ATP:0000005", "WB:WBGene00003001") == []

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -849,7 +849,11 @@ class TestTopicEntityTag:
                                        headers=auth_headers)
             assert all_tags_resp.status_code == status.HTTP_200_OK
             all_tags = all_tags_resp.json()
-            assert len(all_tags) == 6
+            # SCRUM-6183: the fixture's positive mixed tag auto-creates one companion
+            # pure entity tag for WB:WBGene00003001; more_specific_positive_tag reuses
+            # that same entity so its companion is deduped. 5 explicit tags + fixture
+            # tag + 1 companion = 7.
+            assert len(all_tags) == 7
             for tag in all_tags:
                 if tag["topic"] == "ATP:0000079":
                     assert tag["validation_by_author"] == "validation_conflict"

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -648,6 +648,68 @@ class TestTopicEntityTag:
             ).one()
             assert len(specific_tag_obj_2.validated_by) == 0  # nothing should validate the more specific tag
 
+    def test_validate_hierarchy_aware_entity_type(self, db, auth_headers, test_reference,  # noqa
+                                                  test_topic_entity_tag_source, test_mod):  # noqa
+        """SCRUM-6188: a more specific pure-entity tag (entity_type ATP:0000084) should
+        validate a more generic pure-entity tag (entity_type ATP:0000009) for the same
+        entity, following the ATP parent/child hierarchy rather than exact entity_type
+        equality (mirrors the allele / classical-allele case in the ticket)."""
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client:
+            curator_source = {
+                "source_evidence_assertion": "ATP:0000036",
+                "source_method": "abc_literature_system",
+                "validation_type": "professional_biocurator",
+                "description": "curator using the ABC",
+                "data_provider": "WB",
+                "secondary_data_provider_abbreviation": test_mod.new_mod_abbreviation,
+            }
+            curator_source_id = client.post(url="/topic_entity_tag/source", json=curator_source,
+                                            headers=auth_headers).json()["topic_entity_tag_source_id"]
+            # generic pure-entity tag from an automated source (validation_type None)
+            generic_tag = {
+                "reference_curie": test_reference.new_ref_curie,
+                "topic": "ATP:0000009",
+                "entity_type": "ATP:0000009",
+                "entity": "WB:WBGene00003001",
+                "entity_id_validation": "alliance",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": test_topic_entity_tag_source.new_source_id,
+                "negated": False,
+                "data_novelty": "ATP:0000334",
+                "created_by": "WBPerson1",
+            }
+            generic_id = client.post(url="/topic_entity_tag/", json=generic_tag,
+                                     headers=auth_headers).json()["topic_entity_tag_id"]
+            # more specific pure-entity tag entered manually by a curator
+            specific_tag = {
+                "reference_curie": test_reference.new_ref_curie,
+                "topic": "ATP:0000084",
+                "entity_type": "ATP:0000084",
+                "entity": "WB:WBGene00003001",
+                "entity_id_validation": "alliance",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": curator_source_id,
+                "negated": False,
+                "data_novelty": "ATP:0000334",
+                "created_by": "WBPerson2",
+            }
+            specific_id = client.post(url="/topic_entity_tag/", json=specific_tag,
+                                      headers=auth_headers).json()["topic_entity_tag_id"]
+
+            generic_obj = db.query(TopicEntityTagModel).filter(
+                TopicEntityTagModel.topic_entity_tag_id == generic_id).one()
+            validating_ids = {t.topic_entity_tag_id for t in generic_obj.validated_by}
+            assert int(specific_id) in validating_ids, \
+                "specific (child entity_type) tag should validate the generic (parent) tag"
+            assert generic_obj.validation_by_professional_biocurator == "validated_right"
+
+            # reverse direction: the specific curator tag is not validated by the
+            # generic automated tag (its source has no validation_type)
+            specific_obj = db.query(TopicEntityTagModel).filter(
+                TopicEntityTagModel.topic_entity_tag_id == specific_id).one()
+            assert int(generic_id) not in {t.topic_entity_tag_id for t in specific_obj.validated_by}
+
     def test_validate_positive_with_pos_and_neg(self, test_topic_entity_tag, test_reference, test_mod,  # noqa
                                                 auth_headers, db, test_topic_entity_tag_source):  # noqa
         with TestClient(app) as client, \


### PR DESCRIPTION
SCRUM-6183 — Auto-create companion entity tag for mixed tags

When a curator creates a positive mixed topic+entity tag via the API, also create a companion "pure entity" tag (topic == entity_type) with data_novelty "existing data" (ATP:0000334), so curators don't have to add it by hand.

- create_entity_tag_for_mixed_tag(): idempotent, non-fatal helper that reuses the duplicate-check path and never rolls back the committed parent tag.
- Gated behind validate_on_insert so it only fires on the interactive create path, not bulk reference import / reference-merge copies. SGD is excluded.
- Back-population one-off script for historical mixed tags (excludes SGD).
- Tests for companion creation, negated/pure-entity/SGD exclusions.

SCRUM-6188 — Match entity_type by ATP hierarchy in validation
  
  TET validation traversed the ATP ontology for topic and data_novelty but compared entity_type with exact string
  equality, so a more specific manually-entered tag (e.g. classical allele ATP:0000285) failed to validate the
  generic allele tag (ATP:0000006) for the same entity.
  - Added atp_hierarchy_with_self() and made every cross-tag entity_type comparison in all three validation helpers
  (and their entity-only fallback branches) hierarchy-aware, following the same generic/specific direction already
  used for topic/data_novelty.
  - Entity string still matches exactly; same-tag pure-entity/mixed discriminators stay exact; exact entity_type
  matches still validate.
  - Back-population: re-run revalidate_all_tags after deploy to link existing references (e.g.
  AGRKB:101000000900959).
  
  Tests
  
  New tests for companion creation (positive/negated/pure-entity/SGD cases) and hierarchy-aware entity_type
  validation; updated one existing count assertion (6→7).