### PR TITLE
fix(pdf2md): suppress file-upload WFT transition during figure-metadata backfill (SCRUM-6246)

### DIFF
--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -49,6 +49,31 @@ file_needed_tag_atp_id = "ATP:0000141"
 text_conversion_process_atp_id = "ATP:0000161"
 
 
+# TRANSIENT (SCRUM-6246 figure-metadata backfill): a one-off process may flip
+# this so file_upload() persists *auxiliary* files (e.g. the figure-metadata
+# JSON sidecars) WITHOUT firing transition_WFT_for_uploaded_file or pruning
+# superseded main PDFs via cleanup_old_pdf_file. The reference's file-upload
+# workflow status was already set when the figures were originally converted, so
+# re-attaching descriptor files must not move it or trigger downstream
+# reprocessing. Default is False, so the live API / conversion path is
+# unaffected — only the backfill script activates it, for the duration of its
+# run (see lit_processing/pdf2md/backfill_figure_metadata.py). Process-level
+# (module global): the standalone backfill runs in its own process, so this
+# never leaks into the API or cron conversion processes.
+_suppress_post_upload_workflow = False
+
+
+def set_suppress_post_upload_workflow(value: bool) -> None:
+    """Toggle suppression of file_upload()'s post-upload workflow side effects
+    (transition + main-PDF cleanup). See ``_suppress_post_upload_workflow``."""
+    global _suppress_post_upload_workflow
+    _suppress_post_upload_workflow = bool(value)
+
+
+def is_post_upload_workflow_suppressed() -> bool:
+    return _suppress_post_upload_workflow
+
+
 def get_main_pdf_referencefile_id(db: Session, curie_or_reference_id: str,
                                   mod_abbreviation: str = None) -> Union[int, None]:
     logger.info("Getting main pdf referencefile")
