### PR TITLE
feat(person): add privacy field to person table (SCRUM-6157)

### DIFF
--- a/agr_literature_service/api/crud/person_crud.py
+++ b/agr_literature_service/api/crud/person_crud.py
@@ -264,7 +264,7 @@ def patch(db: Session, curie_or_person_id: str, patch_dict: Dict[str, Any]) -> D
 
     ALLOWED = {
         "display_name", "mod_roles", "institution",
-        "webpage", "active_status",
+        "webpage", "active_status", "privacy",
         "city", "state", "postal_code", "country", "street_address",
         "biography_research_interest",
         "unsubscribe",

--- a/agr_literature_service/api/models/person_model.py
+++ b/agr_literature_service/api/models/person_model.py
@@ -28,6 +28,12 @@ class PersonModel(Base, AuditedModel):
         default="active",
         server_default="active",
     )
+    privacy = Column(
+        String(),
+        nullable=False,
+        default="hide_email",
+        server_default="hide_email",
+    )
 
     # Address fields
     city = Column(String(), nullable=True)
@@ -68,6 +74,10 @@ class PersonModel(Base, AuditedModel):
         CheckConstraint(
             "active_status IN ('active', 'retired', 'deceased')",
             name="ck_person_active_status",
+        ),
+        CheckConstraint(
+            "privacy IN ('show_all', 'logged_in_only', 'fully_hidden', 'hide_email')",
+            name="ck_person_privacy",
         ),
     )
 

--- a/agr_literature_service/api/schemas/person_schemas.py
+++ b/agr_literature_service/api/schemas/person_schemas.py
@@ -15,6 +15,7 @@ from .person_note_schemas import PersonNoteSchemaCreate, PersonNoteSchemaRelated
 from .laboratory_person_schemas import LaboratoryPersonSchemaRelated
 
 ActiveStatus = Literal["active", "retired", "deceased"]
+Privacy = Literal["show_all", "logged_in_only", "fully_hidden", "hide_email"]
 
 
 class PersonSchemaPost(BaseModel):
@@ -26,6 +27,7 @@ class PersonSchemaPost(BaseModel):
     institution: Optional[List[str]] = None
     webpage: Optional[List[str]] = None
     active_status: ActiveStatus = "active"
+    privacy: Privacy = "hide_email"
     city: Optional[str] = None
     state: Optional[str] = None
     postal_code: Optional[str] = None
@@ -53,6 +55,7 @@ class PersonSchemaUpdate(BaseModel):
     institution: Optional[List[str]] = None
     webpage: Optional[List[str]] = None
     active_status: Optional[ActiveStatus] = None
+    privacy: Optional[Privacy] = None
     city: Optional[str] = None
     state: Optional[str] = None
     postal_code: Optional[str] = None
@@ -72,6 +75,7 @@ class PersonSchemaShow(AuditedObjectModelSchema):
     institution: Optional[List[str]] = None
     webpage: Optional[List[str]] = None
     active_status: str = "active"
+    privacy: str = "hide_email"
     city: Optional[str] = None
     state: Optional[str] = None
     postal_code: Optional[str] = None

