### PR TITLE
feat(SCRUM-5819): laboratory name/strain lookup + lab_person display …

### DIFF
--- a/agr_literature_service/api/crud/laboratory_crud.py
+++ b/agr_literature_service/api/crud/laboratory_crud.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
@@ -20,8 +20,8 @@ from agr_literature_service.api.crud.user_utils import map_to_user_id
 logger = logging.getLogger(__name__)
 
 # AGRKB curie derived from the laboratory_id until MATI Laboratory support exists.
-# e.g. laboratory_id=1 -> "AGRKB:705000000000001".
-CURIE_PREFIX = "AGRKB:705"
+# e.g. laboratory_id=1 -> "AGRKB:704000000000001".
+CURIE_PREFIX = "AGRKB:704"
 
 
 def laboratory_curie_from_id(laboratory_id: int) -> str:
@@ -253,3 +253,45 @@ def show(db: Session, curie_or_laboratory_id: str) -> LaboratoryModel:
             detail=f"Laboratory with curie or laboratory_id {curie_or_laboratory_id} not found",
         )
     return obj
+
+
+def find_by_name_or_strain_designation(db: Session, query: str) -> List[LaboratoryModel]:
+    """Resolve a free-text laboratory lookup with a fixed precedence:
+
+    1. exact, case-insensitive match on strain_designation (a short code) — return
+       all such labs (normally one; more only if a code is shared);
+    2. otherwise a case-insensitive substring match on name, ordered by name;
+    3. otherwise an empty list.
+
+    Matching strain exactly (never as a substring) keeps a short code from
+    polluting name results. Each result eager-loads the same joins as show().
+    """
+    query = (query or "").strip()
+    if not query:
+        return []
+
+    options = (
+        selectinload(LaboratoryModel.cross_references),
+        selectinload(LaboratoryModel.allele_designations).selectinload(
+            LaboratoryAlleleDesignationModel.mod
+        ),
+        selectinload(LaboratoryModel.lab_persons).selectinload(LaboratoryPersonModel.person),
+    )
+
+    strain_matches = (
+        db.query(LaboratoryModel)
+        .options(*options)
+        .filter(func.lower(LaboratoryModel.strain_designation) == query.lower())
+        .order_by(LaboratoryModel.name.asc())
+        .all()
+    )
+    if strain_matches:
+        return strain_matches
+
+    return (
+        db.query(LaboratoryModel)
+        .options(*options)
+        .filter(LaboratoryModel.name.ilike(f"%{query}%"))
+        .order_by(LaboratoryModel.name.asc())
+        .all()
+    )

--- a/agr_literature_service/api/models/laboratory_model.py
+++ b/agr_literature_service/api/models/laboratory_model.py
@@ -16,7 +16,7 @@ class LaboratoryModel(Base, AuditedModel):
 
     laboratory_id = Column(Integer, primary_key=True, autoincrement=True)
 
-    # Derived from laboratory_id on create (AGRKB:705 + 12-digit pk); indexed for
+    # Derived from laboratory_id on create (AGRKB:704 + 12-digit pk); indexed for
     # lookup but intentionally not unique (no DB constraints on Laboratory fields).
     curie = Column(String(), nullable=True, index=True)
 

--- a/agr_literature_service/api/models/laboratory_person_model.py
+++ b/agr_literature_service/api/models/laboratory_person_model.py
@@ -55,5 +55,20 @@ class LaboratoryPersonModel(Base, AuditedModel):
         """Convenience for serializers — the person curie via the person FK."""
         return self.person.curie if self.person else None
 
+    @property
+    def person_display_name(self):
+        """Convenience for serializers — the person display_name via the person FK."""
+        return self.person.display_name if self.person else None
+
+    @property
+    def laboratory_name(self):
+        """Convenience for serializers — the laboratory name via the laboratory FK."""
+        return self.laboratory.name if self.laboratory else None
+
+    @property
+    def laboratory_strain_designation(self):
+        """Convenience for serializers — the laboratory strain_designation via the FK."""
+        return self.laboratory.strain_designation if self.laboratory else None
+
     def __str__(self) -> str:
         return f"laboratory_person(lab={self.laboratory_id}, person={self.person_id})"