@@ -514,10 +539,17 @@ def file_upload(db: Session, metadata: dict, file: UploadFile, upload_if_already
     else:
         created_referencefiles.append(file_upload_single(db, metadata, file))
     mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None
-    cleanup_old_pdf_file(db, metadata["reference_curie"], mod_abbreviation)
-    transition_WFT_for_uploaded_file(db, metadata["reference_curie"], mod_abbreviation,
-                                     metadata["file_class"], metadata["pdf_type"],
-                                     metadata["file_publication_status"])
+    if _suppress_post_upload_workflow:
+        # Auxiliary upload (e.g. figure-metadata sidecar): persist the file but
+        # do not move the reference's workflow status or prune its main PDFs.
+        # transition_WFT_for_uploaded_file is normally the committing step, so
+        # commit explicitly to guarantee the new referencefile is persisted.
+        db.commit()
+    else:
+        cleanup_old_pdf_file(db, metadata["reference_curie"], mod_abbreviation)
+        transition_WFT_for_uploaded_file(db, metadata["reference_curie"], mod_abbreviation,
+                                         metadata["file_class"], metadata["pdf_type"],
+                                         metadata["file_publication_status"])
     return created_referencefiles
 
 

--- a/agr_literature_service/lit_processing/pdf2md/backfill_figure_metadata.py
+++ b/agr_literature_service/lit_processing/pdf2md/backfill_figure_metadata.py
@@ -19,10 +19,15 @@ Idempotent and resumable: a figure whose sidecar already exists is skipped
 (detected by display_name), and ``file_upload``'s md5sum dedup makes a re-run
 of an identical sidecar a no-op. Safe to re-run after an interruption.
 
-Note: each sidecar goes through the standard ``file_upload`` path, which fires
-``transition_WFT_for_uploaded_file``. For already-converted references the
-file-upload workflow is past its only actionable state, so this is a no-op —
-the same side effect the original figure-PNG uploads already triggered.
+Note: each sidecar goes through the standard ``file_upload`` path. Because these
+references were already converted, this run activates
+``set_suppress_post_upload_workflow(True)`` so attaching the descriptor sidecars
+does NOT re-fire ``transition_WFT_for_uploaded_file`` or prune main PDFs — it
+must not move the reference's file-upload workflow status or trigger downstream
+reprocessing. (Firing the transition here also breaks on the 2nd+ sidecar of a
+reference: when the ATP descendants cache is cold the status lookup returns
+None, so every upload retries the create and collides on the unique
+file-upload WFT.) The sidecars are still persisted and md5-deduped as usual.
 
 Examples:
     # Dry run over everything that still needs metadata
@@ -48,7 +53,10 @@ from sqlalchemy.orm import Session, aliased
 
 from agr_cognito_py import ModAccess, get_admin_token
 
-from agr_literature_service.api.crud.referencefile_crud import download_file
+from agr_literature_service.api.crud.referencefile_crud import (
+    download_file,
+    set_suppress_post_upload_workflow,
+)
 from agr_literature_service.api.models import (
     ModModel,
     ReferencefileModel,
@@ -458,6 +466,14 @@ def backfill(  # pragma: no cover
     set_global_user_id(db, path.basename(__file__).replace(".py", ""))
     stats: Dict[str, int] = defaultdict(int)
 
+    # These references were already converted; their file-upload workflow status
+    # is set. Attaching metadata sidecars must NOT re-fire the file-upload
+    # transition (which would spuriously create a "file upload in progress" tag
+    # and, on the 2nd+ sidecar of a reference, fail with a duplicate-WFT 422) or
+    # prune main PDFs. Suppress those post-upload side effects for this one-off
+    # run; the descriptor files are still persisted and md5-deduped as usual.
+    set_suppress_post_upload_workflow(True)
+
     def get_token() -> str:
         # Re-fetch per source PDF so a long run never trips an expired token.
         return get_admin_token()
@@ -497,6 +513,7 @@ def backfill(  # pragma: no cover
                 logger.error("Error backfilling %s: %s", ref_obj.curie, exc)
                 db.rollback()
     finally:
+        set_suppress_post_upload_workflow(False)
         _log_summary(stats, dry_run)
         db.close()
     return dict(stats)

--- a/tests/api/test_file_conversion.py
+++ b/tests/api/test_file_conversion.py
@@ -14,7 +14,9 @@ Conversion primitives (process_nxml_to_markdown / process_pdf_for_reference) are
 mocked — the real ones would call PDFX and S3.
 """
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+
+import agr_literature_service.api.crud.referencefile_crud as referencefile_crud
 
 from fastapi import status
 from starlette.testclient import TestClient
@@ -51,6 +53,68 @@ def clear_global_manager():
 @pytest.fixture
 def manager():
     return ConversionJobManager()
+
+
+class TestSuppressPostUploadWorkflow:
+    """SCRUM-6246: a one-off process (the figure-metadata backfill) can flip a
+    process-level toggle so file_upload() persists auxiliary files WITHOUT
+    firing the file-upload workflow transition or pruning superseded main PDFs.
+    Default (live API / conversion path) is unchanged: the transition fires."""
+
+    @staticmethod
+    def _metadata():
+        # A figure-metadata sidecar: not main/pdf/final, mod-less so the
+        # corpus / upload-blocked guards are skipped (mod_abbreviation is None).
+        return {
+            "reference_curie": "AGRKB:101000000000001",
+            "mod_abbreviation": None,
+            "file_class": "converted_main_figure_metadata",
+            "file_publication_status": "final",
+            "file_extension": "json",
+            "pdf_type": None,
+        }
+
+    def test_default_fires_transition_and_cleanup(self):
+        mock_db = MagicMock()
+        with patch.object(referencefile_crud, "normalize_reference_curie",
+                          side_effect=lambda _db, curie: curie), \
+                patch.object(referencefile_crud, "file_upload_single",
+                             return_value=MagicMock()), \
+                patch.object(referencefile_crud, "cleanup_old_pdf_file") as cleanup, \
+                patch.object(referencefile_crud,
+                             "transition_WFT_for_uploaded_file") as transition:
+            referencefile_crud.file_upload(mock_db, self._metadata(), MagicMock())
+            transition.assert_called_once()
+            cleanup.assert_called_once()
+
+    def test_suppress_skips_transition_and_cleanup_but_commits(self):
+        mock_db = MagicMock()
+        with patch.object(referencefile_crud, "normalize_reference_curie",
+                          side_effect=lambda _db, curie: curie), \
+                patch.object(referencefile_crud, "file_upload_single",
+                             return_value=MagicMock()), \
+                patch.object(referencefile_crud, "cleanup_old_pdf_file") as cleanup, \
+                patch.object(referencefile_crud,
+                             "transition_WFT_for_uploaded_file") as transition:
+            referencefile_crud.set_suppress_post_upload_workflow(True)
+            try:
+                referencefile_crud.file_upload(mock_db, self._metadata(), MagicMock())
+            finally:
+                referencefile_crud.set_suppress_post_upload_workflow(False)
+            transition.assert_not_called()
+            cleanup.assert_not_called()
+            # The created referencefile must still be persisted even though the
+            # transition (which used to be the committing step) was skipped.
+            mock_db.commit.assert_called_once()
+
+    def test_setter_toggles_and_resets_module_state(self):
+        assert referencefile_crud.is_post_upload_workflow_suppressed() is False
+        referencefile_crud.set_suppress_post_upload_workflow(True)
+        try:
+            assert referencefile_crud.is_post_upload_workflow_suppressed() is True
+        finally:
+            referencefile_crud.set_suppress_post_upload_workflow(False)
+        assert referencefile_crud.is_post_upload_workflow_suppressed() is False
 
 
 class TestConversionJob:


### PR DESCRIPTION
## Summary

Follow-up fix to #1217 (SCRUM-6246). Surfaced while running the figure-metadata backfill on **stage** (one main + one supplement reference).

### The bug
The backfill uploads one JSON metadata sidecar per converted figure through the shared `file_upload()` path, which fires `transition_WFT_for_uploaded_file`. For already-converted references the ATP descendants cache is **cold in the one-off backfill process**, so `get_current_workflow_status(...)` returns `None` on every call. The first sidecar then *creates* the "file upload in progress" tag (`ATP:0000139`) and the **2nd+ sidecar of the same reference collides on the unique file-upload WFT → 422**. It also spuriously regresses a reference that was already at "files uploaded" (`ATP:0000134`).

Observed on stage: sidecar #1 attached, #2–#8 failed with `422 ... ATP:0000139 already exist ... can not create duplicate record`.

### The fix
A **process-level toggle** in `referencefile_crud` (mirrors the transient SCRUM-5795 `converted_*` upload bypass that SCRUM-5867 removed):

- `set_suppress_post_upload_workflow(True/False)` + `is_post_upload_workflow_suppressed()`
- When active, `file_upload()` still persists **and commits** the uploaded file but skips `transition_WFT_for_uploaded_file` and `cleanup_old_pdf_file`.
- The **backfill activates it for the duration of each run** (reset in `finally`). It's a standalone process, so the global never leaks into the API/cron conversion processes.
- **Live API / conversion path is unchanged** (default off) — real conversion artifacts still drive the workflow.

Rationale: these references were already converted; attaching auxiliary descriptor files must not move the file-upload workflow status or trigger downstream reprocessing.

### Verification (stage, against `literature-dev`)
- Cleaned the stray `ATP:0000139` left by the buggy run on `AGRKB:101000000657446`; confirmed it returns to `ATP:0000134` with 8 PNGs ↔ 8 sidecars.
- Ran the fixed backfill on a **pristine** supplement reference `AGRKB:101000001213127`: **6 sidecars added, 0 errors**, 6 PNGs ↔ 6 sidecars, **no stray `ATP:0000139`**, workflow stays at `ATP:0000134`. Sidecar JSON well-formed (manifest fields + nested `image_review`, `url` excluded).
- `flake8` + `mypy` clean; added unit tests for the toggle in `tests/api/test_file_conversion.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)