--- a/alembic/versions/20260622_c4d5e6f7a8b9_add_privacy_to_person.py
+++ b/alembic/versions/20260622_c4d5e6f7a8b9_add_privacy_to_person.py
@@ -1,0 +1,81 @@
+"""add_privacy_to_person
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-06-22
+
+Adds privacy column to person and person_version tables (controlled
+vocabulary: show_all / logged_in_only / fully_hidden / hide_email,
+default hide_email).
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect as sa_inspect
+
+revision = "c4d5e6f7a8b9"
+down_revision = "b3c4d5e6f7a8"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table, column):
+    """Check if a column exists on the given table."""
+    bind = op.get_bind()
+    insp = sa_inspect(bind)
+    columns = [col["name"] for col in insp.get_columns(table)]
+    return column in columns
+
+
+def _constraint_exists(table, name):
+    """Check if a check constraint exists on the given table."""
+    bind = op.get_bind()
+    insp = sa_inspect(bind)
+    for con in insp.get_check_constraints(table):
+        if con["name"] == name:
+            return True
+    return False
+
+
+def upgrade():
+    # 1. Add privacy column to person
+    if not _column_exists("person", "privacy"):
+        op.add_column(
+            "person",
+            sa.Column("privacy", sa.String(), nullable=False,
+                      server_default="hide_email"))
+
+    # 2. Add privacy and privacy_mod columns to person_version
+    if not _column_exists("person_version", "privacy"):
+        op.add_column(
+            "person_version",
+            sa.Column("privacy", sa.String(),
+                      autoincrement=False, nullable=True))
+    if not _column_exists("person_version", "privacy_mod"):
+        op.add_column(
+            "person_version",
+            sa.Column("privacy_mod", sa.Boolean(),
+                      server_default=sa.text("false"),
+                      nullable=False))
+
+    # 3. Add check constraint for the controlled vocabulary
+    if not _constraint_exists("person", "ck_person_privacy"):
+        op.create_check_constraint(
+            "ck_person_privacy",
+            "person",
+            "privacy IN ('show_all', 'logged_in_only', 'fully_hidden', 'hide_email')")
+
+
+def downgrade():
+    # 1. Drop check constraint
+    if _constraint_exists("person", "ck_person_privacy"):
+        op.drop_constraint("ck_person_privacy", "person", type_="check")
+
+    # 2. Drop version columns
+    if _column_exists("person_version", "privacy_mod"):
+        op.drop_column("person_version", "privacy_mod")
+    if _column_exists("person_version", "privacy"):
+        op.drop_column("person_version", "privacy")
+
+    # 3. Drop privacy column
+    if _column_exists("person", "privacy"):
+        op.drop_column("person", "privacy")

--- a/tests/api/test_person_fields.py
+++ b/tests/api/test_person_fields.py
@@ -245,7 +245,7 @@ class TestPersonFields:
             fetched = client.get(f"/person/{person_id}", headers=auth_headers)
             body = fetched.json()
             # All new fields should be present
-            for field in ["webpage", "active_status", "city", "state",
+            for field in ["webpage", "active_status", "privacy", "city", "state",
                           "postal_code", "country", "street_address",
                           "address_last_updated", "biography_research_interest"]:
                 assert field in body, f"Missing field: {field}"
@@ -304,6 +304,8 @@ class TestPersonFields:
             assert body["webpage"] is None
             # active_status is NOT NULL with default "active"
             assert body["active_status"] == "active"
+            # privacy is NOT NULL with default "hide_email"
+            assert body["privacy"] == "hide_email"
             assert body["city"] is None
             assert body["state"] is None
             assert body["postal_code"] is None
@@ -376,6 +378,78 @@ class TestPersonFields:
                 person_id = client.get(f"/person/{res.json()['curie']}", headers=auth_headers).json()["person_id"]
                 fetched = client.get(f"/person/{person_id}", headers=auth_headers)
                 assert fetched.json()["active_status"] == status_value
+
+    def test_create_person_with_privacy(self, auth_headers):  # noqa
+        with TestClient(app) as client:
+            payload = {
+                "display_name": "Privacy Person",
+                "privacy": "show_all",
+            }
+            res = client.post("/person/", json=payload, headers=auth_headers)
+            assert res.status_code == status.HTTP_201_CREATED
+            person_id = client.get(f"/person/{res.json()['curie']}", headers=auth_headers).json()["person_id"]
+
+            fetched = client.get(f"/person/{person_id}", headers=auth_headers)
+            assert fetched.json()["privacy"] == "show_all"
+
+    def test_patch_privacy(self, auth_headers, test_person_id):  # noqa
+        with TestClient(app) as client:
+            res = client.patch(
+                f"/person/{test_person_id}",
+                json={"privacy": "fully_hidden"},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_200_OK
+
+            fetched = client.get(f"/person/{test_person_id}", headers=auth_headers)
+            assert fetched.json()["privacy"] == "fully_hidden"
+
+    def test_privacy_default_hide_email(self, auth_headers):  # noqa
+        """privacy defaults to hide_email when omitted."""
+        with TestClient(app) as client:
+            res = client.post(
+                "/person/",
+                json={"display_name": "Default Privacy Person"},
+                headers=auth_headers,
+            )
+            person_id = client.get(f"/person/{res.json()['curie']}", headers=auth_headers).json()["person_id"]
+
+            fetched = client.get(f"/person/{person_id}", headers=auth_headers)
+            assert fetched.json()["privacy"] == "hide_email"
+
+    def test_privacy_invalid_value_rejected(self, auth_headers):  # noqa
+        """Pydantic Literal should reject privacy values outside the vocabulary."""
+        with TestClient(app) as client:
+            res = client.post(
+                "/person/",
+                json={"display_name": "Bad Privacy", "privacy": "invalid_value"},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_patch_invalid_privacy_rejected(self, auth_headers, test_person_id):  # noqa
+        """PATCH with invalid privacy should be rejected at Pydantic layer."""
+        with TestClient(app) as client:
+            res = client.patch(
+                f"/person/{test_person_id}",
+                json={"privacy": "public"},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_privacy_all_values(self, auth_headers):  # noqa
+        """All four allowed privacy values should be accepted."""
+        with TestClient(app) as client:
+            for privacy_value in ["show_all", "logged_in_only", "fully_hidden", "hide_email"]:
+                res = client.post(
+                    "/person/",
+                    json={"display_name": f"Privacy {privacy_value}", "privacy": privacy_value},
+                    headers=auth_headers,
+                )
+                assert res.status_code == status.HTTP_201_CREATED
+                person_id = client.get(f"/person/{res.json()['curie']}", headers=auth_headers).json()["person_id"]
+                fetched = client.get(f"/person/{person_id}", headers=auth_headers)
+                assert fetched.json()["privacy"] == privacy_value
 
     def test_create_person_with_fields_and_inline_collections(self, auth_headers):  # noqa
         """POST /person/ with all person fields AND inline names, emails, cross_references, notes."""


### PR DESCRIPTION
## Summary

Adds a controlled-vocabulary `privacy` field to the `person` table so researchers can control what is visible when their person record is displayed publicly.

Jira: [SCRUM-6157](https://agr-jira.atlassian.net/browse/SCRUM-6157) (parent epic SCRUM-5295 "Store person and author connections in ABC").

**Values:** `show_all` / `logged_in_only` / `fully_hidden` / `hide_email` — **default `hide_email`**. Modeled on the existing `active_status` field (plain `String` column + DB `CheckConstraint` + Pydantic `Literal`).

> Scope is limited to adding/exposing the field. The actual public-display filtering/enforcement that hides data based on the value is left to a separate ticket.

## Changes

- **`person_model.py`** — `privacy` column (`nullable=False`, default/server_default `hide_email`) + `ck_person_privacy` CheckConstraint
- **`person_schemas.py`** — `Privacy` Literal added to `PersonSchemaPost`, `PersonSchemaUpdate`, `PersonSchemaShow`
- **`person_crud.py`** — `"privacy"` added to the `patch()` `ALLOWED` set
- **Alembic migration** — adds the column to `person` and `person_version`, adds the `privacy_mod` tracking column, and creates the check constraint (idempotent, with `downgrade()`); chained from head `b3c4d5e6f7a8`
- **`test_person_fields.py`** — 6 new tests (create / patch / default / invalid-on-create / invalid-on-patch / all-values) + updated default and show-fields assertions

## Verification

- ✅ flake8 (project config) and mypy clean on changed package files
- ✅ `alembic heads` — single head, migration correctly chained
- ✅ `pytest tests/api/test_person_fields.py` — all privacy tests pass (the 3 unrelated failures only occur when running this file in isolation against a fresh empty DB, a pre-existing fixture-ordering quirk; they pass once the schema exists, as in the full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6157]: https://agr-jira.atlassian.net/browse/SCRUM-6157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