### PR TITLE
feat(api): load resource descriptors from A-Team with YAML fallback (SCRUM-5992)

### DIFF
--- a/agr_literature_service/api/initialize.py
+++ b/agr_literature_service/api/initialize.py
@@ -4,6 +4,7 @@ import sys
 import urllib.request
 from urllib.error import URLError
 from urllib.parse import urlparse
+from typing import Any, Dict, List, Optional
 import yaml
 import logging
 from sqlalchemy.orm import Session
@@ -29,16 +30,99 @@ def initialize_database():
     db_session = next(get_db(), None)
 
 
-def update_resource_descriptor(db: Session = None):
-    """
-    Fetch the YAML at RESOURCE_DESCRIPTOR_URL and reload the
-    ResourceDescriptorModel + ResourceDescriptorPageModel tables.
-    """
-    if db is None:
-        db = db_session
+def _first(rd: Dict[str, Any], *keys: str) -> Any:
+    """Return the first present, non-null value among the given keys."""
+    for key in keys:
+        val = rd.get(key)
+        if val is not None:
+            return val
+    return None
 
+
+def _normalize_ateam_descriptor(rd: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """
+    Map a single A-Team resource-descriptor object to the canonical shape
+    expected by ``_load_descriptors_into_db`` (the same shape the agr_schemas
+    YAML produces): keys are ResourceDescriptor model columns plus ``pages``
+    as a list of ``{"name", "url"}`` dicts.
+
+    A-Team field names are confirmed against the agr_curation source
+    (ResourceDescriptor / ResourceDescriptorPage entities, SCRUM-5992):
+        prefix -> db_prefix, name -> name, synonyms -> aliases,
+        idExample -> example_gid, idPattern -> gid_pattern,
+        defaultUrlTemplate -> default_url,
+        resourcePages[{name, urlTemplate}] -> pages[{name, url}].
+
+    IMPORTANT: these fields (synonyms, idPattern, idExample, resourcePages) are
+    NOT in the default ``ForPublic`` JSON view, so the client must request the
+    findForPublic endpoint with ``view=ResourceDescriptorView`` (see
+    ``_fetch_descriptors_from_ateam``). The canonical YAML keys are kept as
+    fallbacks so this stays correct regardless of source quirks.
+    """
+    db_prefix = _first(rd, "prefix", "db_prefix")
+    if not db_prefix:
+        # db_prefix is required (unique, NOT NULL); skip unusable entries.
+        return None
+
+    pages_raw = _first(rd, "resourcePages", "pages") or []
+    pages: List[Dict[str, Any]] = []
+    for p in pages_raw:
+        if not isinstance(p, dict):
+            continue
+        pages.append({
+            "name": _first(p, "name"),
+            "url": _first(p, "urlTemplate", "url"),
+        })
+
+    normalized: Dict[str, Any] = {
+        "db_prefix": db_prefix,
+        "name": _first(rd, "name", "fullName"),
+        "aliases": _first(rd, "aliases", "synonyms"),
+        "example_gid": _first(rd, "idExample", "example_gid", "example_id"),
+        "gid_pattern": _first(rd, "idPattern", "gid_pattern"),
+        "default_url": _first(rd, "defaultUrlTemplate", "default_url"),
+        "pages": pages,
+    }
+    return normalized
+
+
+def _fetch_descriptors_from_ateam() -> List[Dict[str, Any]]:
+    """
+    Fetch resource descriptors from the A-Team curation API via the shared
+    ``agr_curation_api`` client and normalize them to the canonical shape.
+
+    The client's ``get_resource_descriptors()`` must call
+    ``POST /api/resourcedescriptor/findForPublic`` with
+    ``view=ResourceDescriptorView`` (the default ``ForPublic`` view omits
+    resourcePages / synonyms / idPattern / idExample that ABC needs) and a
+    ``limit`` large enough to return all descriptors in one page.
+
+    Raises on any failure (import/attribute/API error) so the caller can fall
+    back to the YAML source.
+    """
+    # Lazy import so module import never depends on the client being present.
+    from agr_curation_api import AGRCurationAPIClient  # type: ignore
+
+    client = AGRCurationAPIClient()
+    raw_descriptors = client.get_resource_descriptors() or []
+
+    normalized: List[Dict[str, Any]] = []
+    for rd in raw_descriptors:
+        if not isinstance(rd, dict):
+            continue
+        entry = _normalize_ateam_descriptor(rd)
+        if entry is not None:
+            normalized.append(entry)
+    return normalized
+
+
+def _fetch_descriptors_from_yaml() -> List[Dict[str, Any]]:
+    """
+    Fetch resource descriptors from the GitHub YAML at RESOURCE_DESCRIPTOR_URL.
+    This is the fallback source during the transition to the A-Team SOT.
+    """
     raw = config.RESOURCE_DESCRIPTOR_URL or ""
-    # strip whitespace and any angle‑brackets or quotes
+    # strip whitespace and any angle-brackets or quotes
     url = raw.strip().strip("<>'\" ")
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
@@ -51,33 +135,7 @@ def update_resource_descriptor(db: Session = None):
         with urllib.request.urlopen(url) as resp:
             # read + decode before passing to yaml
             body = resp.read().decode("utf-8")
-            descriptors = yaml.full_load(body)
-
-        # clear out old descriptors
-        db.query(ResourceDescriptorModel).delete()
-
-        for rd in descriptors:
-            data = {}
-            pages = []
-            for key, val in rd.items():
-                if key == "pages":
-                    for p in val:
-                        page = ResourceDescriptorPageModel(
-                            name=p.get("name"),
-                            url=p.get("url")
-                        )
-                        db.add(page)
-                        pages.append(page)
-                    data["pages"] = pages
-                elif key == "example_id":
-                    data["example_gid"] = val
-                else:
-                    data[key] = val
-
-            obj = ResourceDescriptorModel(**data)
-            db.add(obj)
-
-        db.commit()
+            return yaml.full_load(body)
     except URLError as e:
         logger.error(f"Could not fetch resource descriptor from {url}: {e}")
         sys.exit(-1)
@@ -85,6 +143,62 @@ def update_resource_descriptor(db: Session = None):
         logger.error(f"Unable to process resource_descriptor '{url}': {e}")
         sys.exit(-1)
 
+
+def _load_descriptors_into_db(db: Session, descriptors: List[Dict[str, Any]]) -> None:
+    """
+    Replace the ResourceDescriptorModel + ResourceDescriptorPageModel tables
+    with the given list of (canonical-shape) descriptor dicts.
+    """
+    # clear out old descriptors
+    db.query(ResourceDescriptorModel).delete()
+
+    for rd in descriptors:
+        data: Dict[str, Any] = {}
+        pages = []
+        for key, val in rd.items():
+            if key == "pages":
+                for p in val:
+                    page = ResourceDescriptorPageModel(
+                        name=p.get("name"),
+                        url=p.get("url")
+                    )
+                    db.add(page)
+                    pages.append(page)
+                data["pages"] = pages
+            elif key == "example_id":
+                data["example_gid"] = val
+            else:
+                data[key] = val
+
+        obj = ResourceDescriptorModel(**data)
+        db.add(obj)
+
+    db.commit()
+
+
+def update_resource_descriptor(db: Session = None):
+    """
+    Reload the ResourceDescriptorModel + ResourceDescriptorPageModel tables.
+
+    The A-Team curation API is the source of truth; fetch from there first and
+    fall back to the agr_schemas YAML (RESOURCE_DESCRIPTOR_URL) if the A-Team
+    fetch fails or returns nothing.
+    """
+    if db is None:
+        db = db_session
+
+    try:
+        descriptors = _fetch_descriptors_from_ateam()
+        if not descriptors:
+            raise ValueError("A-Team returned no resource descriptors")
+        logger.info("Loaded %d resource descriptors from A-Team", len(descriptors))
+    except Exception as e:
+        logger.warning(
+            "A-Team resource descriptor fetch failed (%s); falling back to YAML", e
+        )
+        descriptors = _fetch_descriptors_from_yaml()
+
+    _load_descriptors_into_db(db, descriptors)
     return descriptors
 
 

--- a/tests/api/test_resource_descriptor.py
+++ b/tests/api/test_resource_descriptor.py
@@ -1,8 +1,43 @@
+from unittest import mock
+
 from starlette.testclient import TestClient
 from fastapi import status
 
+import agr_literature_service.api.initialize as initialize
 from agr_literature_service.api.main import app
+from agr_literature_service.api.models.resource_descriptor_models import (
+    ResourceDescriptorModel,
+)
+from ..fixtures import db  # noqa
 from .fixtures import auth_headers  # noqa
+
+
+# A sample A-Team `findForPublic` style descriptor (camelCase keys).
+ATEAM_SAMPLE = [
+    {
+        "prefix": "TESTMOD",
+        "name": "Test Mod",
+        "synonyms": ["TM", "TMOD"],
+        "idExample": "TESTMOD:123",
+        "idPattern": r"^TESTMOD:\d+$",
+        "defaultUrlTemplate": "http://test.org/[%s]",
+        "resourcePages": [
+            {"name": "gene", "urlTemplate": "http://test.org/gene/[%s]"},
+            {"name": "homepage", "urlTemplate": "http://test.org/"},
+        ],
+    }
+]
+
+# A sample agr_schemas YAML style descriptor (canonical keys, with example_id).
+YAML_SAMPLE = [
+    {
+        "db_prefix": "YAMLMOD",
+        "name": "Yaml Mod",
+        "example_id": "YAMLMOD:9",
+        "default_url": "http://yaml.org/[%s]",
+        "pages": [{"name": "homepage", "url": "http://yaml.org/"}],
+    }
+]
 
 
 class TestResourceDescriptor:
@@ -11,3 +46,66 @@ class TestResourceDescriptor:
         with TestClient(app) as client:
             response = client.get(url="/resource_descriptor", headers=auth_headers)
             assert response.status_code == status.HTTP_200_OK
+
+    def test_normalize_ateam_descriptor(self):
+        normalized = initialize._normalize_ateam_descriptor(ATEAM_SAMPLE[0])
+        assert normalized == {
+            "db_prefix": "TESTMOD",
+            "name": "Test Mod",
+            "aliases": ["TM", "TMOD"],
+            "example_gid": "TESTMOD:123",
+            "gid_pattern": r"^TESTMOD:\d+$",
+            "default_url": "http://test.org/[%s]",
+            "pages": [
+                {"name": "gene", "url": "http://test.org/gene/[%s]"},
+                {"name": "homepage", "url": "http://test.org/"},
+            ],
+        }
+
+    def test_normalize_ateam_descriptor_skips_without_prefix(self):
+        assert initialize._normalize_ateam_descriptor({"name": "no prefix"}) is None
+
+    def test_load_from_ateam(self, db):  # noqa
+        with mock.patch("agr_curation_api.AGRCurationAPIClient") as MockClient:
+            MockClient.return_value.get_resource_descriptors.return_value = ATEAM_SAMPLE
+            initialize.update_resource_descriptor(db)
+
+        rd = db.query(ResourceDescriptorModel).filter_by(db_prefix="TESTMOD").one()
+        assert rd.name == "Test Mod"
+        assert rd.aliases == ["TM", "TMOD"]
+        assert rd.example_gid == "TESTMOD:123"
+        assert rd.gid_pattern == r"^TESTMOD:\d+$"
+        assert rd.default_url == "http://test.org/[%s]"
+        pages = sorted(rd.pages, key=lambda p: p.name)
+        assert [(p.name, p.url) for p in pages] == [
+            ("gene", "http://test.org/gene/[%s]"),
+            ("homepage", "http://test.org/"),
+        ]
+
+    def test_fallback_to_yaml_on_ateam_error(self, db):  # noqa
+        with mock.patch.object(
+            initialize, "_fetch_descriptors_from_ateam",
+            side_effect=RuntimeError("boom")
+        ), mock.patch.object(
+            initialize, "_fetch_descriptors_from_yaml",
+            return_value=YAML_SAMPLE
+        ) as yaml_mock:
+            initialize.update_resource_descriptor(db)
+            yaml_mock.assert_called_once()
+
+        rd = db.query(ResourceDescriptorModel).filter_by(db_prefix="YAMLMOD").one()
+        # example_id should be mapped onto the example_gid column.
+        assert rd.example_gid == "YAMLMOD:9"
+        assert rd.default_url == "http://yaml.org/[%s]"
+        assert [(p.name, p.url) for p in rd.pages] == [("homepage", "http://yaml.org/")]
+
+    def test_fallback_to_yaml_when_ateam_empty(self, db):  # noqa
+        with mock.patch.object(
+            initialize, "_fetch_descriptors_from_ateam", return_value=[]
+        ), mock.patch.object(
+            initialize, "_fetch_descriptors_from_yaml", return_value=YAML_SAMPLE
+        ) as yaml_mock:
+            initialize.update_resource_descriptor(db)
+            yaml_mock.assert_called_once()
+
+        assert db.query(ResourceDescriptorModel).filter_by(db_prefix="YAMLMOD").one()


### PR DESCRIPTION
## Summary
A-Team is becoming the source of truth for resource descriptors. This loads them from the A-Team curation API at startup / `PUT /resource_descriptor/` reload, falling back to the existing agr_schemas YAML during the transition.

- Refactors `api/initialize.py`:
  - `_fetch_descriptors_from_ateam()` — calls `AGRCurationAPIClient().get_resource_descriptors()` and normalizes A-Team fields → ResourceDescriptor model.
  - `_fetch_descriptors_from_yaml()` — existing GitHub YAML path (unchanged behavior).
  - `_load_descriptors_into_db()` — extracted DB loader shared by both sources.
  - `update_resource_descriptor()` — tries A-Team first, falls back to YAML if it errors or returns nothing.

## Field mapping (confirmed vs agr_curation source)
`prefix→db_prefix`, `name→name`, `synonyms→aliases`, `idExample→example_gid`, `idPattern→gid_pattern`, `defaultUrlTemplate→default_url`, `resourcePages[{name, urlTemplate}]→pages[{name, url}]`.

## Tests
`tests/api/test_resource_descriptor.py`: field-mapping unit test, A-Team DB load, and both fallback paths (A-Team error + empty). flake8 + mypy clean.

## Dependency / rollout note
Requires the `get_resource_descriptors()` method added in alliance-genome/agr_curation_api_client#20. `requirements.txt` is unchanged here; until that library change is released and the pin is bumped, the A-Team path raises and **safely falls back to the YAML source** — so this is mergeable independently with no runtime breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)