### PR TITLE
fix(deps): bump agr-curation-api-client 0.9.0 -> 0.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ retry==0.9.2                 # No update needed.
 cachetools==5.3.1            # Updated for better performance.
 lxml==4.9.4
 fastapi-okta==1.4.0
-agr-curation-api-client==0.9.0
+agr-curation-api-client==0.13.0
 
 # JWT support
 PyJWT>=2.8.0


### PR DESCRIPTION
## Summary

Bumps `agr-curation-api-client` from `0.9.0` to `0.13.0`.

The pinned `0.9.0` client lacks the `get_resource_descriptors()` method that `initialize.py` relies on to fetch resource descriptors from the A-Team curation API. At runtime the `getattr` fails and the code always falls back to the YAML source, logging:

```
A-Team resource descriptor fetch failed ('AGRCurationAPIClient' object has no
attribute 'get_resource_descriptors'); falling back to YAML
```

The `get_resource_descriptors()` method was first added in **0.13.0** (verified — absent in 0.9.1 through 0.12.1). Its signature `get_resource_descriptors(self) -> List[Dict[str, Any]]` matches how `initialize.py` consumes it.

## Call-site compatibility

All existing `agr_curation_api` call sites verified against 0.13.0 (symbol existence + signatures):

| File | Methods/symbols | Status |
|------|-----------------|--------|
| `api/initialize.py` | `get_resource_descriptors()` | ✅ now available (the fix) |
| `api/crud/ateam_db_helpers.py` | `search_ontology_ancestors_or_descendants`, `get_atp_descendants`, `get_or_create_species`, `models.OntologyTermResult`, `AGRAPIError` | ✅ |
| `oneoff_scripts/SCRUM-5960_update_strain_species.py` | `get_agms(data_provider=, subtype=, limit=, page=)` | ✅ (kwargs match; `primaryExternalId` is an extra field, `extra="allow"` in both versions) |
| `oneoff_scripts/remap_obsolete_species_to_current_taxon.py` | `get_or_create_species`, `AGRAPIError` | ✅ |
| `data_check/load_missing_species_to_ateam.py` | `get_or_create_species`, `AGRAPIError` | ✅ |

## Deploy note

Rebuild the image (`make build`) so containers pick up 0.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)