### PR TITLE
feat(debezium): alias-based blue/green index swap, no reindex (SCRUM-…

### DIFF
--- a/debezium/setup.sh
+++ b/debezium/setup.sh
@@ -245,6 +245,7 @@ if [[ $new_index_doc_count -gt 0 ]] && [[ $public_index_doc_count -gt 0 ]]; then
     else
         echo "ERROR: alias flip was NOT acknowledged; the live index was NOT switched to slot _${SLOT}. The previous slot keeps serving."
         set_reindex_status "error" "{\"message\": \"alias flip failed; live index unchanged\", \"slot\": \"${SLOT}\"}"
+        exit 1
     fi
 else
     # A 0-doc build means the pipeline produced nothing. Do NOT flip (this guard protects the live
@@ -254,6 +255,7 @@ else
     echo "WARNING: build slot _${SLOT} empty (private=${new_index_doc_count}, public=${public_index_doc_count}); NOT flipping alias."
     echo "The previous slot keeps serving but is now FROZEN (its sink moved to the empty slot) until a rebuild succeeds."
     set_reindex_status "error" "{\"message\": \"empty build slot; alias not flipped; served slot frozen\", \"private_index_docs\": $new_index_doc_count, \"public_index_docs\": $public_index_doc_count}"
+    exit 1
 fi
 
 echo "Debezium setup completed successfully!"

--- a/debezium/setup.sh
+++ b/debezium/setup.sh
@@ -35,7 +35,12 @@ SETUP_START=$(date +%s)
 export INDEX_ALIAS="${DEBEZIUM_INDEX_NAME}"
 export PUBLIC_INDEX_ALIAS="public_${DEBEZIUM_INDEX_NAME}"
 
-SLOT=$(resolve_inactive_suffix "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_ALIAS}")
+if ! SLOT=$(resolve_inactive_suffix "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_ALIAS}"); then
+    echo "FATAL: could not resolve the active slot (Elasticsearch unreachable or unexpected response)."
+    echo "Aborting BEFORE touching any index, so a transient ES error can never clobber the live slot."
+    set_reindex_status "error" "{\"message\": \"alias lookup failed; aborted before any index change\"}"
+    exit 1
+fi
 export INDEX_NAME_CURRENT="${INDEX_ALIAS}_${SLOT}"
 export PUBLIC_INDEX_NAME_CURRENT="${PUBLIC_INDEX_ALIAS}_${SLOT}"
 echo "Building into slot _${SLOT}: ${INDEX_NAME_CURRENT} / ${PUBLIC_INDEX_NAME_CURRENT}"
@@ -219,27 +224,36 @@ DATA_PROCESSING_DURATION=$((DATA_PROCESSING_END - SETUP_END))
 # path for test and prod. Guard: never flip to an empty slot, so a failed/empty build can never
 # replace a healthy live index.
 if [[ $new_index_doc_count -gt 0 ]] && [[ $public_index_doc_count -gt 0 ]]; then
-    PROMOTE_START=$(date +%s)
     set_reindex_status "reindexing" "{\"phase\": \"optimize_and_flip\", \"slot\": \"${SLOT}\", \"private_index_docs\": $new_index_doc_count, \"public_index_docs\": $public_index_doc_count}"
 
-    # Optimize + warm OFF the serving path (the alias still points at the old slot here)
+    # Optimize + warm OFF the serving path (the alias still points at the old slot here). These are
+    # best-effort: a failed optimize leaves the index unoptimized but still correct, so it does not
+    # block the flip.
     optimize_and_warm_index "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_NAME_CURRENT}"
     optimize_and_warm_index "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${PUBLIC_INDEX_NAME_CURRENT}"
 
-    # Atomic cutover: point both aliases at the new slot (handles first-run bootstrap)
-    flip_alias "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_ALIAS}" "${INDEX_NAME_CURRENT}"
-    flip_alias "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${PUBLIC_INDEX_ALIAS}" "${PUBLIC_INDEX_NAME_CURRENT}"
-
-    PROMOTE_END=$(date +%s)
-    PROMOTE_DURATION=$((PROMOTE_END - DATA_PROCESSING_END))
-    echo "Alias '${INDEX_ALIAS}' now serves slot _${SLOT} (${new_index_doc_count} docs); previous slot retained as backup."
-
-    set_reindex_status "completed" "{\"message\": \"Alias flipped to slot _${SLOT}\", \"total_documents\": $new_index_doc_count}"
-    save_completion_metrics "$(jq -r '.started_at' /var/lib/debezium_status/reindex_status.json)" \
-        "$SETUP_DURATION" "$DATA_PROCESSING_DURATION" "$PROMOTE_DURATION" "$new_index_doc_count"
+    # Atomic cutover: point both aliases at the new slot (handles first-run bootstrap). The flip is
+    # THE critical step, so only report success if BOTH aliases were acknowledged by ES.
+    if flip_alias "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_ALIAS}" "${INDEX_NAME_CURRENT}" \
+       && flip_alias "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${PUBLIC_INDEX_ALIAS}" "${PUBLIC_INDEX_NAME_CURRENT}"; then
+        PROMOTE_END=$(date +%s)
+        PROMOTE_DURATION=$((PROMOTE_END - DATA_PROCESSING_END))
+        echo "Alias '${INDEX_ALIAS}' now serves slot _${SLOT} (${new_index_doc_count} docs); previous slot retained as backup."
+        set_reindex_status "completed" "{\"message\": \"Alias flipped to slot _${SLOT}\", \"total_documents\": $new_index_doc_count}"
+        save_completion_metrics "$(jq -r '.started_at' /var/lib/debezium_status/reindex_status.json)" \
+            "$SETUP_DURATION" "$DATA_PROCESSING_DURATION" "$PROMOTE_DURATION" "$new_index_doc_count"
+    else
+        echo "ERROR: alias flip was NOT acknowledged; the live index was NOT switched to slot _${SLOT}. The previous slot keeps serving."
+        set_reindex_status "error" "{\"message\": \"alias flip failed; live index unchanged\", \"slot\": \"${SLOT}\"}"
+    fi
 else
-    echo "WARNING: build slot empty (private=${new_index_doc_count}, public=${public_index_doc_count}); NOT flipping alias. Live index left unchanged."
-    set_reindex_status "completed" "{\"message\": \"No flip - empty build slot; live index unchanged\", \"private_index_docs\": $new_index_doc_count, \"public_index_docs\": $public_index_doc_count}"
+    # A 0-doc build means the pipeline produced nothing. Do NOT flip (this guard protects the live
+    # slot). NOTE: the sink was already repointed at this (empty) build slot above, so the previous
+    # slot keeps SERVING but no longer receives CDC -- it is frozen, not merely "unchanged" -- until
+    # a rebuild succeeds. Investigate the pipeline.
+    echo "WARNING: build slot _${SLOT} empty (private=${new_index_doc_count}, public=${public_index_doc_count}); NOT flipping alias."
+    echo "The previous slot keeps serving but is now FROZEN (its sink moved to the empty slot) until a rebuild succeeds."
+    set_reindex_status "error" "{\"message\": \"empty build slot; alias not flipped; served slot frozen\", \"private_index_docs\": $new_index_doc_count, \"public_index_docs\": $public_index_doc_count}"
 fi
 
 echo "Debezium setup completed successfully!"

--- a/debezium/setup.sh
+++ b/debezium/setup.sh
@@ -27,23 +27,24 @@ fi
 # Track timing for metrics
 SETUP_START=$(date +%s)
 
-export INDEX_NAME_FINAL="${DEBEZIUM_INDEX_NAME}"
-export PUBLIC_INDEX_NAME_FINAL="public_${INDEX_NAME_FINAL}"
+# SCRUM-6240: alias-based blue/green swap. The app queries an ALIAS (= DEBEZIUM_INDEX_NAME);
+# the physical data lives in two fixed slots <name>_1 / <name>_2. Each rebuild targets the
+# INACTIVE slot and then atomically flips the alias to it -- search always hits a fully-built
+# index, and the previous slot stays as an instant-rollback backup. No reindex; bounded at 2
+# copies. Same flow for test and prod; only the wait timings differ.
+export INDEX_ALIAS="${DEBEZIUM_INDEX_NAME}"
+export PUBLIC_INDEX_ALIAS="public_${DEBEZIUM_INDEX_NAME}"
 
-if [[ "${ENV_STATE}" == "test" ]]; then
-    # Test mode - use final index names directly
-    export INDEX_NAME_CURRENT="${INDEX_NAME_FINAL}"
-    export PUBLIC_INDEX_NAME_CURRENT="${PUBLIC_INDEX_NAME_FINAL}"
-else
-    # Production mode - use temporary indexes
-    export INDEX_NAME_CURRENT="${INDEX_NAME_FINAL}_temp"
-    export PUBLIC_INDEX_NAME_CURRENT="${PUBLIC_INDEX_NAME_FINAL}_temp"
-fi
+SLOT=$(resolve_inactive_suffix "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_ALIAS}")
+export INDEX_NAME_CURRENT="${INDEX_ALIAS}_${SLOT}"
+export PUBLIC_INDEX_NAME_CURRENT="${PUBLIC_INDEX_ALIAS}_${SLOT}"
+echo "Building into slot _${SLOT}: ${INDEX_NAME_CURRENT} / ${PUBLIC_INDEX_NAME_CURRENT}"
+echo "(alias '${INDEX_ALIAS}' keeps serving the other slot until the cutover)"
 
 # Set initial reindexing status
-set_reindex_status "setup" "{\"env_state\": \"${ENV_STATE}\"}"
+set_reindex_status "setup" "{\"env_state\": \"${ENV_STATE}\", \"slot\": \"${SLOT}\"}"
 
-# Delete and create both private and public indexes
+# Delete + recreate ONLY the inactive slot (the live slot is never touched here)
 curl -i -X DELETE http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/${INDEX_NAME_CURRENT}
 curl -i -X PUT -H "Accept:application/json" -H  "Content-Type:application/json" http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/${INDEX_NAME_CURRENT} -d @/elasticsearch-settings.json
 
@@ -148,19 +149,18 @@ submit_ksql_statements() {
 submit_ksql_statements /ksql_queries.ksql || echo "WARNING: one or more ksql statements failed; downstream topics/index may be incomplete."
 sleep ${KSQL_POST_SLEEP}
 
-# Create sink connectors - use different names for test vs production
-if [[ "${ENV_STATE}" == "test" ]]; then
-    # Test mode - use final connector names directly
-    export SINK_NAME="elastic-sink"
-    export PUBLIC_SINK_NAME="elastic-sink-public"
-else
-    # Production mode - use temporary connector names
-    export SINK_NAME="elastic-sink-temp"
-    export PUBLIC_SINK_NAME="elastic-sink-public-temp"
-fi
-
+# SCRUM-6240: one sink per index (no temp/permanent split -- there is no reindex). The sink
+# writes into the slot being built and keeps writing there after the alias flip; the cutover is
+# alias-only, decoupled from Kafka Connect. Delete any prior connector of the same name first
+# (it points at the now-old slot); DELETE is a no-op if it does not exist.
+export SINK_NAME="elastic-sink"
+export PUBLIC_SINK_NAME="elastic-sink-public"
 export SINK_INDEX_NAME="${INDEX_NAME_CURRENT}"
 export PUBLIC_SINK_INDEX_NAME="${PUBLIC_INDEX_NAME_CURRENT}"
+
+curl -i -X DELETE http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/${SINK_NAME}
+curl -i -X DELETE http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/${PUBLIC_SINK_NAME}
+
 curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/ -d @<(envsubst '$ELASTICSEARCH_HOST$ELASTICSEARCH_PORT$SINK_INDEX_NAME$SINK_NAME' < /elasticsearch-sink.json)
 curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/ -d @<(envsubst '$ELASTICSEARCH_HOST$ELASTICSEARCH_PORT$PUBLIC_SINK_INDEX_NAME$PUBLIC_SINK_NAME' < /elasticsearch-sink-public.json)
 
@@ -214,79 +214,32 @@ echo "Final counts - Private index: ${new_index_doc_count} docs, Public index: $
 DATA_PROCESSING_END=$(date +%s)
 DATA_PROCESSING_DURATION=$((DATA_PROCESSING_END - SETUP_END))
 
-if [[ "${ENV_STATE}" == "test" ]]; then
-    # Test mode - indexes are already final, no promotion needed
-    echo "Test mode: Setup complete with final indexes"
+# SCRUM-6240: promote by optimizing the freshly-built slot and atomically flipping the alias to
+# it. The old slot stays as the instant-rollback backup (overwritten on the next rebuild). Same
+# path for test and prod. Guard: never flip to an empty slot, so a failed/empty build can never
+# replace a healthy live index.
+if [[ $new_index_doc_count -gt 0 ]] && [[ $public_index_doc_count -gt 0 ]]; then
+    PROMOTE_START=$(date +%s)
+    set_reindex_status "reindexing" "{\"phase\": \"optimize_and_flip\", \"slot\": \"${SLOT}\", \"private_index_docs\": $new_index_doc_count, \"public_index_docs\": $public_index_doc_count}"
 
-    # Mark as completed
-    set_reindex_status "completed" "{\"message\": \"Test mode - no reindex needed\"}"
+    # Optimize + warm OFF the serving path (the alias still points at the old slot here)
+    optimize_and_warm_index "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_NAME_CURRENT}"
+    optimize_and_warm_index "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${PUBLIC_INDEX_NAME_CURRENT}"
 
-    # Save metrics
+    # Atomic cutover: point both aliases at the new slot (handles first-run bootstrap)
+    flip_alias "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_ALIAS}" "${INDEX_NAME_CURRENT}"
+    flip_alias "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${PUBLIC_INDEX_ALIAS}" "${PUBLIC_INDEX_NAME_CURRENT}"
+
+    PROMOTE_END=$(date +%s)
+    PROMOTE_DURATION=$((PROMOTE_END - DATA_PROCESSING_END))
+    echo "Alias '${INDEX_ALIAS}' now serves slot _${SLOT} (${new_index_doc_count} docs); previous slot retained as backup."
+
+    set_reindex_status "completed" "{\"message\": \"Alias flipped to slot _${SLOT}\", \"total_documents\": $new_index_doc_count}"
     save_completion_metrics "$(jq -r '.started_at' /var/lib/debezium_status/reindex_status.json)" \
-        "$SETUP_DURATION" "$DATA_PROCESSING_DURATION" 0 "$new_index_doc_count"
+        "$SETUP_DURATION" "$DATA_PROCESSING_DURATION" "$PROMOTE_DURATION" "$new_index_doc_count"
 else
-    # Production mode - promote temporary indexes to final if they have data
-    if [[ $new_index_doc_count -gt 0 ]] && [[ $public_index_doc_count -gt 0 ]]
-    then
-      # Delete old connectors
-      curl -i -X DELETE http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/elastic-sink
-      curl -i -X DELETE http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/elastic-sink-public
-
-      # Update status to reindexing phase
-      REINDEX_START=$(date +%s)
-      set_reindex_status "reindexing" "{\"phase\": \"promoting_indexes\", \"private_index_docs\": $new_index_doc_count, \"public_index_docs\": $public_index_doc_count}"
-
-      # Prepare private index
-      echo "Preparing private index..."
-      curl -i -X DELETE http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/${INDEX_NAME_FINAL}
-      curl -i -X PUT -H "Accept:application/json" -H  "Content-Type:application/json" http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/${INDEX_NAME_FINAL} -d @/elasticsearch-settings.json
-
-      # Prepare public index
-      echo "Preparing public index..."
-      curl -i -X DELETE http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/${PUBLIC_INDEX_NAME_FINAL}
-      curl -i -X PUT -H "Accept:application/json" -H  "Content-Type:application/json" http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/${PUBLIC_INDEX_NAME_FINAL} -d @/elasticsearch-settings-public.json
-
-      # Start both reindex operations in parallel
-      echo "Starting parallel reindex operations..."
-      PRIVATE_TASK_ID=$(start_reindex "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${INDEX_NAME_CURRENT}" "${INDEX_NAME_FINAL}")
-      PUBLIC_TASK_ID=$(start_reindex "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" "${PUBLIC_INDEX_NAME_CURRENT}" "${PUBLIC_INDEX_NAME_FINAL}")
-
-      # Verify both tasks started successfully
-      if [[ "$PRIVATE_TASK_ID" == "null" ]] || [[ "$PUBLIC_TASK_ID" == "null" ]]; then
-        echo "Error: Failed to start one or more reindex tasks"
-        echo "Private task ID: $PRIVATE_TASK_ID"
-        echo "Public task ID: $PUBLIC_TASK_ID"
-        exit 1
-      fi
-
-      # Poll both tasks in parallel
-      poll_multiple_reindex_tasks "${ELASTICSEARCH_HOST}" "${ELASTICSEARCH_PORT}" \
-        "$PRIVATE_TASK_ID" "${INDEX_NAME_FINAL}" \
-        "$PUBLIC_TASK_ID" "${PUBLIC_INDEX_NAME_FINAL}"
-
-      # Track reindex completion
-      REINDEX_END=$(date +%s)
-      REINDEX_DURATION=$((REINDEX_END - REINDEX_START))
-
-      # Create permanent connectors
-      export SINK_NAME="elastic-sink"
-      export PUBLIC_SINK_NAME="elastic-sink-public"
-      export SINK_INDEX_NAME="${INDEX_NAME_FINAL}"
-      export PUBLIC_SINK_INDEX_NAME="${PUBLIC_INDEX_NAME_FINAL}"
-      curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/ -d @<(envsubst '$ELASTICSEARCH_HOST$ELASTICSEARCH_PORT$SINK_INDEX_NAME$SINK_NAME' < /elasticsearch-sink.json)
-      curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json" http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/ -d @<(envsubst '$ELASTICSEARCH_HOST$ELASTICSEARCH_PORT$PUBLIC_SINK_INDEX_NAME$PUBLIC_SINK_NAME' < /elasticsearch-sink-public.json)
-
-      # Mark as completed
-      set_reindex_status "completed" "{\"message\": \"Reindex completed successfully\", \"total_documents\": $new_index_doc_count}"
-
-      # Save metrics
-      save_completion_metrics "$(jq -r '.started_at' /var/lib/debezium_status/reindex_status.json)" \
-          "$SETUP_DURATION" "$DATA_PROCESSING_DURATION" "$REINDEX_DURATION" "$new_index_doc_count"
-    fi
-
-    # Clean up temporary connectors (only in production mode)
-    curl -i -X DELETE http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/elastic-sink-temp
-    curl -i -X DELETE http://${DEBEZIUM_CONNECTOR_HOST}:${DEBEZIUM_CONNECTOR_PORT}/connectors/elastic-sink-public-temp
+    echo "WARNING: build slot empty (private=${new_index_doc_count}, public=${public_index_doc_count}); NOT flipping alias. Live index left unchanged."
+    set_reindex_status "completed" "{\"message\": \"No flip - empty build slot; live index unchanged\", \"private_index_docs\": $new_index_doc_count, \"public_index_docs\": $public_index_doc_count}"
 fi
 
 echo "Debezium setup completed successfully!"

--- a/debezium/status_manager.sh
+++ b/debezium/status_manager.sh
@@ -481,14 +481,25 @@ wait_for_pipeline_drained() {
 # points at neither slot.
 resolve_inactive_suffix() {
     local es_host=$1 es_port=$2 alias=$3
-    local current
-    current=$(curl -s --max-time 10 "http://${es_host}:${es_port}/_alias/${alias}" 2>/dev/null \
-              | jq -r 'if type=="object" and (has("error")|not) then (keys[0] // "") else "" end' 2>/dev/null)
-    if [[ "$current" == "${alias}_1" ]]; then
-        echo "2"
-    else
-        echo "1"
+    local body code current
+    # Capture the HTTP status so a genuine 404 (alias absent -> bootstrap) is NOT confused with a
+    # transient failure (timeout/5xx -> code "000"/"5xx"). Guessing "1" on a transient blip while
+    # the alias is serving slot _1 would make the caller DELETE/rebuild the LIVE slot in place and
+    # break search -- exactly what this feature prevents. On a hard error we return non-zero so the
+    # caller aborts before touching any index.
+    body=$(curl -s -m 10 -w $'\n%{http_code}' "http://${es_host}:${es_port}/_alias/${alias}" 2>/dev/null)
+    code=$(printf '%s' "$body" | tail -n1)
+    body=$(printf '%s' "$body" | sed '$d')
+    if [[ "$code" == "200" ]]; then
+        current=$(printf '%s' "$body" | jq -r 'keys[0] // ""' 2>/dev/null)
+        if [[ "$current" == "${alias}_1" ]]; then echo "2"; else echo "1"; fi
+        return 0
+    elif [[ "$code" == "404" ]]; then
+        echo "1"   # genuine bootstrap: the alias does not exist yet, slot _1 is free
+        return 0
     fi
+    echo "resolve_inactive_suffix: alias '${alias}' lookup returned HTTP '${code}' (expected 200/404); refusing to guess a slot" >&2
+    return 1
 }
 
 # Force-merge an index to a single segment (optimize + expunge upsert tombstones) and warm it
@@ -526,9 +537,17 @@ flip_alias() {
     done
     actions="${actions}{\"add\":{\"index\":\"${new_index}\",\"alias\":\"${alias}\"}}"
     echo "Flipping alias '${alias}' -> '${new_index}'"
-    curl -s -X POST "${base}/_aliases" -H "Content-Type: application/json" \
-        -d "{\"actions\":[${actions}]}"
-    echo
+    local resp
+    resp=$(curl -s -X POST "${base}/_aliases" -H "Content-Type: application/json" \
+        -d "{\"actions\":[${actions}]}")
+    # The flip is the one step where a silent failure means the freshly-built index is never
+    # served. ES returns {"acknowledged":true} on success; treat anything else as a hard failure.
+    if printf '%s' "$resp" | jq -e '.acknowledged == true' >/dev/null 2>&1; then
+        echo "Alias '${alias}' now points at '${new_index}'"
+        return 0
+    fi
+    echo "flip_alias: _aliases POST for '${alias}' -> '${new_index}' NOT acknowledged: ${resp}" >&2
+    return 1
 }
 
 # Export functions for use in other scripts

--- a/debezium/status_manager.sh
+++ b/debezium/status_manager.sh
@@ -481,7 +481,7 @@ wait_for_pipeline_drained() {
 # points at neither slot.
 resolve_inactive_suffix() {
     local es_host=$1 es_port=$2 alias=$3
-    local body code current
+    local body code
     # Capture the HTTP status so a genuine 404 (alias absent -> bootstrap) is NOT confused with a
     # transient failure (timeout/5xx -> code "000"/"5xx"). Guessing "1" on a transient blip while
     # the alias is serving slot _1 would make the caller DELETE/rebuild the LIVE slot in place and
@@ -490,55 +490,82 @@ resolve_inactive_suffix() {
     body=$(curl -s -m 10 -w $'\n%{http_code}' "http://${es_host}:${es_port}/_alias/${alias}" 2>/dev/null)
     code=$(printf '%s' "$body" | tail -n1)
     body=$(printf '%s' "$body" | sed '$d')
-    if [[ "$code" == "200" ]]; then
-        current=$(printf '%s' "$body" | jq -r 'keys[0] // ""' 2>/dev/null)
-        if [[ "$current" == "${alias}_1" ]]; then echo "2"; else echo "1"; fi
-        return 0
-    elif [[ "$code" == "404" ]]; then
-        echo "1"   # genuine bootstrap: the alias does not exist yet, slot _1 is free
+    if [[ "$code" == "404" ]]; then
+        echo "1"   # alias absent -> bootstrap, slot _1 is free
         return 0
     fi
-    echo "resolve_inactive_suffix: alias '${alias}' lookup returned HTTP '${code}' (expected 200/404); refusing to guess a slot" >&2
-    return 1
+    if [[ "$code" != "200" ]]; then
+        echo "resolve_inactive_suffix: alias '${alias}' lookup returned HTTP '${code}' (expected 200/404); refusing to guess a slot" >&2
+        return 1
+    fi
+    # 200: list ONLY indices that actually carry this alias. A bare concrete index named <alias>
+    # (pre-migration) is returned by GET /_alias/<name> as itself with EMPTY aliases (HTTP 200, not
+    # 404) -> no real backers -> treated as bootstrap (slot _1).
+    local backers n
+    backers=$(printf '%s' "$body" | jq -r --arg a "$alias" 'to_entries[] | select(.value.aliases[$a] != null) | .key' 2>/dev/null)
+    n=$(printf '%s' "$backers" | grep -c . 2>/dev/null)
+    if [[ "$n" -gt 1 ]]; then
+        echo "resolve_inactive_suffix: alias '${alias}' points at >1 index ($(echo $backers | tr '\n' ' ')); refusing to guess a slot" >&2
+        return 1
+    fi
+    if [[ "$backers" == "${alias}_1" ]]; then echo "2"; else echo "1"; fi
+    return 0
 }
 
 # Force-merge an index to a single segment (optimize + expunge upsert tombstones) and warm it
-# (page-cache + global ordinals) BEFORE it serves traffic. Runs off the serving path (the alias
-# still points at the old slot at this point).
+# (page-cache + global ordinals) BEFORE it serves traffic. Runs OFF the serving path (the alias
+# still points at the old slot). Best-effort: a failure leaves the index unoptimized but still
+# correct, so it does NOT block the flip. NOTE: _forcemerge is synchronous and on a large index can
+# run for many minutes and competes for I/O with the live slot on a shared node -- this is expected,
+# not a hang (hence no client timeout on the force_merge call). The HTTP outcome is logged so a real
+# failure (e.g. 429 too_many_requests) is visible rather than silently swallowed.
 optimize_and_warm_index() {
-    local es_host=$1 es_port=$2 index=$3
-    echo "Optimizing ${index} (force_merge max_num_segments=1)..."
-    curl -s -X POST "http://${es_host}:${es_port}/${index}/_forcemerge?max_num_segments=1" \
-        -H "Content-Type: application/json" >/dev/null
+    local es_host=$1 es_port=$2 index=$3 code
+    echo "Optimizing ${index} (force_merge max_num_segments=1; may take several minutes)..."
+    code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        "http://${es_host}:${es_port}/${index}/_forcemerge?max_num_segments=1" \
+        -H "Content-Type: application/json")
+    [[ "$code" == "200" ]] || echo "WARNING: force_merge of ${index} returned HTTP ${code} (continuing; index is correct but unoptimized)" >&2
     echo "Warming ${index} (match_all to page in caches)..."
-    curl -s -X POST "http://${es_host}:${es_port}/${index}/_search" \
+    curl -s -m 30 -X POST "http://${es_host}:${es_port}/${index}/_search" \
         -H "Content-Type: application/json" -d '{"size":0,"query":{"match_all":{}}}' >/dev/null
 }
 
-# Atomically point <alias> at <new_index>, removing it from any other index it currently
-# references (single _aliases call = zero-downtime cutover). Bootstrap: if a CONCRETE index
-# literally named <alias> exists (pre-migration), delete it first so the alias name is free
-# (Elasticsearch forbids an alias and an index sharing a name).
+# Atomically point <alias> at <new_index> in a SINGLE _aliases call (zero-downtime cutover):
+# remove the alias from any stale slot, and on first-run bootstrap atomically DELETE a legacy
+# CONCRETE index of the same name via `remove_index` -- in the SAME call as the add, so the name
+# is never absent (no 404 window for the live app). All of it is covered by the acknowledged check.
 flip_alias() {
     local es_host=$1 es_port=$2 alias=$3 new_index=$4
     local base="http://${es_host}:${es_port}"
-    local current_list concrete idx actions=""
-    current_list=$(curl -s "${base}/_alias/${alias}" 2>/dev/null \
-                   | jq -r 'if type=="object" and (has("error")|not) then keys[] else empty end' 2>/dev/null)
-    concrete=$(curl -s "${base}/_cat/indices/${alias}?h=index" 2>/dev/null | tr -d '[:space:]')
-    if [[ "$concrete" == "$alias" ]]; then
-        echo "Bootstrap: deleting legacy concrete index '${alias}' to free the alias name"
-        curl -s -X DELETE "${base}/${alias}" >/dev/null
+    local body code current_list concrete idx actions="" resp
+    # Current alias backers. 200 = alias exists (list ONLY indices that truly carry it); 404 = none.
+    # Use the status code so a transient failure is NOT read as "no backers" (which would skip the
+    # stale-remove and leave the alias on two slots). On a hard error, abort rather than guess.
+    body=$(curl -s -m 10 -w $'\n%{http_code}' "${base}/_alias/${alias}" 2>/dev/null)
+    code=$(printf '%s' "$body" | tail -n1)
+    body=$(printf '%s' "$body" | sed '$d')
+    if [[ "$code" == "200" ]]; then
+        current_list=$(printf '%s' "$body" | jq -r --arg a "$alias" 'to_entries[] | select(.value.aliases[$a] != null) | .key' 2>/dev/null)
+    elif [[ "$code" == "404" ]]; then
         current_list=""
+    else
+        echo "flip_alias: alias '${alias}' lookup returned HTTP '${code}'; aborting flip" >&2
+        return 1
     fi
+    # Bootstrap detection: _cat/indices/<name> lists indices only -- for an alias it resolves to the
+    # backing slot (!= alias); for a bare concrete index it returns the name itself.
+    concrete=$(curl -s -m 10 "${base}/_cat/indices/${alias}?h=index" 2>/dev/null | tr -d '[:space:]')
     for idx in $current_list; do
         [[ "$idx" == "$new_index" ]] && continue
         actions="${actions}{\"remove\":{\"index\":\"${idx}\",\"alias\":\"${alias}\"}},"
     done
+    if [[ "$concrete" == "$alias" ]]; then
+        actions="${actions}{\"remove_index\":{\"index\":\"${alias}\"}},"
+    fi
     actions="${actions}{\"add\":{\"index\":\"${new_index}\",\"alias\":\"${alias}\"}}"
     echo "Flipping alias '${alias}' -> '${new_index}'"
-    local resp
-    resp=$(curl -s -X POST "${base}/_aliases" -H "Content-Type: application/json" \
+    resp=$(curl -s -m 30 -X POST "${base}/_aliases" -H "Content-Type: application/json" \
         -d "{\"actions\":[${actions}]}")
     # The flip is the one step where a silent failure means the freshly-built index is never
     # served. ES returns {"acknowledged":true} on success; treat anything else as a hard failure.

--- a/debezium/status_manager.sh
+++ b/debezium/status_manager.sh
@@ -514,20 +514,62 @@ resolve_inactive_suffix() {
 
 # Force-merge an index to a single segment (optimize + expunge upsert tombstones) and warm it
 # (page-cache + global ordinals) BEFORE it serves traffic. Runs OFF the serving path (the alias
-# still points at the old slot). Best-effort: a failure leaves the index unoptimized but still
-# correct, so it does NOT block the flip. NOTE: _forcemerge is synchronous and on a large index can
-# run for many minutes and competes for I/O with the live slot on a shared node -- this is expected,
-# not a hang (hence no client timeout on the force_merge call). The HTTP outcome is logged so a real
-# failure (e.g. 429 too_many_requests) is visible rather than silently swallowed.
+# still points at the old slot). The force_merge is launched as a BACKGROUND task
+# (wait_for_completion=false) and polled via the Tasks API to TRUE completion, so a long merge on a
+# big index can never be cut short by an endpoint/idle timeout on a blocking HTTP call -- the alias
+# must never flip onto a still-merging index. Falls back to a blocking force_merge on older servers
+# that do not support the async param. Best-effort: a force_merge failure leaves the index correct
+# but unoptimized and does NOT block the flip (always logged, never silently swallowed).
 optimize_and_warm_index() {
-    local es_host=$1 es_port=$2 index=$3 code
-    echo "Optimizing ${index} (force_merge max_num_segments=1; may take several minutes)..."
-    code=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-        "http://${es_host}:${es_port}/${index}/_forcemerge?max_num_segments=1" \
+    local es_host=$1 es_port=$2 index=$3
+    local base="http://${es_host}:${es_port}"
+    local resp code task completed n
+
+    echo "Optimizing ${index} (force_merge max_num_segments=1, async + task poll)..."
+    # No -m on this POST: with wait_for_completion=false it returns a task id instantly; if the
+    # server ignores the param it blocks until done and returns the merge result instead.
+    resp=$(curl -s -X POST \
+        "${base}/${index}/_forcemerge?max_num_segments=1&wait_for_completion=false" \
         -H "Content-Type: application/json")
-    [[ "$code" == "200" ]] || echo "WARNING: force_merge of ${index} returned HTTP ${code} (continuing; index is correct but unoptimized)" >&2
+    task=$(printf '%s' "$resp" | jq -r '.task // empty' 2>/dev/null)
+
+    if [[ -n "$task" ]]; then
+        echo "force_merge task ${task} started for ${index}; polling until complete..."
+        n=0
+        while [[ $n -lt 720 ]]; do          # ~3h cap at 15s/poll
+            sleep 15; n=$((n + 1))
+            resp=$(curl -s -m 15 -w $'\n%{http_code}' "${base}/_tasks/${task}" 2>/dev/null)
+            code=$(printf '%s' "$resp" | tail -n1)
+            resp=$(printf '%s' "$resp" | sed '$d')
+            if [[ "$code" == "404" ]]; then
+                echo "force_merge of ${index}: task ${task} no longer present; assuming complete."
+                break
+            fi
+            completed=$(printf '%s' "$resp" | jq -r '.completed // false' 2>/dev/null)
+            if [[ "$completed" == "true" ]]; then
+                if printf '%s' "$resp" | jq -e 'has("error")' >/dev/null 2>&1; then
+                    echo "WARNING: force_merge task ${task} for ${index} completed WITH ERROR: $(printf '%s' "$resp" | jq -c '.error' 2>/dev/null)" >&2
+                else
+                    echo "force_merge of ${index} completed."
+                fi
+                break
+            fi
+        done
+        [[ $n -ge 720 ]] && echo "WARNING: force_merge of ${index} still running after ~3h; proceeding (merge continues server-side)." >&2
+    elif printf '%s' "$resp" | jq -e '._shards.failed == 0' >/dev/null 2>&1; then
+        echo "force_merge of ${index} completed synchronously (server ignored wait_for_completion)."
+    else
+        # Param rejected (e.g. 400 on older ES) or some other error -> retry a plain blocking
+        # force_merge so the index still gets optimized.
+        echo "force_merge async start unavailable for ${index} (${resp}); retrying a blocking force_merge..." >&2
+        resp=$(curl -s -X POST "${base}/${index}/_forcemerge?max_num_segments=1" -H "Content-Type: application/json")
+        printf '%s' "$resp" | jq -e '._shards.failed == 0' >/dev/null 2>&1 \
+            && echo "force_merge of ${index} completed (blocking)." \
+            || echo "WARNING: force_merge of ${index} did not confirm success: ${resp} (continuing; index is correct but unoptimized)" >&2
+    fi
+
     echo "Warming ${index} (match_all to page in caches)..."
-    curl -s -m 30 -X POST "http://${es_host}:${es_port}/${index}/_search" \
+    curl -s -m 30 -X POST "${base}/${index}/_search" \
         -H "Content-Type: application/json" -d '{"size":0,"query":{"match_all":{}}}' >/dev/null
 }
 

--- a/debezium/status_manager.sh
+++ b/debezium/status_manager.sh
@@ -470,6 +470,67 @@ wait_for_pipeline_drained() {
     return 1
 }
 
+# ---------------------------------------------------------------------------
+# SCRUM-6240: alias-based blue/green index swap helpers.
+# The app queries an ALIAS; physical data lives in two fixed slots <name>_1 / <name>_2.
+# Each rebuild targets the inactive slot, optimizes it, then atomically flips the alias.
+# ---------------------------------------------------------------------------
+
+# Echo the INACTIVE slot suffix ("1" or "2") for an alias, so a rebuild always targets the slot
+# the alias is NOT currently serving. Defaults to "1" when the alias is absent (bootstrap) or
+# points at neither slot.
+resolve_inactive_suffix() {
+    local es_host=$1 es_port=$2 alias=$3
+    local current
+    current=$(curl -s --max-time 10 "http://${es_host}:${es_port}/_alias/${alias}" 2>/dev/null \
+              | jq -r 'if type=="object" and (has("error")|not) then (keys[0] // "") else "" end' 2>/dev/null)
+    if [[ "$current" == "${alias}_1" ]]; then
+        echo "2"
+    else
+        echo "1"
+    fi
+}
+
+# Force-merge an index to a single segment (optimize + expunge upsert tombstones) and warm it
+# (page-cache + global ordinals) BEFORE it serves traffic. Runs off the serving path (the alias
+# still points at the old slot at this point).
+optimize_and_warm_index() {
+    local es_host=$1 es_port=$2 index=$3
+    echo "Optimizing ${index} (force_merge max_num_segments=1)..."
+    curl -s -X POST "http://${es_host}:${es_port}/${index}/_forcemerge?max_num_segments=1" \
+        -H "Content-Type: application/json" >/dev/null
+    echo "Warming ${index} (match_all to page in caches)..."
+    curl -s -X POST "http://${es_host}:${es_port}/${index}/_search" \
+        -H "Content-Type: application/json" -d '{"size":0,"query":{"match_all":{}}}' >/dev/null
+}
+
+# Atomically point <alias> at <new_index>, removing it from any other index it currently
+# references (single _aliases call = zero-downtime cutover). Bootstrap: if a CONCRETE index
+# literally named <alias> exists (pre-migration), delete it first so the alias name is free
+# (Elasticsearch forbids an alias and an index sharing a name).
+flip_alias() {
+    local es_host=$1 es_port=$2 alias=$3 new_index=$4
+    local base="http://${es_host}:${es_port}"
+    local current_list concrete idx actions=""
+    current_list=$(curl -s "${base}/_alias/${alias}" 2>/dev/null \
+                   | jq -r 'if type=="object" and (has("error")|not) then keys[] else empty end' 2>/dev/null)
+    concrete=$(curl -s "${base}/_cat/indices/${alias}?h=index" 2>/dev/null | tr -d '[:space:]')
+    if [[ "$concrete" == "$alias" ]]; then
+        echo "Bootstrap: deleting legacy concrete index '${alias}' to free the alias name"
+        curl -s -X DELETE "${base}/${alias}" >/dev/null
+        current_list=""
+    fi
+    for idx in $current_list; do
+        [[ "$idx" == "$new_index" ]] && continue
+        actions="${actions}{\"remove\":{\"index\":\"${idx}\",\"alias\":\"${alias}\"}},"
+    done
+    actions="${actions}{\"add\":{\"index\":\"${new_index}\",\"alias\":\"${alias}\"}}"
+    echo "Flipping alias '${alias}' -> '${new_index}'"
+    curl -s -X POST "${base}/_aliases" -H "Content-Type: application/json" \
+        -d "{\"actions\":[${actions}]}"
+    echo
+}
+
 # Export functions for use in other scripts
 export -f get_timestamp
 export -f seconds_since
@@ -480,3 +541,6 @@ export -f poll_multiple_reindex_tasks
 export -f save_completion_metrics
 export -f wait_for_source_topics_ready
 export -f wait_for_pipeline_drained
+export -f resolve_inactive_suffix
+export -f optimize_and_warm_index
+export -f flip_alias


### PR DESCRIPTION
…6240)

Replace the delete-final-and-reindex-in-place promotion with a zero-downtime blue/green swap:

- The app queries an ALIAS (= DEBEZIUM_INDEX_NAME); physical data lives in two fixed slots <name>_1 / <name>_2.
- Each rebuild targets the INACTIVE slot (the live slot is never touched), then force_merges (optimize + expunge tombstones) and warms it OFF the serving path before an atomic _aliases flip. The previous slot stays as an instant-rollback backup; disk is bounded at two copies.
- No temp->final reindex (dropped): the streamed slot is promoted directly.
- One sink connector per index, retargeted to the inactive slot at build start and kept after the flip -- the cutover is alias-only, decoupled from Kafka Connect (no temp/permanent connector juggling).
- Guard: never flip to an empty slot, so a failed/empty build cannot replace a healthy live index. flip_alias bootstraps off the legacy bare index name.
- Same flow for test and prod (only wait timings differ).

No API change: ELASTICSEARCH_INDEX already equals the alias name, so search resolves through the alias transparently.

The old reindex helpers (start_reindex / poll_reindex_task / poll_multiple_reindex_tasks) are now unused; left in place to keep this diff focused and can be pruned in a follow-up.