### PR TITLE
add batch /by_references endpoint to speed up the Topic grid

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -15,7 +15,7 @@ from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
 from sqlalchemy import case, and_, create_engine, text
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, joinedload, sessionmaker, noload
+from sqlalchemy.orm import Session, joinedload, selectinload, sessionmaker, noload
 
 from agr_literature_service.api.crud.topic_entity_tag_utils import get_reference_id_from_curie_or_id, \
     get_source_from_db, add_source_obj_to_db_session, get_sorted_column_values, \
@@ -1034,9 +1034,16 @@ def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1, p
         distinct_values = [x[0] for x in distinct_column_values if x[0] is not None]
         return jsonable_encoder(distinct_values)
 
+    # Eager-load validated_by: add_list_of_users_who_validated_tag /
+    # add_list_of_validating_tag_ids read it for every tag, so without this it
+    # lazy-loads once per tag (N+1) -- the dominant server-side cost when the
+    # batch endpoint runs this for many references. selectinload (one extra
+    # query for the whole result set) is limit-safe, unlike a collection
+    # joinedload.
     query = db.query(TopicEntityTagModel).options(
         joinedload(TopicEntityTagModel.topic_entity_tag_source),
-        joinedload(TopicEntityTagModel.ml_model)).filter(
+        joinedload(TopicEntityTagModel.ml_model),
+        selectinload(TopicEntityTagModel.validated_by)).filter(
         TopicEntityTagModel.reference_id == reference_id)
 
     if column_filter and column_values:

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -7,7 +7,7 @@ import logging
 from typing import Optional
 from collections import defaultdict
 from os import environ
-from typing import Dict, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 from datetime import datetime, timedelta
 
 from dateutil import parser as date_parser
@@ -1137,6 +1137,28 @@ def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1, p
             all_tet.append(tet_data)
         curie_to_name = get_curie_to_name_from_all_tets(db, curie_or_reference_id)
         return [get_tet_with_names(db, tag, curie_to_name) for tag in all_tet]
+
+
+def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids: List[str]):
+    """Batch variant of show_all_reference_tags.
+
+    Returns a map of each input identifier -> its full TET list, reusing the
+    single-reference logic so the per-tag enrichment (display names, validated_by,
+    ml_model version, etc.) is identical. This lets the TET validation grid fetch
+    every reference's tags for a search page in ONE request instead of firing one
+    HTTP call per reference (the previous per-row fan-out was the grid's main
+    bottleneck). Unresolvable identifiers map to an empty list, mirroring the
+    per-row endpoint's behavior so a single bad id never fails the whole batch.
+    """
+    result: Dict[str, Any] = {}
+    for ident in curies_or_reference_ids:
+        if ident in result:
+            continue
+        try:
+            result[ident] = show_all_reference_tags(db, ident)
+        except HTTPException:
+            result[ident] = []
+    return result
 
 
 def get_all_topic_entity_tags_by_mod(db: Session, mod_abbreviation: str, days_updated: int = 7):

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1012,7 +1012,7 @@ def check_for_duplicate_tags(db: Session, topic_entity_tag_data: dict, source: T
     return None
 
 
-def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1, page_size: int = None, count_only: bool = False, sort_by: str = None, desc_sort: bool = False, column_only: str = None, column_filter: str = None, column_values: str = None):      # noqa: C901
+def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1, page_size: int = None, count_only: bool = False, sort_by: str = None, desc_sort: bool = False, column_only: str = None, column_filter: str = None, column_values: str = None, curie_to_name: dict = None):      # noqa: C901
 
     if page < 1:
         page = 1