--- a/agr_literature_service/api/routers/laboratory_router.py
+++ b/agr_literature_service/api/routers/laboratory_router.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import List, Optional, Dict, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Response, Security, status
 
@@ -59,6 +59,25 @@ def get_by_laboratory_cross_reference(
             ),
         )
     return laboratory_crud.show(db, str(lcr.laboratory_id))
+
+
+# Free-text lookup — declared BEFORE the catch-all /{curie_or_laboratory_id}.
+@router.get(
+    "/by_name_or_strain_designation",
+    response_model=List[LaboratorySchemaShow],
+    status_code=status.HTTP_200_OK,
+)
+def get_by_name_or_strain_designation(
+    query: str,
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+    db: Session = db_session,
+):
+    """Find laboratories by an exact strain_designation code or a name substring.
+
+    Precedence: an exact (case-insensitive) strain_designation match wins; otherwise
+    a case-insensitive substring match on name. Returns a (possibly empty) list.
+    """
+    return laboratory_crud.find_by_name_or_strain_designation(db, query)
 
 
 @router.delete("/{curie_or_laboratory_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/agr_literature_service/api/schemas/laboratory_person_schemas.py
+++ b/agr_literature_service/api/schemas/laboratory_person_schemas.py
@@ -43,8 +43,11 @@ class LaboratoryPersonSchemaShow(AuditedObjectModelSchema):
     laboratory_person_id: int
     laboratory_id: int
     laboratory_curie: Optional[str] = None
+    laboratory_name: Optional[str] = None
+    laboratory_strain_designation: Optional[str] = None
     person_id: int
     person_curie: Optional[str] = None
+    person_display_name: Optional[str] = None
     is_pi: Optional[datetime] = None
     former_pi: Optional[datetime] = None
     alum: Optional[datetime] = None
@@ -59,8 +62,11 @@ class LaboratoryPersonSchemaRelated(AuditedObjectModelSchema):
     laboratory_person_id: int
     laboratory_id: int
     laboratory_curie: Optional[str] = None
+    laboratory_name: Optional[str] = None
+    laboratory_strain_designation: Optional[str] = None
     person_id: int
     person_curie: Optional[str] = None
+    person_display_name: Optional[str] = None
     is_pi: Optional[datetime] = None
     former_pi: Optional[datetime] = None
     alum: Optional[datetime] = None

--- a/tests/api/test_laboratory.py
+++ b/tests/api/test_laboratory.py
@@ -64,7 +64,7 @@ class TestLaboratory:
         assert lab.email_visibility == "not_shown"
 
     def test_curie_derived_from_id(self, test_laboratory):  # noqa
-        expected = f"AGRKB:705{test_laboratory.new_laboratory_id:012d}"
+        expected = f"AGRKB:704{test_laboratory.new_laboratory_id:012d}"
         assert test_laboratory.curie == expected
 
     def test_lookup_by_curie(self, auth_headers, test_laboratory):  # noqa
@@ -200,3 +200,103 @@ class TestLaboratory:
             .filter(LaboratoryAlleleDesignationModel.allele_designation == "x")
             .count()
         ) == 0
