### PR TITLE
feat(pdf2md): persist & expose PDFX figure metadata sidecars + backfill (SCRUM-6246)

### DIFF
--- a/agr_literature_service/api/crud/file_conversion_crud.py
+++ b/agr_literature_service/api/crud/file_conversion_crud.py
@@ -454,6 +454,13 @@ _FIGURE_FILE_CLASS_FOR_SOURCE: Dict[str, str] = {
     "supplement": "converted_supplement_figure",
 }
 
+# Parallel mapping for the JSON metadata sidecar each figure now carries
+# (SCRUM-6246). Kept in sync with FIGURE_METADATA_FILE_CLASSES in pdf2md_utils.
+_FIGURE_METADATA_FILE_CLASS_FOR_SOURCE: Dict[str, str] = {
+    "main": "converted_main_figure_metadata",
+    "supplement": "converted_supplement_figure_metadata",
+}
+
 
 def _figures_for_source(reference: ReferenceModel,
                         source_display_name: Optional[str],
@@ -465,13 +472,40 @@ def _figures_for_source(reference: ReferenceModel,
     ``{source_display_name}_image_{idx:03d}`` convention and one of the
     ``converted_main_figure`` / ``converted_supplement_figure`` file_classes,
     so we match on display_name prefix + the corresponding figure file_class.
+
+    Each figure's JSON metadata sidecar (SCRUM-6246) shares the PNG's
+    display_name under the parallel ``converted_*_figure_metadata`` file_class
+    (``json`` extension), so we link the two by exact display_name match and
+    expose the sidecar as ``metadata_referencefile_id``.
     """
     if not source_display_name or not source_file_class:
         return []
     figure_file_class = _FIGURE_FILE_CLASS_FOR_SOURCE.get(source_file_class)
     if figure_file_class is None:
         return []
+    metadata_file_class = _FIGURE_METADATA_FILE_CLASS_FOR_SOURCE.get(
+        source_file_class
+    )
     prefix = f"{source_display_name}_image_"
+
+    # display_name -> metadata sidecar referencefile_id, so each figure PNG
+    # can point at its sidecar without re-querying the DB per figure.
+    metadata_by_display_name: Dict[str, int] = {}
+    if metadata_file_class is not None:
+        for ref_file in reference.referencefiles or []:
+            if ref_file.file_class != metadata_file_class:
+                continue
+            if ref_file.file_extension != "json":
+                continue
+            if ref_file.file_publication_status != "final":
+                continue
+            display_name = ref_file.display_name or ""
+            if not display_name.startswith(prefix):
+                continue
+            metadata_by_display_name[display_name] = int(
+                ref_file.referencefile_id
+            )
+
     figures: List[Dict[str, Any]] = []
     for ref_file in reference.referencefiles or []:
         if ref_file.file_class != figure_file_class:
@@ -484,6 +518,9 @@ def _figures_for_source(reference: ReferenceModel,
             "display_name": ref_file.display_name,
             "file_class": ref_file.file_class,
             "referencefile_id": int(ref_file.referencefile_id),
+            "metadata_referencefile_id": metadata_by_display_name.get(
+                ref_file.display_name
+            ),
         })
     figures.sort(key=lambda f: f["display_name"] or "")
     return figures

--- a/agr_literature_service/api/schemas/file_conversion_schemas.py
+++ b/agr_literature_service/api/schemas/file_conversion_schemas.py
@@ -9,6 +9,12 @@ class ConversionFileInfo(BaseModel):
     display_name: str
     file_class: str
     referencefile_id: Optional[int] = None
+    # For extracted-figure rows: the referencefile_id of the figure's JSON
+    # metadata sidecar (SCRUM-6246), so AI Curation can fetch a figure's
+    # PDFX manifest metadata (caption, figure number, bbox, ...) without
+    # guessing display_name prefixes. None for non-figure rows or figures
+    # whose sidecar is missing (e.g. extracted before the metadata feature).
+    metadata_referencefile_id: Optional[int] = None
 
 
 class ConversionModStatusSchema(BaseModel):

--- a/agr_literature_service/lit_processing/pdf2md/backfill_figure_metadata.py
+++ b/agr_literature_service/lit_processing/pdf2md/backfill_figure_metadata.py
@@ -1,0 +1,553 @@
+"""Backfill JSON figure-metadata sidecars for already-converted references
+(SCRUM-6246).
+
+Earlier conversions persisted only the figure PNGs (``converted_main_figure``
+/ ``converted_supplement_figure``); the PDFX manifest metadata (figure number,
+caption/legend text, page index, bbox/polygon, image_review_*) was discarded.
+This script finds references whose figures lack the JSON metadata sidecar,
+re-runs each source PDF through PDFX in **marker-only** mode (``methods=marker``,
+``merge=False``) — Marker is the only extractor that produces the image
+manifest, so we skip Grobid, Docling and the merge/consensus step to save
+credits — regenerates the transient image manifest, matches the manifest
+entries back to the existing figure PNGs by order, and uploads one metadata
+``.json`` sidecar per figure, sharing the PNG's display_name.
+
+Attach-only: existing figure PNG rows are never re-uploaded — only the missing
+metadata sidecars are added.
+
+Idempotent and resumable: a figure whose sidecar already exists is skipped
+(detected by display_name), and ``file_upload``'s md5sum dedup makes a re-run
+of an identical sidecar a no-op. Safe to re-run after an interruption.
+
+Note: each sidecar goes through the standard ``file_upload`` path, which fires
+``transition_WFT_for_uploaded_file``. For already-converted references the
+file-upload workflow is past its only actionable state, so this is a no-op —
+the same side effect the original figure-PNG uploads already triggered.
+
+Examples:
+    # Dry run over everything that still needs metadata
+    python3 backfill_figure_metadata.py --dry-run
+
+    # Backfill a single reference (for testing)
+    python3 backfill_figure_metadata.py --reference AGRKB:101000000000001
+    python3 backfill_figure_metadata.py --curie PMID:12345678
+
+    # Backfill the first 50 references, main figures only
+    python3 backfill_figure_metadata.py --limit 50 --no-supplements
+"""
+import argparse
+import logging
+import re
+import sys
+from collections import defaultdict
+from os import path
+from typing import Callable, Dict, List, Optional, Tuple
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, aliased
+
+from agr_cognito_py import ModAccess, get_admin_token
+
+from agr_literature_service.api.crud.referencefile_crud import download_file
+from agr_literature_service.api.models import (
+    ModModel,
+    ReferencefileModel,
+    ReferenceModel,
+)
+from agr_literature_service.api.models.referencefile_model import (
+    ReferencefileModAssociationModel,
+)
+from agr_literature_service.api.user import set_global_user_id
+from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
+    CONVERTED_FIGURE_FILE_EXTENSION,
+    CONVERTED_FIGURE_METADATA_FILE_EXTENSION,
+    FIGURE_FILE_CLASSES,
+    FIGURE_METADATA_FILE_CLASSES,
+    PdfType,
+    _upload_figure_metadata_sidecar,
+    download_pdfx_image_manifest,
+    get_pdf_files_for_reference,
+    poll_pdfx_status,
+    resolve_curie_to_reference,
+    submit_pdf_to_pdfx,
+)
+from agr_literature_service.lit_processing.utils.sqlalchemy_utils import (
+    create_postgres_session,
+)
+
+logger = logging.getLogger(__name__)
+
+# Canonical marker figure naming: "{source_display_name}_image_NNN".
+_FIGURE_INDEX_RE = re.compile(r"_image_(\d+)$")
+
+
+def _configure_logging(log_file: str = "") -> None:
+    formatter = logging.Formatter(
+        fmt='%(asctime)s - %(levelname)s - {%(module)s %(funcName)s:%(lineno)d} - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    root.addHandler(stream_handler)
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
+    root.setLevel(logging.INFO)
+
+
+def _first_mod_abbreviation(ref_file: ReferencefileModel) -> Optional[str]:
+    """Return the first non-null MOD abbreviation associated with a
+    referencefile, or None (shared / PMC). Mirrors the mod-resolution in
+    ``pdf2md_utils._process_single_pdf_file`` so the backfilled sidecar lands
+    with the same MOD context the live path would use."""
+    for ref_file_mod in ref_file.referencefile_mods or []:
+        if ref_file_mod.mod is not None:
+            return ref_file_mod.mod.abbreviation
+    return None
+
+
+def _figure_index_from_display_name(display_name: str, fallback: int) -> int:
+    """Parse the 1-based ordinal encoded in a marker figure's display_name
+    (``..._image_NNN``), falling back to ``fallback`` if the name is not
+    canonical. Tying the persisted ``figure_index`` to the display_name
+    ordinal (rather than a positional counter) keeps the value identical
+    whether the sidecar is written by the live conversion path (which sets
+    ``figure_index`` = manifest position, matching the ``_NNN`` it stamped
+    into the PNG name) or by this backfill."""
+    match = _FIGURE_INDEX_RE.search(display_name or "")
+    return int(match.group(1)) if match else fallback
+
+
+def plan_sidecars_for_source(
+    png_rows: List[ReferencefileModel],
+    manifest_images: List[Dict],
+    existing_metadata_names: set,
+) -> Tuple[List[Dict], int, Optional[str]]:
+    """Pure planning step: decide which figure PNGs of one source PDF still
+    need a metadata sidecar and which regenerated manifest entry feeds each.
+
+    The existing figures are sorted by display_name (which sorts by the
+    ``_image_NNN`` index) and paired positionally with the manifest images
+    (PDFX/Marker emits images in a stable order for a given PDF). A figure
+    whose display_name is already in ``existing_metadata_names`` is skipped
+    (idempotency/resume). ``figure_index`` is parsed from each PNG's
+    display_name so it stays consistent with the live conversion path.
+
+    Returns ``(planned, skipped_existing, skip_reason)`` where:
+      - ``planned`` is a list of ``{figure_index, figure_display_name, image}``
+        dicts to upload (one per figure still missing its sidecar);
+      - ``skipped_existing`` counts figures that already had a sidecar;
+      - ``skip_reason`` is None when planning succeeded, else a human-readable
+        reason the WHOLE source was skipped. We refuse to plan (rather than
+        risk attaching a caption to the wrong figure — the exact failure the
+        provenance feature must avoid) when either:
+          * any existing figure PNG has a non-canonical name (e.g. a prior
+            re-conversion left a ``_N`` rename suffix), so sorted order no
+            longer reliably equals manifest order; or
+          * the regenerated manifest's image count differs from the number of
+            existing figures.
+    """
+    sorted_pngs = sorted(png_rows, key=lambda r: r.display_name or "")
+
+    non_canonical = [
+        p.display_name for p in sorted_pngs
+        if not _FIGURE_INDEX_RE.search(p.display_name or "")
+    ]
+    if non_canonical:
+        return [], 0, (
+            f"{len(non_canonical)} figure PNG(s) have non-canonical names "
+            f"(e.g. {non_canonical[0]!r}); cannot reliably align them to the "
+            f"regenerated manifest by order"
+        )
+    if len(sorted_pngs) != len(manifest_images):
+        return [], 0, (
+            f"regenerated manifest has {len(manifest_images)} image(s) but "
+            f"{len(sorted_pngs)} existing figure(s)"
+        )
+
+    planned: List[Dict] = []
+    skipped_existing = 0
+    for pos, (png, image) in enumerate(zip(sorted_pngs, manifest_images), start=1):
+        display_name = png.display_name
+        if display_name in existing_metadata_names:
+            skipped_existing += 1
+            continue
+        planned.append({
+            "figure_index": _figure_index_from_display_name(display_name, pos),
+            "figure_display_name": display_name,
+            "image": image,
+        })
+    return planned, skipped_existing, None
+
+
+def select_references_needing_metadata(  # pragma: no cover
+    db: Session, mod_abbreviation: str = "", limit: int = 0,
+) -> List[int]:
+    """Return reference_ids that have at least one converted figure PNG
+    without a matching metadata sidecar.
+
+    A figure PNG is considered backfilled when a ``json`` referencefile under
+    one of the ``converted_*_figure_metadata`` classes shares its
+    ``(reference_id, display_name)``. Optionally restrict to references whose
+    figure PNGs are associated with ``mod_abbreviation`` (or are shared /
+    null-mod)."""
+    png = ReferencefileModel
+    meta = aliased(ReferencefileModel)
+
+    sidecar_exists = (
+        db.query(meta.referencefile_id)
+        .filter(
+            meta.reference_id == png.reference_id,
+            meta.display_name == png.display_name,
+            meta.file_extension == CONVERTED_FIGURE_METADATA_FILE_EXTENSION,
+            meta.file_publication_status == "final",
+            meta.file_class.in_(list(FIGURE_METADATA_FILE_CLASSES.values())),
+        )
+        .exists()
+    )
+
+    q = (
+        db.query(png.reference_id)
+        .filter(
+            png.file_class.in_(list(FIGURE_FILE_CLASSES.values())),
+            png.file_extension == CONVERTED_FIGURE_FILE_EXTENSION,
+            png.file_publication_status == "final",
+            ~sidecar_exists,
+        )
+    )
+
+    if mod_abbreviation:
+        mod = (
+            db.query(ModModel)
+            .filter(ModModel.abbreviation == mod_abbreviation)
+            .one_or_none()
+        )
+        if mod is None:
+            logger.warning("MOD not found: %s", mod_abbreviation)
+            return []
+        q = (
+            q.join(
+                ReferencefileModAssociationModel,
+                ReferencefileModAssociationModel.referencefile_id
+                == png.referencefile_id,
+            )
+            .filter(or_(
+                ReferencefileModAssociationModel.mod_id == mod.mod_id,
+                ReferencefileModAssociationModel.mod_id.is_(None),
+            ))
+        )
+
+    q = q.distinct().order_by(png.reference_id)
+    if limit and limit > 0:
+        q = q.limit(limit)
+    return [row[0] for row in q.all()]
+
+
+def _regenerate_image_manifest_marker_only(  # pragma: no cover
+    file_content: bytes,
+    token: str,
+    reference_curie: str,
+    mod_abbreviation: Optional[str],
+) -> Dict:
+    """Re-run a source PDF through PDFX using ONLY Marker (no Grobid/Docling,
+    no merge/consensus) to regenerate the transient image manifest. Image
+    review stays on (PDFX default) so image_review_* fields are populated."""
+    process_id = submit_pdf_to_pdfx(
+        file_content=file_content,
+        token=token,
+        methods="marker",
+        merge=False,
+        reference_curie=reference_curie,
+        mod_abbreviation=mod_abbreviation,
+        extract_images=True,
+    )
+    poll_pdfx_status(process_id, token)
+    return download_pdfx_image_manifest(process_id, token)
+
+
+def _figure_pngs_for_source(reference: ReferenceModel, figure_file_class: str,
+                            prefix: str) -> List[ReferencefileModel]:
+    return [
+        rf for rf in (reference.referencefiles or [])
+        if rf.file_class == figure_file_class
+        and rf.file_extension == CONVERTED_FIGURE_FILE_EXTENSION
+        and rf.file_publication_status == "final"
+        and (rf.display_name or "").startswith(prefix)
+    ]
+
+
+def _existing_sidecar_names(reference: ReferenceModel, metadata_file_class: str,
+                            prefix: str) -> set:
+    return {
+        rf.display_name for rf in (reference.referencefiles or [])
+        if rf.file_class == metadata_file_class
+        and rf.file_extension == CONVERTED_FIGURE_METADATA_FILE_EXTENSION
+        and rf.file_publication_status == "final"
+        and (rf.display_name or "").startswith(prefix)
+    }
+
+
+def backfill_reference(  # pragma: no cover
+    db: Session,
+    reference: ReferenceModel,
+    get_token: Callable[[], str],
+    dry_run: bool,
+    include_supplements: bool,
+    stats: Dict[str, int],
+) -> bool:
+    """Backfill metadata sidecars for one reference. Returns True if any
+    sidecar was added (or would be, in dry-run mode)."""
+    reference_curie = reference.curie
+    source_file_classes: List[PdfType] = ["main"]
+    if include_supplements:
+        source_file_classes.append("supplement")
+
+    any_added = False
+    for source_file_class in source_file_classes:
+        figure_file_class = FIGURE_FILE_CLASSES[source_file_class]
+        metadata_file_class = FIGURE_METADATA_FILE_CLASSES[source_file_class]
+
+        for pdf_file in get_pdf_files_for_reference(
+            db, reference.reference_id, source_file_class
+        ):
+            prefix = f"{pdf_file.display_name}_image_"
+            png_rows = _figure_pngs_for_source(
+                reference, figure_file_class, prefix
+            )
+            if not png_rows:
+                continue
+
+            existing_names = _existing_sidecar_names(
+                reference, metadata_file_class, prefix
+            )
+            missing = [
+                r for r in png_rows if r.display_name not in existing_names
+            ]
+            if not missing:
+                stats["sources_already_complete"] += 1
+                continue
+
+            if dry_run:
+                logger.info(
+                    "[dry-run] %s %s '%s': %d figure(s) need metadata "
+                    "(would re-run marker-only PDFX)",
+                    reference_curie, source_file_class,
+                    pdf_file.display_name, len(missing),
+                )
+                stats["sidecars_would_add"] += len(missing)
+                any_added = True
+                continue
+
+            mod_abbreviation = _first_mod_abbreviation(pdf_file)
+
+            try:
+                file_content = download_file(
+                    db=db,
+                    referencefile_id=pdf_file.referencefile_id,
+                    mod_access=ModAccess.ALL_ACCESS,
+                    use_in_api=False,
+                )
+            except Exception as exc:
+                stats["sources_download_failed"] += 1
+                logger.error(
+                    "Failed to download %s PDF '%s' for %s: %s",
+                    source_file_class, pdf_file.display_name,
+                    reference_curie, exc,
+                )
+                continue
+            if not file_content:
+                stats["sources_download_failed"] += 1
+                logger.error(
+                    "Empty %s PDF '%s' for %s; skipping",
+                    source_file_class, pdf_file.display_name, reference_curie,
+                )
+                continue
+
+            try:
+                manifest = _regenerate_image_manifest_marker_only(
+                    file_content, get_token(), reference_curie, mod_abbreviation
+                )
+            except Exception as exc:
+                stats["sources_pdfx_failed"] += 1
+                logger.error(
+                    "PDFX marker-only re-run failed for %s %s '%s': %s",
+                    reference_curie, source_file_class,
+                    pdf_file.display_name, exc,
+                )
+                continue
+
+            images = manifest.get("images") or []
+            planned, skipped, skip_reason = plan_sidecars_for_source(
+                png_rows, images, existing_names
+            )
+            if skip_reason is not None:
+                stats["sources_mismatch"] += 1
+                logger.warning(
+                    "%s %s '%s': %s; skipping to avoid mis-association",
+                    reference_curie, source_file_class, pdf_file.display_name,
+                    skip_reason,
+                )
+                continue
+            stats["sources_processed"] += 1
+
+            for plan in planned:
+                try:
+                    _upload_figure_metadata_sidecar(
+                        db=db,
+                        image=plan["image"],
+                        figure_index=plan["figure_index"],
+                        figure_display_name=plan["figure_display_name"],
+                        figure_metadata_file_class=metadata_file_class,
+                        source_display_name=pdf_file.display_name,
+                        source_file_class=source_file_class,
+                        reference_curie=reference_curie,
+                        mod_abbreviation=mod_abbreviation,
+                    )
+                    stats["sidecars_added"] += 1
+                    any_added = True
+                    # Audit trail: record which regenerated manifest entry fed
+                    # each sidecar so a human can verify the order-based match.
+                    logger.info(
+                        "%s: attached metadata sidecar '%s' "
+                        "(figure_index=%d, manifest filename=%r)",
+                        reference_curie, plan["figure_display_name"],
+                        plan["figure_index"], plan["image"].get("filename"),
+                    )
+                except Exception as exc:
+                    stats["sidecar_errors"] += 1
+                    logger.error(
+                        "Failed to upload metadata sidecar '%s' for %s: %s",
+                        plan["figure_display_name"], reference_curie, exc,
+                    )
+
+    if any_added:
+        stats["refs_with_new_metadata"] += 1
+    return any_added
+
+
+def _log_summary(stats: Dict[str, int], dry_run: bool) -> None:  # pragma: no cover
+    verb = "would add" if dry_run else "added"
+    count_key = "sidecars_would_add" if dry_run else "sidecars_added"
+    logger.info(
+        "Done (%s). refs_scanned=%d refs_with_new_metadata=%d "
+        "sources_processed=%d sources_already_complete=%d "
+        "sources_mismatch=%d sources_download_failed=%d "
+        "sources_pdfx_failed=%d sidecars_%s=%d sidecar_errors=%d "
+        "refs_failed=%d",
+        "dry-run" if dry_run else "live",
+        stats["refs_scanned"], stats["refs_with_new_metadata"],
+        stats["sources_processed"], stats["sources_already_complete"],
+        stats["sources_mismatch"], stats["sources_download_failed"],
+        stats["sources_pdfx_failed"], verb, stats[count_key],
+        stats["sidecar_errors"], stats["refs_failed"],
+    )
+
+
+def backfill(  # pragma: no cover
+    mod_abbreviation: str = "",
+    reference: str = "",
+    limit: int = 0,
+    include_supplements: bool = True,
+    dry_run: bool = False,
+) -> Dict[str, int]:
+    db = create_postgres_session(False)
+    set_global_user_id(db, path.basename(__file__).replace(".py", ""))
+    stats: Dict[str, int] = defaultdict(int)
+
+    def get_token() -> str:
+        # Re-fetch per source PDF so a long run never trips an expired token.
+        return get_admin_token()
+
+    try:
+        if reference:
+            ref_obj = resolve_curie_to_reference(db, reference)
+            if ref_obj is None:
+                logger.error("Could not resolve reference: %s", reference)
+                return dict(stats)
+            references: List[ReferenceModel] = [ref_obj]
+            logger.info("Backfilling single reference %s", ref_obj.curie)
+        else:
+            ref_ids = select_references_needing_metadata(
+                db, mod_abbreviation=mod_abbreviation, limit=limit
+            )
+            scope = f" for {mod_abbreviation}" if mod_abbreviation else ""
+            logger.info(
+                "Found %d reference(s) with figures missing metadata "
+                "sidecars%s", len(ref_ids), scope,
+            )
+            references = [
+                db.query(ReferenceModel)
+                .filter(ReferenceModel.reference_id == rid)
+                .one()
+                for rid in ref_ids
+            ]
+
+        for ref_obj in references:
+            stats["refs_scanned"] += 1
+            try:
+                backfill_reference(
+                    db, ref_obj, get_token, dry_run, include_supplements, stats
+                )
+            except Exception as exc:
+                stats["refs_failed"] += 1
+                logger.error("Error backfilling %s: %s", ref_obj.curie, exc)
+                db.rollback()
+    finally:
+        _log_summary(stats, dry_run)
+        db.close()
+    return dict(stats)
+
+
+def main() -> None:  # pragma: no cover
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill JSON figure-metadata sidecars for already-converted "
+            "references (SCRUM-6246), re-running source PDFs through "
+            "marker-only PDFX."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--mod", default="",
+        help="Restrict to references whose figures are associated with this "
+             "MOD (e.g. WB); shared / PMC figures are always included.",
+    )
+    parser.add_argument(
+        "--reference", "--curie", dest="reference", default="",
+        help="Backfill a single reference (AGRKB id or xref curie like "
+             "PMID:12345678); ignores --mod/--limit. Useful for testing.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=0,
+        help="Cap the number of references processed (0 = no cap).",
+    )
+    parser.add_argument(
+        "--no-supplements", dest="include_supplements", action="store_false",
+        help="Skip supplement figures; backfill main figures only.",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Report what would change without re-running PDFX or uploading.",
+    )
+    parser.add_argument(
+        "--log-file", default="",
+        help="Optional path to also write logs to a file.",
+    )
+    args = parser.parse_args()
+    _configure_logging(args.log_file)
+    backfill(
+        mod_abbreviation=args.mod,
+        reference=args.reference,
+        limit=args.limit,
+        include_supplements=args.include_supplements,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md_utils.py
@@ -6,6 +6,7 @@ including PDFX API integration, reference lookup by curie, nXML conversion, and 
 retrieval for both main and supplemental files.
 """
 import gzip
+import json
 import logging
 import os
 import re
@@ -58,6 +59,32 @@ FIGURE_FILE_CLASSES: Dict[str, str] = {
 }
 # Marker emits .png; the manifest filenames also end in .png.
 CONVERTED_FIGURE_FILE_EXTENSION = "png"
+
+# file_class for the JSON metadata sidecar persisted next to each extracted
+# figure (SCRUM-6246). One per figure PNG, sharing the PNG's display_name —
+# the referencefile uniqueness key is (display_name, file_extension,
+# reference), so a .json can reuse the identical display_name as its .png.
+FIGURE_METADATA_FILE_CLASSES: Dict[str, str] = {
+    "main": "converted_main_figure_metadata",
+    "supplement": "converted_supplement_figure_metadata",
+}
+CONVERTED_FIGURE_METADATA_FILE_EXTENSION = "json"
+
+# PDFX manifest fields copied verbatim into each figure's metadata sidecar.
+# Always emitted (None when the manifest omits one) so the JSON schema is
+# predictable for AI Curation consumers. The transient presigned ``url`` is
+# deliberately NOT persisted: it expires, carries no provenance value, and
+# would make the JSON md5sum unstable across re-runs (defeating idempotency).
+_FIGURE_METADATA_MANIFEST_FIELDS = (
+    "figure_label",
+    "figure_number",
+    "caption_text",
+    "nearby_text",
+    "page_index",
+    "bbox",
+    "polygon",
+    "filename",
+)
 
 # MODs whose corpus membership makes a reference eligible for supplemental-PDF
 # conversion. Curating the supplements is expensive and only WB/ZFIN/FB
@@ -717,6 +744,116 @@ def download_pdfx_image(image_url: str) -> bytes:  # pragma: no cover
     return response.content
 
 
+def build_figure_metadata_payload(
+    image: Dict,
+    *,
+    figure_index: int,
+    figure_display_name: str,
+    source_display_name: str,
+    source_file_class: str,
+) -> Dict:
+    """
+    Build the JSON metadata payload persisted alongside an extracted figure
+    (SCRUM-6246).
+
+    Copies the documented PDFX manifest fields (see
+    :data:`_FIGURE_METADATA_MANIFEST_FIELDS`) plus every ``image_review_*``
+    field, and records the figure's own ``display_name`` / source linkage so
+    the sidecar is self-describing and — crucially — unique within the
+    reference. The referencefile ``(md5sum, reference)`` uniqueness constraint
+    means two figures of the same reference must not produce byte-identical
+    JSON; the per-figure ``display_name`` + ``figure_index`` guarantee that
+    even when every manifest metadata field is absent.
+
+    The transient presigned ``url`` is intentionally omitted so re-running the
+    same extraction yields byte-identical JSON (md5sum-stable → idempotent
+    uploads).
+    """
+    payload: Dict = {
+        "display_name": figure_display_name,
+        "figure_index": figure_index,
+        "source_display_name": source_display_name,
+        "source_file_class": source_file_class,
+    }
+    for field in _FIGURE_METADATA_MANIFEST_FIELDS:
+        payload[field] = image.get(field)
+    image_review = {
+        key: value
+        for key, value in image.items()
+        if key.startswith("image_review")
+    }
+    if image_review:
+        payload["image_review"] = image_review
+    return payload
+
+
+def serialize_figure_metadata(payload: Dict) -> bytes:
+    """
+    Serialize a figure-metadata payload deterministically (sorted keys, fixed
+    formatting) so identical metadata produces an identical md5sum on re-runs.
+    This is what makes the metadata uploads idempotent: a second run computes
+    the same md5 and ``file_upload_single`` short-circuits to a no-op.
+    """
+    return json.dumps(
+        payload, sort_keys=True, indent=2, ensure_ascii=False
+    ).encode("utf-8")
+
+
+def _upload_figure_metadata_sidecar(  # pragma: no cover
+    db: Session,
+    image: Dict,
+    *,
+    figure_index: int,
+    figure_display_name: str,
+    figure_metadata_file_class: str,
+    source_display_name: str,
+    source_file_class: str,
+    reference_curie: str,
+    mod_abbreviation: Optional[str],
+) -> None:
+    """
+    Build and upload the JSON metadata sidecar for one extracted figure.
+
+    The sidecar shares the figure PNG's ``display_name`` (the referencefile
+    uniqueness key is ``(display_name, file_extension, reference)``, so a
+    ``.json`` can reuse the identical ``display_name`` as its ``.png``) under
+    the dedicated metadata file_class. Reuses the standard ``file_upload``
+    path (md5sum dedup, MOD association, ``upload_if_already_converted``).
+    Raises on failure; the caller records the error without aborting the rest
+    of the conversion.
+    """
+    payload = build_figure_metadata_payload(
+        image,
+        figure_index=figure_index,
+        figure_display_name=figure_display_name,
+        source_display_name=source_display_name,
+        source_file_class=source_file_class,
+    )
+    metadata_bytes = serialize_figure_metadata(payload)
+    metadata = {
+        "reference_curie": reference_curie,
+        "display_name": figure_display_name,
+        "file_class": figure_metadata_file_class,
+        "file_publication_status": "final",
+        "file_extension": CONVERTED_FIGURE_METADATA_FILE_EXTENSION,
+        "pdf_type": None,
+        "is_annotation": None,
+        "mod_abbreviation": mod_abbreviation,
+    }
+    file_upload(
+        db=db,
+        metadata=metadata,
+        file=UploadFile(
+            file=BytesIO(metadata_bytes),
+            filename=(
+                f"{figure_display_name}."
+                f"{CONVERTED_FIGURE_METADATA_FILE_EXTENSION}"
+            ),
+        ),
+        upload_if_already_converted=True,
+    )
+
+
 def process_extracted_images(  # pragma: no cover
     db: Session,
     process_id: str,
@@ -739,9 +876,18 @@ def process_extracted_images(  # pragma: no cover
     manifest order) so names stay stable, sortable, and unique within a
     source PDF.
 
-    Returns ``(succeeded_count, failed_count, errors)``. Image-extraction
-    failures never raise — the caller's overall conversion still succeeds
-    based on the Markdown outputs.
+    For each figure PNG, a JSON metadata sidecar (SCRUM-6246) is also
+    persisted: same display_name as the PNG, ``json`` extension, under the
+    dedicated ``converted_*_figure_metadata`` file_class. The sidecar carries
+    the PDFX manifest's figure_label/figure_number/caption_text/page_index/
+    bbox/polygon/image_review_* fields. Sidecar failures are counted and
+    logged but never flip the figure's success — the PNG is the contract.
+
+    Returns ``(succeeded_count, failed_count, errors)`` where the counts
+    refer to figure PNGs (the primary artifact). Both image-extraction and
+    metadata-sidecar failures are appended to ``errors`` for visibility but
+    never raise — the caller's overall conversion still succeeds based on the
+    Markdown outputs.
     """
     figure_file_class = FIGURE_FILE_CLASSES.get(source_file_class)
     if figure_file_class is None:
@@ -751,6 +897,9 @@ def process_extracted_images(  # pragma: no cover
             f"{reference_curie}"
         )
         return 0, 0, []
+    figure_metadata_file_class = FIGURE_METADATA_FILE_CLASSES.get(
+        source_file_class
+    )
 
     try:
         manifest = download_pdfx_image_manifest(process_id, token)
@@ -769,6 +918,8 @@ def process_extracted_images(  # pragma: no cover
 
     succeeded = 0
     failed = 0
+    metadata_succeeded = 0
+    metadata_failed = 0
     errors: List[str] = []
 
     for idx, image in enumerate(images, start=1):
@@ -812,7 +963,7 @@ def process_extracted_images(  # pragma: no cover
         }
 
         try:
-            file_upload(
+            created = file_upload(
                 db=db,
                 metadata=metadata,
                 file=UploadFile(
@@ -832,12 +983,56 @@ def process_extracted_images(  # pragma: no cover
             logger.error(
                 f"Failed to upload extracted image {idx} for {reference_curie}: {e}"
             )
+            continue
+
+        # The PNG is the contract; its metadata sidecar is best-effort. Use the
+        # actual display_name assigned to the PNG (file_upload may have appended
+        # _N for uniqueness, or returned an existing row on a re-run) so the
+        # .json always matches its .png exactly rather than re-deriving from idx.
+        figure_display_name = output_display_name
+        if (
+            isinstance(created, list) and created
+            and isinstance(getattr(created[0], "display_name", None), str)
+        ):
+            figure_display_name = created[0].display_name
+
+        if figure_metadata_file_class is None:
+            continue
+        try:
+            _upload_figure_metadata_sidecar(
+                db=db,
+                image=image,
+                figure_index=idx,
+                figure_display_name=figure_display_name,
+                figure_metadata_file_class=figure_metadata_file_class,
+                source_display_name=source_display_name,
+                source_file_class=source_file_class,
+                reference_curie=reference_curie,
+                mod_abbreviation=mod_abbreviation,
+            )
+            metadata_succeeded += 1
+            logger.info(
+                f"Uploaded figure metadata sidecar for {reference_curie} as "
+                f"{figure_metadata_file_class} '{figure_display_name}'"
+            )
+        except Exception as e:
+            metadata_failed += 1
+            errors.append(
+                f"image {idx} ({figure_display_name}): "
+                f"metadata sidecar upload failed: {e}"
+            )
+            logger.error(
+                f"Failed to upload figure metadata sidecar {idx} for "
+                f"{reference_curie}: {e}"
+            )
 
     if succeeded or failed:
         logger.info(
             f"Image extraction for {reference_curie} "
             f"({source_file_class} '{source_display_name}'): "
-            f"{succeeded} succeeded, {failed} failed"
+            f"{succeeded} succeeded, {failed} failed; "
+            f"metadata sidecars {metadata_succeeded} succeeded, "
+            f"{metadata_failed} failed"
         )
     return succeeded, failed, errors
 

--- a/tests/api/test_file_conversion.py
+++ b/tests/api/test_file_conversion.py
@@ -226,6 +226,59 @@ class TestFiguresHelpers:
         ref = self._make_reference([])
         assert _figures_for_source(ref, "paper", "main") == []
 
+    def test_figures_for_source_links_metadata_sidecar(self):
+        """Each figure PNG is linked to its JSON metadata sidecar (same
+        display_name, parallel metadata file_class) via metadata_referencefile_id."""
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        rfs = [
+            self._make_ref_file("converted_main_figure", "paper_image_001", 10),
+            self._make_ref_file("converted_main_figure", "paper_image_002", 11),
+            self._make_ref_file("converted_main_figure_metadata", "paper_image_001", 110, file_extension="json"),
+            self._make_ref_file("converted_main_figure_metadata", "paper_image_002", 111, file_extension="json"),
+        ]
+        result = _figures_for_source(self._make_reference(rfs), "paper", "main")
+        assert [r["referencefile_id"] for r in result] == [10, 11]
+        assert [r["metadata_referencefile_id"] for r in result] == [110, 111]
+
+    def test_figures_for_source_metadata_id_none_when_no_sidecar(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        rfs = [
+            self._make_ref_file("converted_main_figure", "paper_image_001", 10),
+        ]
+        result = _figures_for_source(self._make_reference(rfs), "paper", "main")
+        assert result[0]["metadata_referencefile_id"] is None
+
+    def test_figures_for_source_metadata_requires_json_and_final(self):
+        """A sidecar row that is not json, or not final, is not linked."""
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        rfs = [
+            self._make_ref_file("converted_main_figure", "paper_image_001", 10),
+            # wrong extension
+            self._make_ref_file("converted_main_figure_metadata", "paper_image_001", 110, file_extension="txt"),
+            self._make_ref_file("converted_main_figure", "paper_image_002", 11),
+            # non-final
+            self._make_ref_file("converted_main_figure_metadata", "paper_image_002", 111, file_extension="json", file_publication_status="temp"),
+        ]
+        result = _figures_for_source(self._make_reference(rfs), "paper", "main")
+        assert [r["metadata_referencefile_id"] for r in result] == [None, None]
+
+    def test_figures_for_source_supplement_links_supplement_metadata(self):
+        from agr_literature_service.api.crud.file_conversion_crud import (
+            _figures_for_source,
+        )
+        rfs = [
+            self._make_ref_file("converted_supplement_figure", "supp1_image_001", 1),
+            self._make_ref_file("converted_supplement_figure_metadata", "supp1_image_001", 101, file_extension="json"),
+        ]
+        result = _figures_for_source(self._make_reference(rfs), "supp1", "supplement")
+        assert result[0]["metadata_referencefile_id"] == 101
+
     def test_attach_figures_mutates_each_progress_entry(self):
         from agr_literature_service.api.crud.file_conversion_crud import (
             _attach_figures,

--- a/tests/lit_processing/pdf2md/test_backfill_figure_metadata.py
+++ b/tests/lit_processing/pdf2md/test_backfill_figure_metadata.py
@@ -1,0 +1,123 @@
+"""Unit tests for the figure-metadata backfill planning logic (SCRUM-6246).
+
+Only the pure, side-effect-free helpers are unit-tested here; the DB/PDFX
+orchestration (select_references_needing_metadata, backfill_reference,
+_regenerate_image_manifest_marker_only) is integration-level and marked
+``# pragma: no cover``.
+"""
+from types import SimpleNamespace
+
+from agr_literature_service.lit_processing.pdf2md.backfill_figure_metadata import (
+    _first_mod_abbreviation,
+    plan_sidecars_for_source,
+)
+
+
+def _png(display_name):
+    return SimpleNamespace(display_name=display_name)
+
+
+class TestPlanSidecarsForSource:
+    def test_pairs_manifest_to_sorted_pngs(self):
+        # PNG rows provided out of order; planning sorts by display_name.
+        png_rows = [_png("paper_image_002"), _png("paper_image_001")]
+        images = [{"caption_text": "first"}, {"caption_text": "second"}]
+        planned, skipped, skip_reason = plan_sidecars_for_source(
+            png_rows, images, existing_metadata_names=set()
+        )
+        assert skip_reason is None
+        assert skipped == 0
+        assert [p["figure_display_name"] for p in planned] == [
+            "paper_image_001", "paper_image_002",
+        ]
+        assert [p["figure_index"] for p in planned] == [1, 2]
+        # Manifest entries are paired in order with the sorted PNGs.
+        assert planned[0]["image"] == {"caption_text": "first"}
+        assert planned[1]["image"] == {"caption_text": "second"}
+
+    def test_figure_index_parsed_from_display_name_not_position(self):
+        """figure_index comes from the PNG's ``_image_NNN`` ordinal, so a
+        gap (e.g. image 002 failed to download originally) yields [1, 3], not
+        the positional [1, 2] — keeping it consistent with the live path."""
+        png_rows = [_png("paper_image_001"), _png("paper_image_003")]
+        images = [{"a": 1}, {"a": 2}]
+        planned, _skipped, skip_reason = plan_sidecars_for_source(
+            png_rows, images, existing_metadata_names=set()
+        )
+        assert skip_reason is None
+        assert [p["figure_index"] for p in planned] == [1, 3]
+
+    def test_skips_pngs_that_already_have_a_sidecar(self):
+        png_rows = [_png("paper_image_001"), _png("paper_image_002")]
+        images = [{"a": 1}, {"a": 2}]
+        planned, skipped, skip_reason = plan_sidecars_for_source(
+            png_rows, images, existing_metadata_names={"paper_image_001"}
+        )
+        assert skip_reason is None
+        assert skipped == 1
+        assert [p["figure_display_name"] for p in planned] == ["paper_image_002"]
+        # figure_index reflects the figure's own ordinal (parsed from the
+        # display_name), not its position among the still-missing subset.
+        assert planned[0]["figure_index"] == 2
+
+    def test_all_sidecars_present_plans_nothing(self):
+        png_rows = [_png("paper_image_001"), _png("paper_image_002")]
+        images = [{"a": 1}, {"a": 2}]
+        planned, skipped, skip_reason = plan_sidecars_for_source(
+            png_rows, images,
+            existing_metadata_names={"paper_image_001", "paper_image_002"},
+        )
+        assert planned == []
+        assert skipped == 2
+        assert skip_reason is None
+
+    def test_count_mismatch_skips_source(self):
+        png_rows = [_png("paper_image_001"), _png("paper_image_002")]
+        images = [{"a": 1}, {"a": 2}, {"a": 3}]  # one extra image
+        planned, skipped, skip_reason = plan_sidecars_for_source(
+            png_rows, images, existing_metadata_names=set()
+        )
+        assert skip_reason is not None
+        assert "manifest has 3 image(s) but 2 existing" in skip_reason
+        assert planned == []
+        assert skipped == 0
+
+    def test_fewer_images_than_figures_skips_source(self):
+        png_rows = [_png("paper_image_001"), _png("paper_image_002")]
+        images = [{"a": 1}]
+        _planned, _skipped, skip_reason = plan_sidecars_for_source(
+            png_rows, images, existing_metadata_names=set()
+        )
+        assert skip_reason is not None
+
+    def test_non_canonical_png_name_skips_source(self):
+        """A renamed PNG (``_image_002_1`` from a prior re-conversion) breaks
+        the sorted-order==manifest-order assumption, so the whole source is
+        skipped rather than risk attaching a caption to the wrong figure —
+        even though the image count happens to match."""
+        png_rows = [_png("paper_image_001"), _png("paper_image_002_1")]
+        images = [{"a": 1}, {"a": 2}]
+        planned, _skipped, skip_reason = plan_sidecars_for_source(
+            png_rows, images, existing_metadata_names=set()
+        )
+        assert skip_reason is not None
+        assert "non-canonical" in skip_reason
+        assert planned == []
+
+
+class TestFirstModAbbreviation:
+    def test_returns_first_non_null_mod(self):
+        ref_file = SimpleNamespace(referencefile_mods=[
+            SimpleNamespace(mod=None),
+            SimpleNamespace(mod=SimpleNamespace(abbreviation="WB")),
+            SimpleNamespace(mod=SimpleNamespace(abbreviation="ZFIN")),
+        ])
+        assert _first_mod_abbreviation(ref_file) == "WB"
+
+    def test_returns_none_when_only_null_mod(self):
+        ref_file = SimpleNamespace(referencefile_mods=[SimpleNamespace(mod=None)])
+        assert _first_mod_abbreviation(ref_file) is None
+
+    def test_returns_none_when_no_associations(self):
+        assert _first_mod_abbreviation(SimpleNamespace(referencefile_mods=[])) is None
+        assert _first_mod_abbreviation(SimpleNamespace(referencefile_mods=None)) is None

--- a/tests/lit_processing/pdf2md/test_pdf2md_utils.py
+++ b/tests/lit_processing/pdf2md/test_pdf2md_utils.py
@@ -18,9 +18,13 @@ import requests
 from agr_literature_service.lit_processing.pdf2md import pdf2md_utils
 from agr_literature_service.lit_processing.pdf2md.pdf2md_utils import (
     CONVERTED_FIGURE_FILE_EXTENSION,
+    CONVERTED_FIGURE_METADATA_FILE_EXTENSION,
     ELIGIBLE_SUPPLEMENT_MODS,
     EXTRACTION_METHODS,
     FIGURE_FILE_CLASSES,
+    FIGURE_METADATA_FILE_CLASSES,
+    build_figure_metadata_payload,
+    serialize_figure_metadata,
     PdfDetail,
     ProcessingResult,
     submit_pdf_to_pdfx,
@@ -665,6 +669,18 @@ class TestFigureFileClasses:
     def test_default_extension_is_png(self):
         assert CONVERTED_FIGURE_FILE_EXTENSION == "png"
 
+    def test_metadata_classes_parallel_the_figure_classes(self):
+        assert FIGURE_METADATA_FILE_CLASSES["main"] == \
+            "converted_main_figure_metadata"
+        assert FIGURE_METADATA_FILE_CLASSES["supplement"] == \
+            "converted_supplement_figure_metadata"
+        # The metadata mapping must cover exactly the same source classes as
+        # the figure mapping so every PNG can get a sidecar.
+        assert set(FIGURE_METADATA_FILE_CLASSES) == set(FIGURE_FILE_CLASSES)
+
+    def test_metadata_extension_is_json(self):
+        assert CONVERTED_FIGURE_METADATA_FILE_EXTENSION == "json"
+
 
 class TestDownloadPdfxImageManifest:
     """Test download_pdfx_image_manifest function."""
@@ -795,8 +811,10 @@ class TestProcessExtractedImages:
         assert succeeded == 2
         assert failed == 0
         assert errors == []
-        assert mock_upload.call_count == 2
-        # Verify the first image's metadata mirrors the converted-MD convention.
+        # Each figure now produces TWO uploads: the PNG and its JSON sidecar,
+        # interleaved per image (PNG1, JSON1, PNG2, JSON2).
+        assert mock_upload.call_count == 4
+        # Verify the first image's PNG metadata mirrors the converted-MD convention.
         first_metadata = mock_upload.call_args_list[0].kwargs["metadata"]
         assert first_metadata["display_name"] == "paper_image_001"
         assert first_metadata["file_class"] == "converted_main_figure"
@@ -806,6 +824,15 @@ class TestProcessExtractedImages:
         assert first_metadata["reference_curie"] == "AGRKB:1"
         assert first_metadata["pdf_type"] is None
         assert first_metadata["is_annotation"] is None
+        # The sidecar follows the PNG, sharing its display_name, json
+        # extension and the dedicated metadata file_class.
+        first_sidecar = mock_upload.call_args_list[1].kwargs["metadata"]
+        assert first_sidecar["display_name"] == "paper_image_001"
+        assert first_sidecar["file_class"] == "converted_main_figure_metadata"
+        assert first_sidecar["file_extension"] == "json"
+        assert first_sidecar["file_publication_status"] == "final"
+        assert first_sidecar["mod_abbreviation"] == "WB"
+        assert first_sidecar["reference_curie"] == "AGRKB:1"
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image")
@@ -828,9 +855,16 @@ class TestProcessExtractedImages:
             mod_abbreviation=None,
         )
 
-        metadata = mock_upload.call_args.kwargs["metadata"]
-        assert metadata["file_class"] == "converted_supplement_figure"
-        assert metadata["display_name"] == "supp1_image_001"
+        # call 0 = the PNG, call 1 = its JSON sidecar.
+        png_metadata = mock_upload.call_args_list[0].kwargs["metadata"]
+        assert png_metadata["file_class"] == "converted_supplement_figure"
+        assert png_metadata["display_name"] == "supp1_image_001"
+        assert png_metadata["file_extension"] == "png"
+        sidecar_metadata = mock_upload.call_args_list[1].kwargs["metadata"]
+        assert sidecar_metadata["file_class"] == \
+            "converted_supplement_figure_metadata"
+        assert sidecar_metadata["display_name"] == "supp1_image_001"
+        assert sidecar_metadata["file_extension"] == "json"
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload")
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image")
@@ -861,8 +895,9 @@ class TestProcessExtractedImages:
         assert failed == 1
         assert len(errors) == 1
         assert "S3 timeout" in errors[0]
-        # Two successful uploads should have been attempted.
-        assert mock_upload.call_count == 2
+        # Two PNGs succeeded, each followed by its JSON sidecar (the middle
+        # image failed to download, so no upload at all for it): 2 x 2 = 4.
+        assert mock_upload.call_count == 4
 
     @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
     def test_manifest_entry_missing_url_is_recorded_as_failure(self, mock_manifest):
@@ -889,6 +924,223 @@ class TestProcessExtractedImages:
         assert succeeded == 1
         assert failed == 1
         assert any("missing 'url'" in e for e in errors)
+
+
+class TestBuildFigureMetadataPayload:
+    """Tests for build_figure_metadata_payload (SCRUM-6246)."""
+
+    def _full_image(self):
+        return {
+            "filename": "_page_2_Figure_3.png",
+            "url": "https://s3.example/presigned?sig=abc",
+            "figure_label": "Figure 3",
+            "figure_number": 3,
+            "caption_text": "Expression of gene X in the gut.",
+            "nearby_text": "As shown in Figure 3...",
+            "page_index": 2,
+            "bbox": [10, 20, 110, 220],
+            "polygon": [[10, 20], [110, 20], [110, 220], [10, 220]],
+            "image_review_is_figure": True,
+            "image_review_score": 0.97,
+        }
+
+    def test_includes_documented_manifest_fields(self):
+        payload = build_figure_metadata_payload(
+            self._full_image(),
+            figure_index=3,
+            figure_display_name="paper_image_003",
+            source_display_name="paper",
+            source_file_class="main",
+        )
+        assert payload["figure_label"] == "Figure 3"
+        assert payload["figure_number"] == 3
+        assert payload["caption_text"] == "Expression of gene X in the gut."
+        assert payload["nearby_text"] == "As shown in Figure 3..."
+        assert payload["page_index"] == 2
+        assert payload["bbox"] == [10, 20, 110, 220]
+        assert payload["polygon"] == [[10, 20], [110, 20], [110, 220], [10, 220]]
+        assert payload["filename"] == "_page_2_Figure_3.png"
+
+    def test_collects_image_review_fields(self):
+        payload = build_figure_metadata_payload(
+            self._full_image(),
+            figure_index=3,
+            figure_display_name="paper_image_003",
+            source_display_name="paper",
+            source_file_class="main",
+        )
+        assert payload["image_review"] == {
+            "image_review_is_figure": True,
+            "image_review_score": 0.97,
+        }
+
+    def test_records_figure_and_source_linkage(self):
+        payload = build_figure_metadata_payload(
+            self._full_image(),
+            figure_index=3,
+            figure_display_name="paper_image_003",
+            source_display_name="paper",
+            source_file_class="main",
+        )
+        assert payload["display_name"] == "paper_image_003"
+        assert payload["figure_index"] == 3
+        assert payload["source_display_name"] == "paper"
+        assert payload["source_file_class"] == "main"
+
+    def test_missing_manifest_fields_default_to_none(self):
+        """A bare manifest entry still yields a predictable schema: the
+        documented fields are present as None, no image_review key."""
+        payload = build_figure_metadata_payload(
+            {"url": "https://s3/x"},
+            figure_index=1,
+            figure_display_name="paper_image_001",
+            source_display_name="paper",
+            source_file_class="main",
+        )
+        for field in ("figure_label", "figure_number", "caption_text",
+                      "nearby_text", "page_index", "bbox", "polygon"):
+            assert payload[field] is None
+        assert "image_review" not in payload
+
+    def test_excludes_transient_presigned_url(self):
+        payload = build_figure_metadata_payload(
+            self._full_image(),
+            figure_index=3,
+            figure_display_name="paper_image_003",
+            source_display_name="paper",
+            source_file_class="main",
+        )
+        assert "url" not in payload
+
+
+class TestSerializeFigureMetadata:
+    """Tests for serialize_figure_metadata determinism (idempotency)."""
+
+    def test_key_order_does_not_change_bytes(self):
+        a = serialize_figure_metadata({"b": 1, "a": 2})
+        b = serialize_figure_metadata({"a": 2, "b": 1})
+        assert a == b
+
+    def test_identical_payload_yields_identical_bytes(self):
+        payload = {"display_name": "paper_image_001", "figure_number": 1}
+        assert serialize_figure_metadata(payload) == \
+            serialize_figure_metadata(dict(payload))
+
+    def test_returns_utf8_bytes(self):
+        out = serialize_figure_metadata({"caption_text": "café α-helix"})
+        assert isinstance(out, bytes)
+        assert "café α-helix" in out.decode("utf-8")
+
+
+class TestProcessExtractedImagesMetadataSidecar:
+    """process_extracted_images persists a JSON sidecar per figure."""
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_sidecar_uses_actual_png_display_name(
+        self, mock_manifest, mock_download
+    ):
+        """When file_upload renames the PNG (returns a row whose display_name
+        differs from the idx-derived name), the sidecar reuses that exact
+        name rather than re-deriving from idx."""
+        mock_manifest.return_value = {
+            "images": [{"filename": "x.png", "url": "https://s3/a",
+                        "caption_text": "cap"}]
+        }
+        mock_download.return_value = b"\x89PNG"
+
+        with patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload"
+        ) as mock_upload:
+            # PNG upload returns a renamed row; sidecar upload return is ignored.
+            mock_upload.side_effect = [
+                [SimpleNamespace(display_name="paper_image_001_7")],
+                None,
+            ]
+            process_extracted_images(
+                db=MagicMock(),
+                process_id="abc",
+                token="t",
+                source_display_name="paper",
+                source_file_class="main",
+                reference_curie="AGRKB:1",
+                mod_abbreviation="WB",
+            )
+
+        sidecar_metadata = mock_upload.call_args_list[1].kwargs["metadata"]
+        assert sidecar_metadata["display_name"] == "paper_image_001_7"
+        assert sidecar_metadata["file_class"] == "converted_main_figure_metadata"
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_sidecar_failure_does_not_fail_the_figure(
+        self, mock_manifest, mock_download
+    ):
+        """A sidecar upload error is recorded but the PNG still counts as a
+        success — the figure PNG is the contract."""
+        mock_manifest.return_value = {
+            "images": [{"filename": "x.png", "url": "https://s3/a"}]
+        }
+        mock_download.return_value = b"\x89PNG"
+
+        with patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload"
+        ) as mock_upload:
+            mock_upload.side_effect = [
+                [SimpleNamespace(display_name="paper_image_001")],
+                RuntimeError("disk full"),
+            ]
+            succeeded, failed, errors = process_extracted_images(
+                db=MagicMock(),
+                process_id="abc",
+                token="t",
+                source_display_name="paper",
+                source_file_class="main",
+                reference_curie="AGRKB:1",
+                mod_abbreviation="WB",
+            )
+
+        assert succeeded == 1
+        assert failed == 0
+        assert any("metadata sidecar" in e and "disk full" in e for e in errors)
+
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image")
+    @patch("agr_literature_service.lit_processing.pdf2md.pdf2md_utils.download_pdfx_image_manifest")
+    def test_sidecar_content_has_metadata_but_not_presigned_url(
+        self, mock_manifest, mock_download
+    ):
+        """The persisted JSON carries the manifest metadata but never the
+        transient presigned URL."""
+        mock_manifest.return_value = {
+            "images": [{"filename": "x.png",
+                        "url": "https://s3.example/presigned?sig=SECRET",
+                        "caption_text": "a caption"}]
+        }
+        mock_download.return_value = b"\x89PNG"
+
+        with patch(
+            "agr_literature_service.lit_processing.pdf2md.pdf2md_utils.file_upload"
+        ) as mock_upload:
+            mock_upload.side_effect = [
+                [SimpleNamespace(display_name="paper_image_001")],
+                None,
+            ]
+            process_extracted_images(
+                db=MagicMock(),
+                process_id="abc",
+                token="t",
+                source_display_name="paper",
+                source_file_class="main",
+                reference_curie="AGRKB:1",
+                mod_abbreviation="WB",
+            )
+
+        sidecar_file = mock_upload.call_args_list[1].kwargs["file"]
+        content = sidecar_file.file.read()
+        assert b"a caption" in content
+        assert b"paper_image_001" in content
+        assert b"SECRET" not in content
+        assert b"presigned" not in content
 
 
 class TestEligibleSupplementMods:


### PR DESCRIPTION
## What & why

Addresses the ABC Literature side of **KANBAN-1384** (Doug Howe / AI Curation need figure-and-panel provenance plus figure **legends** for gene-expression extractions). Today the pdf2md pipeline fetches the PDFX/Marker image manifest but **discards all of its metadata** — only the figure PNGs are persisted as ordinary `referencefile` rows. This PR persists each figure's manifest metadata as a JSON sidecar so AI Curation can query legends and map evidence to a figure.

Tracked as **SCRUM-6246**.

## Changes

1. **Persist a metadata sidecar** (`lit_processing/pdf2md/pdf2md_utils.py`) — `process_extracted_images` now uploads a deterministic JSON sidecar per figure: same `display_name` as the figure PNG, `.json` extension, under new file_classes `converted_main_figure_metadata` / `converted_supplement_figure_metadata`. Fields persisted: `figure_label`, `figure_number`, `caption_text` (the legend), `nearby_text`, `page_index`, `bbox`, `polygon`, `filename`, and `image_review_*`. Serialized with sorted keys → md5sum-stable → idempotent; the transient presigned `url` is excluded. Sidecar failures are logged but never fail the conversion. This single change covers **both** the cron batch (`pdf2md.py`) and the on-demand conversion API (both funnel through `_process_single_pdf_file`).
2. **Expose it** (`api/schemas/file_conversion_schemas.py`, `api/crud/file_conversion_crud.py`) — `ConversionFileInfo` gains `metadata_referencefile_id`, and `_figures_for_source` links each figure PNG to its sidecar (matched by shared `display_name`). `show_all` returns the sidecar rows unchanged. **No DB column / migration** — metadata lives in the JSON referencefile.
3. **Backfill** (`lit_processing/pdf2md/backfill_figure_metadata.py`, new) — finds already-converted references whose figures lack a sidecar and re-runs each source PDF through **marker-only** PDFX (`methods=marker, merge=False` — skips Grobid/Docling/merge to **save credits**; image-review left on). Attach-only (never re-uploads PNGs), idempotent, resumable, `--dry-run`, single-`--reference`/`--curie` mode, `--mod`, `--limit`, `--no-supplements`. Targets **only** the Marker `converted_*_figure` classes and refuses a source whose figure names are non-canonical or whose regenerated manifest count doesn't match, to avoid mis-associating a caption to the wrong figure.

## Scope (verified against prod)

276 references / ~2,786 Marker-extracted figures need backfill (274 still have a source PDF). This explicitly **excludes** the ~3.14M-file `figure` class (images downloaded from PMC/PubMed or manually uploaded) — those are never touched.

## Testing

Unit tests added/updated for the payload builder, deterministic serialization, the sidecar upload (incl. failure isolation and the PNG-rename case), the API linking, and all backfill planning branches. Verified via CI (the test DB is wiped if run locally). `flake8` + `mypy` pass.

## Independent review

An independent review confirmed all 4 acceptance criteria are met (no blocker/high). Two MEDIUM findings were fixed in this branch: `figure_index` is now parsed from the PNG ordinal so it's consistent between the live and backfill paths; and the backfill refuses sources with non-canonical figure names (plus a per-attach audit log).

---

## @christabone — consumer-contract questions (please review)

The metadata is **one JSON sidecar file per figure** (not a separate store/columns) — every field, **including `image_review_*`, lives inside that single `.json`**. Could you confirm the contract so AI Curation can build against it without rework?

- **`image_review_*`** — these are PDFX's per-image LLM image-review fields. I persist them **inside the same sidecar, nested under an `image_review` object** (original keys preserved, e.g. `image_review.image_review_score`). Do you want them **flat at the top level** instead (`image_review_score`, …)? Easy to change.
- **PNG → metadata mapping** — will you map via the **shared `display_name`** (through `show_all`), via **`metadata_referencefile_id`** (conversion API figures listing), or both?
- **Legend field** — is **`caption_text`** the legend you need, or should you read `nearby_text`? (Both are persisted.)
- **Panel-level provenance** — the PDFX manifest is **figure-level** (no panel field), so this delivers figure number + legend + bbox but **not panel numbering**. Is figure-level sufficient for the gene-expression use case, or do you need panels (which would be a separate, PDFX/extraction-side problem)?
- **`bbox`/`polygon`** — do you need page dimensions to interpret the coordinates, or is the raw bbox/polygon enough? (`page_index` is included; page size is not.)

Coordination (non-blocking): the backfill re-runs marker-only PDFX on ~274 references (credits + time) — happy to align on timing, and to ship the live-path change first so no new gaps accumulate during the backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