@@ -1135,7 +1135,10 @@ def show_all_reference_tags(db: Session, curie_or_reference_id, page: int = 1, p
             if tet.ml_model:
                 tet_data["ml_model_version"] = tet.ml_model.version_num
             all_tet.append(tet_data)
-        curie_to_name = get_curie_to_name_from_all_tets(db, curie_or_reference_id)
+        # Callers (e.g. the batch endpoint) may supply a precomputed map built
+        # once across many references, to avoid the per-reference external lookups.
+        if curie_to_name is None:
+            curie_to_name = get_curie_to_name_from_all_tets(db, curie_or_reference_id)
         return [get_tet_with_names(db, tag, curie_to_name) for tag in all_tet]
 
 
@@ -1149,15 +1152,32 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
     HTTP call per reference (the previous per-row fan-out was the grid's main
     bottleneck). Unresolvable identifiers map to an empty list, mirroring the
     per-row endpoint's behavior so a single bad id never fails the whole batch.
+
+    The curie->name resolution (external A-team lookups) is done ONCE across the
+    union of every reference's tags, rather than once per reference -- otherwise
+    the batch would just serialize the same N x external-call fan-out into a
+    single long request and end up slower than the old concurrent per-row calls.
     """
-    result: Dict[str, Any] = {}
+    # Resolve each identifier to a reference_id once (None if unresolvable).
+    ident_to_ref_id: Dict[str, Any] = {}
     for ident in curies_or_reference_ids:
-        if ident in result:
+        if ident in ident_to_ref_id:
             continue
         try:
-            result[ident] = show_all_reference_tags(db, ident)
+            ident_to_ref_id[ident] = get_reference_id_from_curie_or_id(db, ident)
         except HTTPException:
+            ident_to_ref_id[ident] = None
+
+    # One name map for the union of all references' tags (the expensive part).
+    ref_ids = [rid for rid in ident_to_ref_id.values() if rid is not None]
+    curie_to_name = get_curie_to_name_from_references(db, ref_ids)
+
+    result: Dict[str, Any] = {}
+    for ident, ref_id in ident_to_ref_id.items():
+        if ref_id is None:
             result[ident] = []
+        else:
+            result[ident] = show_all_reference_tags(db, ident, curie_to_name=curie_to_name)
     return result
 
 
@@ -1222,6 +1242,24 @@ def get_curie_to_name_mapping_for_mod(db, mod_abbreviation, last_date_updated):
 def get_curie_to_name_from_all_tets(db: Session, curie_or_reference_id: str):
     reference_id = get_reference_id_from_curie_or_id(db, curie_or_reference_id)
     ref_related_tets = db.query(TopicEntityTagModel).filter(TopicEntityTagModel.reference_id == reference_id).all()
+    return build_curie_to_name_map(db, ref_related_tets)
+
+
+def get_curie_to_name_from_references(db: Session, reference_ids: List[int]):
+    """Build ONE curie->name map for the union of all tags across many
+    references. The external A-team name lookups (atpterm / ecoterm / species /
+    entity) are the expensive part, so resolving the union once -- instead of
+    once per reference -- is what makes the batch endpoint actually faster than
+    the old per-reference fan-out."""
+    if not reference_ids:
+        return {}
+    ref_related_tets = db.query(TopicEntityTagModel).options(
+        joinedload(TopicEntityTagModel.topic_entity_tag_source)).filter(
+        TopicEntityTagModel.reference_id.in_(reference_ids)).all()
+    return build_curie_to_name_map(db, ref_related_tets)
+
+
+def build_curie_to_name_map(db: Session, ref_related_tets):
     all_atp_terms = set()
     entity_id_validation_entity_type_entities: Dict[str, Dict[str, Set[str]]] = defaultdict(lambda: defaultdict(set))
     all_entity_curies = set()

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -165,6 +165,14 @@ def show_all_reference_tags(
     return result
 
 
+# Each reference in the batch runs the full per-reference resolution (DB query
+# plus external curie->name lookups), so the work is N x a single fetch. Cap the
+# batch to bound worst-case latency / avoid gateway timeouts. The grid only ever
+# sends one search page (max 100 results, chunked at 50 per request), so this is
+# comfortable headroom above any legitimate request.
+MAX_BATCH_REFERENCES = 100
+
+
 @router.post('/by_references',
              status_code=200)
 def show_all_reference_tags_batch(
@@ -175,6 +183,13 @@ def show_all_reference_tags_batch(
     """Return all TETs for many references in one request, keyed by the input
     identifier. Used by the TET validation grid to avoid one HTTP round-trip per
     reference (see show_all_reference_tags_for_references)."""
+    if len(curies_or_reference_ids) > MAX_BATCH_REFERENCES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Too many references in one batch "
+                   f"({len(curies_or_reference_ids)} > {MAX_BATCH_REFERENCES}); "
+                   f"split into smaller requests."
+        )
     return topic_entity_tag_crud.show_all_reference_tags_for_references(
         db, curies_or_reference_ids
     )

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -2,7 +2,7 @@ from multiprocessing import Process, Value
 from typing import List, Dict, Union, Any, Optional
 
 from agr_cognito_py import get_mod_access
-from fastapi import APIRouter, Depends, Query, Response, Security, status, HTTPException
+from fastapi import APIRouter, Body, Depends, Query, Response, Security, status, HTTPException
 from sqlalchemy.orm import Session
 
 from agr_literature_service.api import database
@@ -163,6 +163,21 @@ def show_all_reference_tags(
         column_values
     )
     return result
+
+
+@router.post('/by_references',
+             status_code=200)
+def show_all_reference_tags_batch(
+    curies_or_reference_ids: List[str] = Body(..., embed=False),
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+    db: Session = db_session
+) -> Dict[str, List[TopicEntityTagSchemaRelated]]:
+    """Return all TETs for many references in one request, keyed by the input
+    identifier. Used by the TET validation grid to avoid one HTTP round-trip per
+    reference (see show_all_reference_tags_for_references)."""
+    return topic_entity_tag_crud.show_all_reference_tags_for_references(
+        db, curies_or_reference_ids
+    )
 
 
 @router.get('/by_mod/{mod_abbreviation}',

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -110,6 +110,26 @@ class TestTopicEntityTag:
             for key, value in expected_fields.items():
                 assert resp_data[key] == value
 
+    def test_show_all_reference_tags_batch(self, test_topic_entity_tag, auth_headers):  # noqa
+        with TestClient(app) as client:
+            ref_curie = test_topic_entity_tag.related_ref_curie
+            response = client.post(
+                url="/topic_entity_tag/by_references",
+                json=[ref_curie, "AGRKB:000000000"],
+                headers=auth_headers,
+            )
+            assert response.status_code == status.HTTP_200_OK
+            data = response.json()
+            # the known reference returns its tag(s)
+            assert ref_curie in data
+            assert len(data[ref_curie]) >= 1
+            assert any(
+                t["topic_entity_tag_id"] == int(test_topic_entity_tag.new_tet_id)
+                for t in data[ref_curie]
+            )
+            # an unresolvable id maps to an empty list rather than failing the batch
+            assert data.get("AGRKB:000000000") == []
+
     def test_patch(self, test_topic_entity_tag, auth_headers): # noqa
         with TestClient(app) as client:
             patch_data = {

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -130,6 +130,15 @@ class TestTopicEntityTag:
             # an unresolvable id maps to an empty list rather than failing the batch
             assert data.get("AGRKB:000000000") == []
 
+    def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa
+        with TestClient(app) as client:
+            response = client.post(
+                url="/topic_entity_tag/by_references",
+                json=[f"AGRKB:{i}" for i in range(101)],
+                headers=auth_headers,
+            )
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     def test_patch(self, test_topic_entity_tag, auth_headers): # noqa
         with TestClient(app) as client:
             patch_data = {

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -111,10 +111,13 @@ class TestTopicEntityTag:
                 assert resp_data[key] == value
 
     def test_show_all_reference_tags_batch(self, test_topic_entity_tag, auth_headers):  # noqa
+        # The batch endpoint resolves names once across the union of all
+        # references via get_curie_to_name_from_references, so patch that to
+        # avoid the external A-team lookups.
         with TestClient(app) as client, \
-                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
-                mock_get_curie_to_name_from_all_tets:
-            mock_get_curie_to_name_from_all_tets.return_value = {
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_references") as \
+                mock_get_curie_to_name_from_references:
+            mock_get_curie_to_name_from_references.return_value = {
                 'ATP:0000122': 'ATP:0000122', 'ATP:0000005': 'gene',
                 'WB:WBGene00003001': 'lin-12', 'NCBITaxon:6239': 'Caenorhabditis elegans'
             }

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -111,7 +111,13 @@ class TestTopicEntityTag:
                 assert resp_data[key] == value
 
     def test_show_all_reference_tags_batch(self, test_topic_entity_tag, auth_headers):  # noqa
-        with TestClient(app) as client:
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
+                mock_get_curie_to_name_from_all_tets:
+            mock_get_curie_to_name_from_all_tets.return_value = {
+                'ATP:0000122': 'ATP:0000122', 'ATP:0000005': 'gene',
+                'WB:WBGene00003001': 'lin-12', 'NCBITaxon:6239': 'Caenorhabditis elegans'
+            }
             ref_curie = test_topic_entity_tag.related_ref_curie
             response = client.post(
                 url="/topic_entity_tag/by_references",


### PR DESCRIPTION
The TET validation (Topic) grid fetched tags with **one HTTP call per reference**
(`GET /topic_entity_tag/by_reference/{curie}`) — the grid's main performance bottleneck on a full search page. This adds a batch endpoint so the grid can fetch every reference's tags in a single request.