+
+    def test_find_by_strain_designation_exact(self, auth_headers):  # noqa
+        with TestClient(app) as client:
+            client.post(
+                "/laboratory/",
+                json={"name": "Strain Exact Lab ZZQ1", "strain_designation": "QX"},
+                headers=auth_headers,
+            )
+            res = client.get(
+                "/laboratory/by_name_or_strain_designation", params={"query": "QX"}, headers=auth_headers
+            )
+            assert res.status_code == status.HTTP_200_OK
+            rows = res.json()
+            assert len(rows) == 1
+            assert rows[0]["strain_designation"] == "QX"
+            # case-insensitive
+            res2 = client.get(
+                "/laboratory/by_name_or_strain_designation", params={"query": "qx"}, headers=auth_headers
+            )
+            assert len(res2.json()) == 1
+
+    def test_find_by_strain_shared_returns_list(self, auth_headers):  # noqa
+        # A strain code shared by >1 lab returns all of them (a pick-list).
+        with TestClient(app) as client:
+            for nm in ("Shared Strain A ZZQ", "Shared Strain B ZZQ"):
+                client.post(
+                    "/laboratory/",
+                    json={"name": nm, "strain_designation": "SHX"},
+                    headers=auth_headers,
+                )
+            res = client.get(
+                "/laboratory/by_name_or_strain_designation", params={"query": "SHX"}, headers=auth_headers
+            )
+            assert res.status_code == status.HTTP_200_OK
+            assert len(res.json()) == 2
+
+    def test_find_by_name_substring_single_and_multiple(self, auth_headers):  # noqa
+        with TestClient(app) as client:
+            client.post("/laboratory/", json={"name": "Unique Kappa Lab UNIQK"}, headers=auth_headers)
+            res = client.get(
+                "/laboratory/by_name_or_strain_designation", params={"query": "UNIQK"}, headers=auth_headers
+            )
+            assert len(res.json()) == 1
+
+            client.post("/laboratory/", json={"name": "Multi MMTOKEN One"}, headers=auth_headers)
+            client.post("/laboratory/", json={"name": "Multi MMTOKEN Two"}, headers=auth_headers)
+            res2 = client.get(
+                "/laboratory/by_name_or_strain_designation", params={"query": "MMTOKEN"}, headers=auth_headers
+            )
+            assert len(res2.json()) == 2
+
+    def test_strain_exact_short_circuits_name(self, auth_headers):  # noqa
+        # One lab has the query as its strain code; another merely contains it in
+        # its name. The exact-strain match wins and the name match is not returned.
+        with TestClient(app) as client:
+            client.post(
+                "/laboratory/",
+                json={"name": "Has strain code SCQ", "strain_designation": "SCQ"},
+                headers=auth_headers,
+            )
+            client.post("/laboratory/", json={"name": "Name contains SCQ here"}, headers=auth_headers)
+            res = client.get(
+                "/laboratory/by_name_or_strain_designation", params={"query": "SCQ"}, headers=auth_headers
+            )
+            rows = res.json()
+            assert len(rows) == 1
+            assert rows[0]["strain_designation"] == "SCQ"
+
+    def test_find_no_match_empty_list(self, auth_headers):  # noqa
+        with TestClient(app) as client:
+            res = client.get(
+                "/laboratory/by_name_or_strain_designation",
+                params={"query": "NOSUCHLABTOKENXYZ"},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_200_OK
+            assert res.json() == []
+
+    def test_find_results_include_joins(self, db, auth_headers):  # noqa
+        mod = db.query(ModModel).filter(ModModel.abbreviation == "WB").one_or_none()
+        if mod is None:
+            db.add(ModModel(abbreviation="WB", short_name="WB", full_name="WormBase"))
+            db.commit()
+        with TestClient(app) as client:
+            payload = {
+                "name": "Joins Lab JNQ",
+                "strain_designation": "JNQ",
+                "cross_references": [{"curie": "WB:WBlabJNQ"}],
+                "allele_designations": [{"mod_abbreviation": "WB", "allele_designation": "j"}],
+            }
+            client.post("/laboratory/", json=payload, headers=auth_headers)
+            res = client.get(
+                "/laboratory/by_name_or_strain_designation", params={"query": "JNQ"}, headers=auth_headers
+            )
+            rows = res.json()
+            assert len(rows) == 1
+            lab = rows[0]
+            assert lab["cross_references"][0]["curie"] == "WB:WBlabJNQ"
+            assert lab["allele_designations"][0]["allele_designation"] == "j"
+            assert "lab_persons" in lab

--- a/tests/api/test_laboratory_person.py
+++ b/tests/api/test_laboratory_person.py
@@ -23,7 +23,9 @@ LabPersonTestData = namedtuple(
 
 @pytest.fixture
 def seeded_lab_and_person(db):  # noqa
-    lab = LaboratoryModel(name="People Lab", status="active", lab_is_open=False)
+    lab = LaboratoryModel(
+        name="People Lab", strain_designation="PL", status="active", lab_is_open=False
+    )
     person = PersonModel(display_name="Lab Member", curie="AGRKB:test-lab-person")
     db.add(lab)
     db.add(person)
@@ -155,6 +157,45 @@ class TestLaboratoryPerson:
             assert res.status_code == status.HTTP_200_OK
             lps = res.json().get("lab_persons") or []
             assert any(lp["laboratory_person_id"] == test_lab_person.new_id for lp in lps)
+
+    def _assert_enriched(self, row):
+        # The derived display fields surfaced for the UI.
+        assert row["person_display_name"] == "Lab Member"
+        assert row["laboratory_name"] == "People Lab"
+        assert row["laboratory_strain_designation"] == "PL"
+
+    def test_show_includes_display_fields(self, auth_headers, test_lab_person):  # noqa
+        with TestClient(app) as client:
+            res = client.get(f"/laboratory_person/{test_lab_person.new_id}", headers=auth_headers)
+            assert res.status_code == status.HTTP_200_OK
+            self._assert_enriched(res.json())
+
+    def test_list_for_person_includes_display_fields(self, auth_headers, test_lab_person):  # noqa
+        with TestClient(app) as client:
+            res = client.get(
+                f"/laboratory_person/person/{test_lab_person.person_id}", headers=auth_headers
+            )
+            assert res.status_code == status.HTTP_200_OK
+            row = next(r for r in res.json() if r["laboratory_person_id"] == test_lab_person.new_id)
+            self._assert_enriched(row)
+
+    def test_list_for_laboratory_includes_display_fields(self, auth_headers, test_lab_person):  # noqa
+        with TestClient(app) as client:
+            res = client.get(
+                f"/laboratory_person/laboratory/{test_lab_person.laboratory_id}", headers=auth_headers
+            )
+            assert res.status_code == status.HTTP_200_OK
+            row = next(r for r in res.json() if r["laboratory_person_id"] == test_lab_person.new_id)
+            self._assert_enriched(row)
+
+    def test_nested_lab_persons_include_display_fields(self, auth_headers, test_lab_person):  # noqa
+        # The lab_persons nested under Laboratory Show also carry the display fields.
+        with TestClient(app) as client:
+            res = client.get(f"/laboratory/{test_lab_person.laboratory_id}", headers=auth_headers)
+            assert res.status_code == status.HTTP_200_OK
+            lps = res.json().get("lab_persons") or []
+            row = next(lp for lp in lps if lp["laboratory_person_id"] == test_lab_person.new_id)
+            self._assert_enriched(row)
 
     def test_destroy_lab_person(self, auth_headers, test_lab_person):  # noqa
         with TestClient(app) as client:


### PR DESCRIPTION
…fields

- Fix the mock laboratory curie prefix AGRKB:705 -> AGRKB:704 (CURIE_PREFIX, doc comments, test expectation).
- Add GET /laboratory/by_name_or_strain_designation?query= backed by laboratory_crud.find_by_name_or_strain_designation: an exact case-insensitive strain_designation match wins; otherwise a case-insensitive name substring match; otherwise an empty list. Matching strain exactly keeps a short code from polluting name results. Results eager-load the same joins as show().
- Enrich laboratory_person payloads with derived person_display_name, laboratory_name, and laboratory_strain_designation (model properties added to LaboratoryPersonSchemaShow and ...Related, so the two reverse endpoints and the lab_persons nested under Laboratory all carry them).
- Tests for the lookup precedence and the new display fields.