### PR TITLE
server-side aggregates and validate write path for the TET grid

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1260,7 +1260,7 @@ def _ci_in(column, values):
     return func.upper(column).in_(upper_values)
 
 
-def _apply_batch_tag_filters(query, filters: Optional[Dict[str, Any]]):
+def _apply_batch_tag_filters(query, filters: Optional[Dict[str, Any]]):  # noqa: C901
     """Restrict a TET query to the tags the initial search asked for.
 
     Mirrors the TET facet criteria the search UI sends (searchActions.js). The
@@ -1332,6 +1332,18 @@ def _apply_batch_tag_filters(query, filters: Optional[Dict[str, Any]]):
             query = query.filter(or_(*positive_conditions))
 
     # --- per-tag refinements, applied in both modes -------------------------- #
+    # MOD scope (the search's corpus facet): keep only tags owned by one of the
+    # selected MODs, i.e. whose source's secondary_data_provider matches (the same
+    # field create_or_update uses for created_by_mod). Applied to ALL tags --
+    # curator validations included -- so a WB-scoped grid never shows another
+    # MOD's tags (e.g. an fb_svm_classifier / FB source) on a shared reference.
+    mods = filters.get("mods")
+    if mods:
+        upper_mods = [str(m).upper() for m in mods if m]
+        query = query.filter(TopicEntityTagModel.topic_entity_tag_source.has(
+            TopicEntityTagSourceModel.secondary_data_provider.has(
+                func.upper(ModModel.abbreviation).in_(upper_mods))))
+
     entity_types = filters.get("entity_types")
     if entity_types:
         query = query.filter(_ci_in(TopicEntityTagModel.entity_type, entity_types))

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1547,6 +1547,42 @@ def _build_tag_entries(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict[
     return entries_by_ref_topic
 
 
+def _build_validation_states(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict[str, str]]:
+    """Aggregate the curator validation state per reference -> topic so the grid's
+    Validation column can sort/filter (and ultimately render) without deriving it
+    from raw tags client-side.
+
+    Mirrors the UI's validationState (groupTets.js): only *topic-level* tags
+    (no entity) from a professional-biocurator/curator source count as a
+    validation. A topic is 'conflict' when it has both a positive and a negative
+    such tag, else 'positive' / 'negative'. Topics with no curator validation are
+    omitted -- the client treats an absent topic as 'unvalidated', matching
+    validationState's empty-list behavior. Topic keys are uppercased to match the
+    UI's normalizeCurie."""
+    polarity: Dict[int, Dict[str, Dict[str, bool]]] = defaultdict(
+        lambda: defaultdict(lambda: {"pos": False, "neg": False}))
+    for tag in serialized_tags:
+        if tag.get("entity") or not _is_curator_source_tag(tag):
+            continue
+        ref_id = tag["reference_id"]
+        topic = str(tag.get("topic") or "").upper()
+        if tag.get("negated"):
+            polarity[ref_id][topic]["neg"] = True
+        else:
+            polarity[ref_id][topic]["pos"] = True
+
+    states: Dict[int, Dict[str, str]] = defaultdict(dict)
+    for ref_id, by_topic in polarity.items():
+        for topic, pol in by_topic.items():
+            if pol["pos"] and pol["neg"]:
+                states[ref_id][topic] = "conflict"
+            elif pol["pos"]:
+                states[ref_id][topic] = "positive"
+            else:
+                states[ref_id][topic] = "negative"
+    return states
+
+
 def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids: List[str],
                                            filters: Optional[Dict[str, Any]] = None):
     """Batch variant of show_all_reference_tags.
@@ -1598,6 +1634,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
             "tags": {ident: [] for ident in ident_to_ref_id},
             "counts": {ident: {} for ident in ident_to_ref_id},
             "entries": {ident: {} for ident in ident_to_ref_id},
+            "validation": {ident: {} for ident in ident_to_ref_id},
             "debug_timing": None
         }
 
@@ -1638,6 +1675,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
         tags_by_ref_id[tag["reference_id"]].append(tag)
     counts_by_ref_id = _build_tag_counts(serialized_tags)
     entries_by_ref_id = _build_tag_entries(serialized_tags)
+    validation_by_ref_id = _build_validation_states(serialized_tags)
     serialize_ms = (perf_counter() - serialize_start) * 1000
     _log_tet_batch_timing(
         "TET batch serialized in %.1fms: tags=%s",
@@ -1648,15 +1686,18 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
     tags_result: Dict[str, Any] = {}
     counts_result: Dict[str, Any] = {}
     entries_result: Dict[str, Any] = {}
+    validation_result: Dict[str, Any] = {}
     for ident, ref_id in ident_to_ref_id.items():
         if ref_id is None:
             tags_result[ident] = []
             counts_result[ident] = {}
             entries_result[ident] = {}
+            validation_result[ident] = {}
         else:
             tags_result[ident] = tags_by_ref_id[ref_id]
             counts_result[ident] = counts_by_ref_id.get(ref_id, {})
             entries_result[ident] = entries_by_ref_id.get(ref_id, {})
+            validation_result[ident] = validation_by_ref_id.get(ref_id, {})
     total_ms = (perf_counter() - total_start) * 1000
     _log_tet_batch_timing(
         "TET batch total in %.1fms: inputs=%s unique=%s resolved=%s tags=%s",
@@ -1683,6 +1724,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
         "tags": tags_result,
         "counts": counts_result,
         "entries": entries_result,
+        "validation": validation_result,
         "debug_timing": debug_timing
     }
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -38,6 +38,7 @@ from agr_literature_service.api.models.audited_model import (
     disable_set_updated_by_onupdate,
     disable_set_date_updated_onupdate
 )
+from agr_literature_service.api.user import get_global_user_id
 from agr_cognito_py import ModAccess, MOD_ACCESS_ABBR
 from agr_literature_service.api.schemas.topic_entity_tag_schemas import (TopicEntityTagSchemaPost,
                                                                          TopicEntityTagSourceSchemaUpdate,
@@ -1629,22 +1630,40 @@ def _build_validation_details(serialized_tags: List[Dict[str, Any]]) -> Dict[int
     return out
 
 
-def _build_filter_flags(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict[str, Any]]:
+def _empty_filter_flags() -> Dict[str, bool]:
+    """The all-False per-cell filter-flag dict. Single source of truth for the
+    flag set so the batch aggregate, the single-cell recompute default and any
+    'no tags' fallback stay in lock-step."""
+    return {"has_any": False, "has_y": False, "has_n": False,
+            "has_note": False, "my_validation_present": False}
+
+
+def _build_filter_flags(serialized_tags: List[Dict[str, Any]],
+                        rows: Optional[List[TopicEntityTagModel]] = None,
+                        current_user_id: Optional[str] = None) -> Dict[int, Dict[str, Any]]:
     """Per reference -> topic boolean flags backing the grid's per-topic cell
     filter (TopicCellFilter / cellPredicate) so it can filter without scanning
     raw tags. Computed over ALL tags of the (reference, topic) cell -- entity and
     topic-level, curator and non-curator -- matching cellPredicate's asTets set::
 
-        has_any  -> the cell has >= 1 tag         ('has any tag'; 'empty' == not has_any)
-        has_y    -> >= 1 tag with negated False    ('has Y')
-        has_n    -> >= 1 tag with negated True      ('has N')
-        has_note -> >= 1 tag with a non-empty note  ('has note')
+        has_any              -> the cell has >= 1 tag       ('has any tag'; 'empty' == not has_any)
+        has_y                -> >= 1 tag with negated False  ('has Y')
+        has_n                -> >= 1 tag with negated True    ('has N')
+        has_note             -> >= 1 tag with a non-empty note ('has note')
+        my_validation_present -> >= 1 tag authored by the current user ('my validation present')
 
-    'my validation present' is intentionally omitted pending the curator-identity
-    model (created_by is a display name in the serialized tag, the UI compares it
-    to the Okta subject id). Topic keys are uppercased to match normalizeCurie."""
-    flags: Dict[int, Dict[str, Any]] = defaultdict(lambda: defaultdict(
-        lambda: {"has_any": False, "has_y": False, "has_n": False, "has_note": False}))
+    my_validation_present is computed from the RAW ORM ``rows`` (whose
+    ``created_by`` is the internal users.id), NOT from ``serialized_tags`` (where
+    created_by has been replaced by a display name). ``current_user_id`` is the
+    current request's users.id (get_global_user_id()); the tag's created_by is the
+    same identity space, so the comparison is exact -- resolving the deferral from
+    increment 3, where the client could only compare its Okta subject id against a
+    serialized display name. When ``rows``/``current_user_id`` are absent, or the
+    request is anonymous (current_user_id is None), the flag stays False for every
+    cell. Matches cellPredicate's ``arr.some(t => t.created_by === currentUid)``:
+    over ALL tags of the cell, not just curator validations. Topic keys are
+    uppercased to match normalizeCurie."""
+    flags: Dict[int, Dict[str, Any]] = defaultdict(lambda: defaultdict(_empty_filter_flags))
     for tag in serialized_tags:
         ref_id = tag["reference_id"]
         topic = str(tag.get("topic") or "").upper()
@@ -1657,6 +1676,11 @@ def _build_filter_flags(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict
         note = tag.get("note")
         if note is not None and note != "":
             cell["has_note"] = True
+    if rows is not None and current_user_id is not None:
+        for row in rows:
+            if row.created_by == current_user_id:
+                topic = str(row.topic or "").upper()
+                flags[row.reference_id][topic]["my_validation_present"] = True
     return flags
 
 
@@ -1797,7 +1821,8 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
     counts_by_ref_id = _build_tag_counts(serialized_tags)
     entries_by_ref_id = _build_tag_entries(serialized_tags)
     validation_by_ref_id = _build_validation_details(serialized_tags)
-    filter_flags_by_ref_id = _build_filter_flags(serialized_tags)
+    filter_flags_by_ref_id = _build_filter_flags(
+        serialized_tags, rows=rows, current_user_id=get_global_user_id())
     discovery_result = _build_discovery(serialized_tags)
     serialize_ms = (perf_counter() - serialize_start) * 1000
     _log_tet_batch_timing(
@@ -1927,8 +1952,9 @@ def _recompute_validation_cell(db: Session, reference_id: int, topic: str) -> Di
     curie_to_name = build_curie_to_name_map(db, rows)
     serialized_tags = _serialize_reference_tag_rows(db, rows, curie_to_name)
     validation = _build_validation_details(serialized_tags).get(reference_id, {}).get(topic_upper)
-    filter_flags = _build_filter_flags(serialized_tags).get(reference_id, {}).get(
-        topic_upper, {"has_any": False, "has_y": False, "has_n": False, "has_note": False})
+    filter_flags = _build_filter_flags(
+        serialized_tags, rows=rows, current_user_id=get_global_user_id()).get(
+        reference_id, {}).get(topic_upper, _empty_filter_flags())
     return {"topic": topic_upper, "validation": validation, "filter_flags": filter_flags}
 
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1547,40 +1547,72 @@ def _build_tag_entries(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict[
     return entries_by_ref_topic
 
 
-def _build_validation_states(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict[str, str]]:
-    """Aggregate the curator validation state per reference -> topic so the grid's
-    Validation column can sort/filter (and ultimately render) without deriving it
-    from raw tags client-side.
+def _build_validation_details(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict[str, Any]]:
+    """Aggregate the curator validation of each reference -> topic so the grid's
+    Validation column can sort, filter AND render without deriving any of it from
+    raw tags client-side.
 
-    Mirrors the UI's validationState (groupTets.js): only *topic-level* tags
-    (no entity) from a professional-biocurator/curator source count as a
-    validation. A topic is 'conflict' when it has both a positive and a negative
-    such tag, else 'positive' / 'negative'. Topics with no curator validation are
-    omitted -- the client treats an absent topic as 'unvalidated', matching
-    validationState's empty-list behavior. Topic keys are uppercased to match the
-    UI's normalizeCurie."""
-    polarity: Dict[int, Dict[str, Dict[str, bool]]] = defaultdict(
-        lambda: defaultdict(lambda: {"pos": False, "neg": False}))
+    Mirrors ValidationCell + validationState (UI): only *topic-level* tags (no
+    entity) from a professional-biocurator/curator source count as a validation.
+    Per (reference, topic) it returns::
+
+        {"state": "positive" | "negative" | "conflict",
+         "positives": <count>, "negatives": <count>,
+         "by_curator": [{"name", "negated", "sources": [{"method", "label"}],
+                         "species": [curie, ...]}, ...]}
+
+    ``by_curator`` groups validations by (curator display name, polarity) -- the
+    same grouping ValidationCell renders -- accumulating the distinct source
+    methods (label = ``method [/ secondary_data_provider]``) and species per
+    group, preserving first-seen order. ``name`` falls back to
+    '(unknown curator)' so no validation is dropped. Topics with no curator
+    validation are omitted (client treats an absent topic as 'unvalidated').
+    Topic keys are uppercased to match the UI's normalizeCurie."""
+    # ref_id -> topic -> {positives, negatives, by_curator: {(name, negated): grp}}
+    acc: Dict[int, Dict[str, Dict[str, Any]]] = defaultdict(lambda: defaultdict(
+        lambda: {"positives": 0, "negatives": 0, "by_curator": {}}))
     for tag in serialized_tags:
         if tag.get("entity") or not _is_curator_source_tag(tag):
             continue
         ref_id = tag["reference_id"]
         topic = str(tag.get("topic") or "").upper()
-        if tag.get("negated"):
-            polarity[ref_id][topic]["neg"] = True
+        bucket = acc[ref_id][topic]
+        negated = bool(tag.get("negated"))
+        if negated:
+            bucket["negatives"] += 1
         else:
-            polarity[ref_id][topic]["pos"] = True
+            bucket["positives"] += 1
+        name = tag.get("created_by") or "(unknown curator)"
+        group = bucket["by_curator"].get((name, negated))
+        if group is None:
+            group = {"name": name, "negated": negated, "sources": {}, "species": []}
+            bucket["by_curator"][(name, negated)] = group
+        source = tag.get("topic_entity_tag_source") or {}
+        method = source.get("source_method")
+        if method and method not in group["sources"]:
+            sec = source.get("secondary_data_provider_abbreviation")
+            group["sources"][method] = f"{method} / {sec}" if sec else method
+        species = tag.get("species")
+        if species and species not in group["species"]:
+            group["species"].append(species)
 
-    states: Dict[int, Dict[str, str]] = defaultdict(dict)
-    for ref_id, by_topic in polarity.items():
-        for topic, pol in by_topic.items():
-            if pol["pos"] and pol["neg"]:
-                states[ref_id][topic] = "conflict"
-            elif pol["pos"]:
-                states[ref_id][topic] = "positive"
-            else:
-                states[ref_id][topic] = "negative"
-    return states
+    out: Dict[int, Dict[str, Any]] = defaultdict(dict)
+    for ref_id, by_topic in acc.items():
+        for topic, bucket in by_topic.items():
+            pos, neg = bucket["positives"], bucket["negatives"]
+            state = "conflict" if (pos and neg) else ("positive" if pos else "negative")
+            out[ref_id][topic] = {
+                "state": state,
+                "positives": pos,
+                "negatives": neg,
+                "by_curator": [
+                    {"name": g["name"], "negated": g["negated"],
+                     "sources": [{"method": m, "label": lab} for m, lab in g["sources"].items()],
+                     "species": g["species"]}
+                    for g in bucket["by_curator"].values()
+                ],
+            }
+    return out
 
 
 def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids: List[str],
@@ -1675,7 +1707,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
         tags_by_ref_id[tag["reference_id"]].append(tag)
     counts_by_ref_id = _build_tag_counts(serialized_tags)
     entries_by_ref_id = _build_tag_entries(serialized_tags)
-    validation_by_ref_id = _build_validation_states(serialized_tags)
+    validation_by_ref_id = _build_validation_details(serialized_tags)
     serialize_ms = (perf_counter() - serialize_start) * 1000
     _log_tet_batch_timing(
         "TET batch serialized in %.1fms: tags=%s",

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -38,7 +38,6 @@ from agr_literature_service.api.models.audited_model import (
     disable_set_updated_by_onupdate,
     disable_set_date_updated_onupdate
 )
-from agr_literature_service.api.user import get_global_user_id
 from agr_cognito_py import ModAccess, MOD_ACCESS_ABBR
 from agr_literature_service.api.schemas.topic_entity_tag_schemas import (TopicEntityTagSchemaPost,
                                                                          TopicEntityTagSourceSchemaUpdate,
@@ -1666,15 +1665,19 @@ def _build_filter_flags(serialized_tags: List[Dict[str, Any]],
 
     my_validation_present is computed from the RAW ORM ``rows`` (whose
     ``created_by`` is the internal users.id), NOT from ``serialized_tags`` (where
-    created_by has been replaced by a display name). ``current_user_id`` is the
-    current request's users.id (get_global_user_id()); the tag's created_by is the
-    same identity space, so the comparison is exact -- resolving the deferral from
-    increment 3, where the client could only compare its Okta subject id against a
-    serialized display name. When ``rows``/``current_user_id`` are absent, or the
-    request is anonymous (current_user_id is None), the flag stays False for every
-    cell. Matches cellPredicate's ``arr.some(t => t.created_by === currentUid)``:
-    over ALL tags of the cell, not just curator validations. Topic keys are
-    uppercased to match normalizeCurie."""
+    created_by has been replaced by a display name). ``current_user_id`` must be
+    the value the audit hook stamps into a tag's created_by for this request --
+    i.e. get_default_user_value() (get_global_user_id(), falling back to
+    'default_user'). Comparing against the raw get_global_user_id() would miss a
+    tag the SAME request just wrote whenever the global id is unset (e.g. a
+    service-account/VPN-bypass request stamps created_by='default_user' while
+    get_global_user_id() is None), so a curator's own just-created validation
+    would wrongly read as not-mine. This resolves the deferral from increment 3,
+    where the client could only compare its Okta subject id against a serialized
+    display name. When ``rows``/``current_user_id`` are absent the flag stays
+    False for every cell. Matches cellPredicate's
+    ``arr.some(t => t.created_by === currentUid)``: over ALL tags of the cell, not
+    just curator validations. Topic keys are uppercased to match normalizeCurie."""
     flags: Dict[int, Dict[str, Any]] = defaultdict(lambda: defaultdict(_empty_filter_flags))
     for tag in serialized_tags:
         ref_id = tag["reference_id"]
@@ -1834,7 +1837,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
     entries_by_ref_id = _build_tag_entries(serialized_tags)
     validation_by_ref_id = _build_validation_details(serialized_tags)
     filter_flags_by_ref_id = _build_filter_flags(
-        serialized_tags, rows=rows, current_user_id=get_global_user_id())
+        serialized_tags, rows=rows, current_user_id=get_default_user_value())
     discovery_result = _build_discovery(serialized_tags)
     serialize_ms = (perf_counter() - serialize_start) * 1000
     _log_tet_batch_timing(
@@ -1965,7 +1968,7 @@ def _recompute_validation_cell(db: Session, reference_id: int, topic: str) -> Di
     serialized_tags = _serialize_reference_tag_rows(db, rows, curie_to_name)
     validation = _build_validation_details(serialized_tags).get(reference_id, {}).get(topic_upper)
     filter_flags = _build_filter_flags(
-        serialized_tags, rows=rows, current_user_id=get_global_user_id()).get(
+        serialized_tags, rows=rows, current_user_id=get_default_user_value()).get(
         reference_id, {}).get(topic_upper, _empty_filter_flags())
     return {"topic": topic_upper, "validation": validation, "filter_flags": filter_flags}
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1646,6 +1646,48 @@ def _build_filter_flags(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict
     return flags
 
 
+def _build_discovery(serialized_tags: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Batch-global discovery aggregate backing the grid's column set and source
+    filter so neither has to be derived from raw tags client-side. Unlike the
+    other aggregates this is NOT keyed per reference -- it summarises the whole
+    batch (post-filter) once.
+
+    ``topics`` is the distinct set of topic columns present across the WHOLE batch
+    -- over ALL tags (entity + topic-level, curator + non-curator) -- matching the
+    column the grid renders whenever any tag exists for a topic. Each entry is
+    ``{"curie": <UPPERCASED topic>, "name": <topic display name>}``.
+
+    ``sources`` is the distinct set of source labels present, computed over
+    NON-curator tags only -- identically to _build_tag_counts / _build_tag_entries
+    -- because curator submissions surface in the Validation column, not in the
+    per-source Sources cells the source filter targets. Each entry is
+    ``{"label", "method", "secondary_data_provider", "data_provider"}`` so the UI
+    can render and group without re-parsing the label.
+
+    Both lists preserve first-seen order (deterministic: the batch query orders by
+    reference_id then topic_entity_tag_id), consistent with the other aggregates;
+    the client may re-sort for presentation. Topic keys are uppercased to match
+    the UI's normalizeCurie."""
+    topics: Dict[str, Dict[str, Any]] = {}
+    sources: Dict[str, Dict[str, Any]] = {}
+    for tag in serialized_tags:
+        topic = str(tag.get("topic") or "").upper()
+        if topic and topic not in topics:
+            topics[topic] = {"curie": topic, "name": tag.get("topic_name") or topic}
+        if _is_curator_source_tag(tag):
+            continue
+        source_data = tag.get("topic_entity_tag_source") or {}
+        label = _source_label(source_data)
+        if label not in sources:
+            sources[label] = {
+                "label": label,
+                "method": source_data.get("source_method"),
+                "secondary_data_provider": source_data.get("secondary_data_provider_abbreviation"),
+                "data_provider": source_data.get("data_provider"),
+            }
+    return {"topics": list(topics.values()), "sources": list(sources.values())}
+
+
 def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids: List[str],
                                            filters: Optional[Dict[str, Any]] = None):
     """Batch variant of show_all_reference_tags.
@@ -1699,6 +1741,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
             "entries": {ident: {} for ident in ident_to_ref_id},
             "validation": {ident: {} for ident in ident_to_ref_id},
             "filter_flags": {ident: {} for ident in ident_to_ref_id},
+            "discovery": {"topics": [], "sources": []},
             "debug_timing": None
         }
 
@@ -1741,6 +1784,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
     entries_by_ref_id = _build_tag_entries(serialized_tags)
     validation_by_ref_id = _build_validation_details(serialized_tags)
     filter_flags_by_ref_id = _build_filter_flags(serialized_tags)
+    discovery_result = _build_discovery(serialized_tags)
     serialize_ms = (perf_counter() - serialize_start) * 1000
     _log_tet_batch_timing(
         "TET batch serialized in %.1fms: tags=%s",
@@ -1794,6 +1838,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
         "entries": entries_result,
         "validation": validation_result,
         "filter_flags": filter_flags_result,
+        "discovery": discovery_result,
         "debug_timing": debug_timing
     }
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1861,27 +1861,56 @@ def get_or_create_curator_validation_source(db: Session, mod_abbreviation: str) 
     """Resolve the per-MOD ABC curator source used for grid validations, creating
     it if absent. Server-side equivalent of the UI's getCuratorSourceId (GET the
     source by name, POST to create on 404) so the validate write path no longer
-    needs the client to resolve a source id first."""
+    needs the client to resolve a source id first.
+
+    validation_type is set to CURATOR_VALIDATION_TYPE ('professional_curator') to
+    match exactly what getCuratorSourceId POSTs. NOTE the source unique key
+    (source_evidence_assertion, source_method, data_provider,
+    secondary_data_provider) excludes validation_type, so when a source already
+    exists for the MOD it is reused verbatim -- the same row the UI write path
+    uses. abc_literature_system curator sources are 'professional_curator' (or
+    legacy 'curator'), never 'professional_biocurator': the UI has only ever
+    created them as 'curator'/'professional_curator' and no other code path
+    creates this (assertion, method, mod) source. The opposite-negation guard in
+    check_for_duplicate_tags (Branch 3) is gated on 'professional_biocurator', so
+    it does not apply here -- a same-curator opposite-polarity re-validation is
+    recorded (read side shows 'conflict') rather than rejected with 409, matching
+    the existing UI write path."""
     mod = db.query(ModModel).filter(ModModel.abbreviation == mod_abbreviation).one_or_none()
     if mod is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail=f"Cannot find the MOD '{mod_abbreviation}'")
-    source = db.query(TopicEntityTagSourceModel).filter(
-        TopicEntityTagSourceModel.source_evidence_assertion == CURATOR_VALIDATION_SOURCE_EVIDENCE_ASSERTION,
-        TopicEntityTagSourceModel.source_method == CURATOR_VALIDATION_SOURCE_METHOD,
-        TopicEntityTagSourceModel.data_provider == mod_abbreviation,
-        TopicEntityTagSourceModel.secondary_data_provider_id == mod.mod_id,
-    ).first()
+
+    def _lookup():
+        return db.query(TopicEntityTagSourceModel).filter(
+            TopicEntityTagSourceModel.source_evidence_assertion == CURATOR_VALIDATION_SOURCE_EVIDENCE_ASSERTION,
+            TopicEntityTagSourceModel.source_method == CURATOR_VALIDATION_SOURCE_METHOD,
+            TopicEntityTagSourceModel.data_provider == mod_abbreviation,
+            TopicEntityTagSourceModel.secondary_data_provider_id == mod.mod_id,
+        ).first()
+
+    source = _lookup()
     if source is not None:
         return source
-    new_source_id = create_source(db, TopicEntityTagSourceSchemaCreate(
-        source_evidence_assertion=CURATOR_VALIDATION_SOURCE_EVIDENCE_ASSERTION,
-        source_method=CURATOR_VALIDATION_SOURCE_METHOD,
-        validation_type=CURATOR_VALIDATION_TYPE,
-        description=CURATOR_VALIDATION_SOURCE_DESCRIPTION,
-        data_provider=mod_abbreviation,
-        secondary_data_provider_abbreviation=mod_abbreviation,
-    ))
+    try:
+        new_source_id = create_source(db, TopicEntityTagSourceSchemaCreate(
+            source_evidence_assertion=CURATOR_VALIDATION_SOURCE_EVIDENCE_ASSERTION,
+            source_method=CURATOR_VALIDATION_SOURCE_METHOD,
+            validation_type=CURATOR_VALIDATION_TYPE,
+            description=CURATOR_VALIDATION_SOURCE_DESCRIPTION,
+            data_provider=mod_abbreviation,
+            secondary_data_provider_abbreviation=mod_abbreviation,
+        ))
+    except HTTPException:
+        # Lost a create race with a concurrent first-time validation for the same
+        # MOD: create_source rolls back and raises 422 on the unique-key
+        # violation. The row exists now -- re-fetch and use it rather than
+        # failing the request.
+        db.rollback()
+        source = _lookup()
+        if source is None:
+            raise
+        return source
     return get_source_from_db(db, new_source_id)
 
 
@@ -1913,9 +1942,16 @@ def validate_topic(db: Session, reference_curie: str, topic: str, mod_abbreviati
     species} plus their MOD -- resolve the curator source server-side and create
     the topic-level validation tag through the normal create_tag path (so dedup,
     note-append upsert and validation all behave identically to a manual create),
-    then return the recomputed single cell. force_insertion mirrors the UI: a
-    same-curator opposite-polarity re-validation should record the new assertion
-    rather than 409."""
+    then return the recomputed single cell.
+
+    force_insertion=True mirrors the UI payload; it bypasses the different-creator
+    duplicate guard (Branches 4/5 in check_for_duplicate_tags). A same-curator
+    opposite-polarity re-validation is recorded rather than rejected because the
+    opposite-negation guard (Branch 3) only applies to 'professional_biocurator'
+    sources, and the curator source resolved here is 'professional_curator' (see
+    get_or_create_curator_validation_source). An exact same-curator, same-polarity
+    resubmit still 409s (duplicate) unless it carries a new note (note-append
+    upsert), exactly like a manual create."""
     source = get_or_create_curator_validation_source(db, mod_abbreviation)
     tag = TopicEntityTagSchemaPost(
         reference_curie=reference_curie,

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1995,10 +1995,15 @@ def validate_topic(db: Session, reference_curie: str, topic: str, mod_abbreviati
 
     The new tag is created through the normal create_tag path (force_insertion
     bypasses the different-creator guard; add-paper-to-MOD and indexing-workflow
-    side effects still run). create_tag runs with validate_on_insert=False because
-    the single revalidate_all_tags below rebuilds the whole reference's validation
-    relationships/values once -- covering both the new tag and any tags affected
-    by the delete -- exactly as patch_tag/destroy_tag do."""
+    side effects still run). The prior delete is only FLUSHED, not committed, so
+    create_tag's own commit covers the delete AND the insert atomically: if
+    create_tag raises (422 invalid topic, 404 source, a 409, ...) the delete is
+    never committed and rolls back with the request, so the curator never ends up
+    with their prior validation gone and no replacement. create_tag runs with
+    validate_on_insert=False because the single revalidate_all_tags below rebuilds
+    the whole reference's validation relationships/values once -- covering both the
+    new tag and any tags affected by the delete -- exactly as patch_tag/destroy_tag
+    do."""
     source = get_or_create_curator_validation_source(db, mod_abbreviation)
     reference_id = get_reference_id_from_curie_or_id(db, reference_curie)
     current_user = get_default_user_value()
@@ -2015,7 +2020,13 @@ def validate_topic(db: Session, reference_curie: str, topic: str, mod_abbreviati
     for old_tag in prior:
         db.delete(old_tag)
     if prior:
-        db.commit()
+        # Flush (NOT commit) so the delete is visible within this transaction --
+        # create_tag's check_for_duplicate_tags then won't see the prior row --
+        # while staying uncommitted until create_tag's own commit, making
+        # delete+insert atomic. If create_tag raises, the delete is rolled back
+        # with it (create_tag's except, or the request session's rollback on
+        # close), so a failed re-validation never destroys the prior one.
+        db.flush()
 
     tag = TopicEntityTagSchemaPost(
         reference_curie=reference_curie,

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1674,8 +1674,13 @@ def _build_filter_flags(serialized_tags: List[Dict[str, Any]],
     get_global_user_id() is None), so a curator's own just-created validation
     would wrongly read as not-mine. This resolves the deferral from increment 3,
     where the client could only compare its Okta subject id against a serialized
-    display name. When ``rows``/``current_user_id`` are absent the flag stays
-    False for every cell. Matches cellPredicate's
+    display name. Because current_user_id is get_default_user_value() it is never
+    None from the real call sites (an unauthenticated/service-account request
+    resolves to 'default_user'), so such a request marks cells whose tags were
+    created by 'default_user' as mine -- consistent, since that is exactly the id
+    those tags are stamped with. The flag only stays False for every cell when
+    ``rows`` is not supplied (the default), which is why the guard below also
+    checks current_user_id is not None defensively. Matches cellPredicate's
     ``arr.some(t => t.created_by === currentUid)``: over ALL tags of the cell, not
     just curator validations. Topic keys are uppercased to match normalizeCurie."""
     flags: Dict[int, Dict[str, Any]] = defaultdict(lambda: defaultdict(_empty_filter_flags))

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -76,6 +76,20 @@ TET_SOURCE_CURIE_FIELDS = ['source_evidence_assertion']
 # tag auto-created from a positive mixed topic+entity tag.
 EXISTING_DATA_NOVELTY_ATP = "ATP:0000334"
 
+# SCRUM-6242 (increment 5): the curator validation written by the grid's
+# Validation column. These mirror exactly what the UI (CellValidationStrip /
+# getCuratorSourceId) sends today so the server-side validate path produces an
+# identical tag: a topic-level (no entity) tag from the per-MOD ABC curator
+# source. data_novelty is required (non-null column) and the UI hardcodes the
+# "no data" term for these topic-level validations.
+CURATOR_VALIDATION_SOURCE_EVIDENCE_ASSERTION = "ATP:0000036"
+CURATOR_VALIDATION_SOURCE_METHOD = "abc_literature_system"
+CURATOR_VALIDATION_TYPE = "professional_curator"
+CURATOR_VALIDATION_DATA_NOVELTY = "ATP:0000335"
+CURATOR_VALIDATION_SOURCE_DESCRIPTION = (
+    "Trained professional biocurator specializing in curation of model organism "
+    "data using the ABC data entry form.")
+
 
 def create_tag(db: Session, topic_entity_tag: TopicEntityTagSchemaPost,
                validate_on_insert: bool = True) -> Tuple[int, bool]:
@@ -1840,6 +1854,88 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
         "filter_flags": filter_flags_result,
         "discovery": discovery_result,
         "debug_timing": debug_timing
+    }
+
+
+def get_or_create_curator_validation_source(db: Session, mod_abbreviation: str) -> TopicEntityTagSourceModel:
+    """Resolve the per-MOD ABC curator source used for grid validations, creating
+    it if absent. Server-side equivalent of the UI's getCuratorSourceId (GET the
+    source by name, POST to create on 404) so the validate write path no longer
+    needs the client to resolve a source id first."""
+    mod = db.query(ModModel).filter(ModModel.abbreviation == mod_abbreviation).one_or_none()
+    if mod is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail=f"Cannot find the MOD '{mod_abbreviation}'")
+    source = db.query(TopicEntityTagSourceModel).filter(
+        TopicEntityTagSourceModel.source_evidence_assertion == CURATOR_VALIDATION_SOURCE_EVIDENCE_ASSERTION,
+        TopicEntityTagSourceModel.source_method == CURATOR_VALIDATION_SOURCE_METHOD,
+        TopicEntityTagSourceModel.data_provider == mod_abbreviation,
+        TopicEntityTagSourceModel.secondary_data_provider_id == mod.mod_id,
+    ).first()
+    if source is not None:
+        return source
+    new_source_id = create_source(db, TopicEntityTagSourceSchemaCreate(
+        source_evidence_assertion=CURATOR_VALIDATION_SOURCE_EVIDENCE_ASSERTION,
+        source_method=CURATOR_VALIDATION_SOURCE_METHOD,
+        validation_type=CURATOR_VALIDATION_TYPE,
+        description=CURATOR_VALIDATION_SOURCE_DESCRIPTION,
+        data_provider=mod_abbreviation,
+        secondary_data_provider_abbreviation=mod_abbreviation,
+    ))
+    return get_source_from_db(db, new_source_id)
+
+
+def _recompute_validation_cell(db: Session, reference_id: int, topic: str) -> Dict[str, Any]:
+    """Recompute the single (reference, topic) grid cell's validation + filter
+    flags from the current DB state, in the SAME shape the batch endpoint returns.
+    Lets the validate write path hand the UI an authoritative replacement cell so
+    it never has to re-fetch and re-aggregate the whole batch after one edit."""
+    topic_upper = str(topic or "").upper()
+    rows = db.query(TopicEntityTagModel).options(
+        joinedload(TopicEntityTagModel.topic_entity_tag_source),
+        joinedload(TopicEntityTagModel.ml_model),
+        selectinload(TopicEntityTagModel.validated_by)).filter(
+        TopicEntityTagModel.reference_id == reference_id).all()
+    curie_to_name = build_curie_to_name_map(db, rows)
+    serialized_tags = _serialize_reference_tag_rows(db, rows, curie_to_name)
+    validation = _build_validation_details(serialized_tags).get(reference_id, {}).get(topic_upper)
+    filter_flags = _build_filter_flags(serialized_tags).get(reference_id, {}).get(
+        topic_upper, {"has_any": False, "has_y": False, "has_n": False, "has_note": False})
+    return {"topic": topic_upper, "validation": validation, "filter_flags": filter_flags}
+
+
+def validate_topic(db: Session, reference_curie: str, topic: str, mod_abbreviation: str,
+                   negated: bool = False, note: Optional[str] = None,
+                   species: Optional[str] = None) -> Dict[str, Any]:
+    """Write path for the grid's Validation column (SCRUM-6242 increment 5).
+
+    Given just the cell the curator acted on -- {reference, topic, negated, note,
+    species} plus their MOD -- resolve the curator source server-side and create
+    the topic-level validation tag through the normal create_tag path (so dedup,
+    note-append upsert and validation all behave identically to a manual create),
+    then return the recomputed single cell. force_insertion mirrors the UI: a
+    same-curator opposite-polarity re-validation should record the new assertion
+    rather than 409."""
+    source = get_or_create_curator_validation_source(db, mod_abbreviation)
+    tag = TopicEntityTagSchemaPost(
+        reference_curie=reference_curie,
+        topic=topic,
+        entity=None,
+        entity_type=None,
+        species=species,
+        data_novelty=CURATOR_VALIDATION_DATA_NOVELTY,
+        negated=negated,
+        note=note,
+        topic_entity_tag_source_id=source.topic_entity_tag_source_id,
+        force_insertion=True,
+    )
+    tag_id, was_upsert = create_tag(db, tag)
+    reference_id = get_reference_id_from_curie_or_id(db, reference_curie)
+    cell = _recompute_validation_cell(db, reference_id, topic)
+    return {
+        "topic_entity_tag_id": tag_id,
+        "upserted": was_upsert,
+        **cell,
     }
 
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1615,6 +1615,37 @@ def _build_validation_details(serialized_tags: List[Dict[str, Any]]) -> Dict[int
     return out
 
 
+def _build_filter_flags(serialized_tags: List[Dict[str, Any]]) -> Dict[int, Dict[str, Any]]:
+    """Per reference -> topic boolean flags backing the grid's per-topic cell
+    filter (TopicCellFilter / cellPredicate) so it can filter without scanning
+    raw tags. Computed over ALL tags of the (reference, topic) cell -- entity and
+    topic-level, curator and non-curator -- matching cellPredicate's asTets set::
+
+        has_any  -> the cell has >= 1 tag         ('has any tag'; 'empty' == not has_any)
+        has_y    -> >= 1 tag with negated False    ('has Y')
+        has_n    -> >= 1 tag with negated True      ('has N')
+        has_note -> >= 1 tag with a non-empty note  ('has note')
+
+    'my validation present' is intentionally omitted pending the curator-identity
+    model (created_by is a display name in the serialized tag, the UI compares it
+    to the Okta subject id). Topic keys are uppercased to match normalizeCurie."""
+    flags: Dict[int, Dict[str, Any]] = defaultdict(lambda: defaultdict(
+        lambda: {"has_any": False, "has_y": False, "has_n": False, "has_note": False}))
+    for tag in serialized_tags:
+        ref_id = tag["reference_id"]
+        topic = str(tag.get("topic") or "").upper()
+        cell = flags[ref_id][topic]
+        cell["has_any"] = True
+        if tag.get("negated") is True:
+            cell["has_n"] = True
+        elif tag.get("negated") is False:
+            cell["has_y"] = True
+        note = tag.get("note")
+        if note is not None and note != "":
+            cell["has_note"] = True
+    return flags
+
+
 def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids: List[str],
                                            filters: Optional[Dict[str, Any]] = None):
     """Batch variant of show_all_reference_tags.
@@ -1667,6 +1698,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
             "counts": {ident: {} for ident in ident_to_ref_id},
             "entries": {ident: {} for ident in ident_to_ref_id},
             "validation": {ident: {} for ident in ident_to_ref_id},
+            "filter_flags": {ident: {} for ident in ident_to_ref_id},
             "debug_timing": None
         }
 
@@ -1708,6 +1740,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
     counts_by_ref_id = _build_tag_counts(serialized_tags)
     entries_by_ref_id = _build_tag_entries(serialized_tags)
     validation_by_ref_id = _build_validation_details(serialized_tags)
+    filter_flags_by_ref_id = _build_filter_flags(serialized_tags)
     serialize_ms = (perf_counter() - serialize_start) * 1000
     _log_tet_batch_timing(
         "TET batch serialized in %.1fms: tags=%s",
@@ -1719,17 +1752,20 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
     counts_result: Dict[str, Any] = {}
     entries_result: Dict[str, Any] = {}
     validation_result: Dict[str, Any] = {}
+    filter_flags_result: Dict[str, Any] = {}
     for ident, ref_id in ident_to_ref_id.items():
         if ref_id is None:
             tags_result[ident] = []
             counts_result[ident] = {}
             entries_result[ident] = {}
             validation_result[ident] = {}
+            filter_flags_result[ident] = {}
         else:
             tags_result[ident] = tags_by_ref_id[ref_id]
             counts_result[ident] = counts_by_ref_id.get(ref_id, {})
             entries_result[ident] = entries_by_ref_id.get(ref_id, {})
             validation_result[ident] = validation_by_ref_id.get(ref_id, {})
+            filter_flags_result[ident] = filter_flags_by_ref_id.get(ref_id, {})
     total_ms = (perf_counter() - total_start) * 1000
     _log_tet_batch_timing(
         "TET batch total in %.1fms: inputs=%s unique=%s resolved=%s tags=%s",
@@ -1757,6 +1793,7 @@ def show_all_reference_tags_for_references(db: Session, curies_or_reference_ids:
         "counts": counts_result,
         "entries": entries_result,
         "validation": validation_result,
+        "filter_flags": filter_flags_result,
         "debug_timing": debug_timing
     }
 

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1868,14 +1868,13 @@ def get_or_create_curator_validation_source(db: Session, mod_abbreviation: str) 
     (source_evidence_assertion, source_method, data_provider,
     secondary_data_provider) excludes validation_type, so when a source already
     exists for the MOD it is reused verbatim -- the same row the UI write path
-    uses. abc_literature_system curator sources are 'professional_curator' (or
-    legacy 'curator'), never 'professional_biocurator': the UI has only ever
-    created them as 'curator'/'professional_curator' and no other code path
-    creates this (assertion, method, mod) source. The opposite-negation guard in
-    check_for_duplicate_tags (Branch 3) is gated on 'professional_biocurator', so
-    it does not apply here -- a same-curator opposite-polarity re-validation is
-    recorded (read side shows 'conflict') rather than rejected with 409, matching
-    the existing UI write path."""
+    uses. That means the resolved source's validation_type is NOT guaranteed to be
+    'professional_curator': a pre-existing curator source may be
+    'professional_biocurator' for some MODs, and the opposite-negation guard in
+    check_for_duplicate_tags (Branch 3) fires only for that value. validate_topic
+    does not rely on the validation_type either way -- it deletes the curator's
+    prior validation before inserting the new one, so a flipped re-validation
+    never trips Branch 3 regardless of the source's validation_type."""
     mod = db.query(ModModel).filter(ModModel.abbreviation == mod_abbreviation).one_or_none()
     if mod is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
@@ -1939,20 +1938,44 @@ def validate_topic(db: Session, reference_curie: str, topic: str, mod_abbreviati
     """Write path for the grid's Validation column (SCRUM-6242 increment 5).
 
     Given just the cell the curator acted on -- {reference, topic, negated, note,
-    species} plus their MOD -- resolve the curator source server-side and create
-    the topic-level validation tag through the normal create_tag path (so dedup,
-    note-append upsert and validation all behave identically to a manual create),
-    then return the recomputed single cell.
+    species} plus their MOD -- resolve the curator source server-side, record the
+    curator's topic-level validation, and return the recomputed single cell.
 
-    force_insertion=True mirrors the UI payload; it bypasses the different-creator
-    duplicate guard (Branches 4/5 in check_for_duplicate_tags). A same-curator
-    opposite-polarity re-validation is recorded rather than rejected because the
-    opposite-negation guard (Branch 3) only applies to 'professional_biocurator'
-    sources, and the curator source resolved here is 'professional_curator' (see
-    get_or_create_curator_validation_source). An exact same-curator, same-polarity
-    resubmit still 409s (duplicate) unless it carries a new note (note-append
-    upsert), exactly like a manual create."""
+    REPLACE-PRIOR semantics: a curator holds at most one validation per
+    (reference, topic). Any existing topic-level validation by this curator on the
+    curator source is deleted before the new one is inserted, so re-validating
+    REPLACES the prior assertion (flip Yes<->No, or update note/species) rather
+    than creating a second, contradictory tag. This is robust regardless of the
+    curator source's validation_type: the abc curator source is
+    'professional_curator' for some MODs and 'professional_biocurator' for others,
+    and the opposite-negation guard (check_for_duplicate_tags Branch 3) only fires
+    for the latter -- deleting the curator's prior tag first means the new insert
+    never trips that guard either way, so a flipped vote never 409s.
+
+    The new tag is created through the normal create_tag path (force_insertion
+    bypasses the different-creator guard; add-paper-to-MOD and indexing-workflow
+    side effects still run). create_tag runs with validate_on_insert=False because
+    the single revalidate_all_tags below rebuilds the whole reference's validation
+    relationships/values once -- covering both the new tag and any tags affected
+    by the delete -- exactly as patch_tag/destroy_tag do."""
     source = get_or_create_curator_validation_source(db, mod_abbreviation)
+    reference_id = get_reference_id_from_curie_or_id(db, reference_curie)
+    current_user = get_default_user_value()
+    topic_upper = str(topic or "").upper()
+
+    prior = db.query(TopicEntityTagModel).filter(
+        TopicEntityTagModel.reference_id == reference_id,
+        func.upper(TopicEntityTagModel.topic) == topic_upper,
+        TopicEntityTagModel.entity.is_(None),
+        TopicEntityTagModel.topic_entity_tag_source_id == source.topic_entity_tag_source_id,
+        TopicEntityTagModel.created_by == current_user,
+    ).all()
+    replaced = bool(prior)
+    for old_tag in prior:
+        db.delete(old_tag)
+    if prior:
+        db.commit()
+
     tag = TopicEntityTagSchemaPost(
         reference_curie=reference_curie,
         topic=topic,
@@ -1965,12 +1988,13 @@ def validate_topic(db: Session, reference_curie: str, topic: str, mod_abbreviati
         topic_entity_tag_source_id=source.topic_entity_tag_source_id,
         force_insertion=True,
     )
-    tag_id, was_upsert = create_tag(db, tag)
-    reference_id = get_reference_id_from_curie_or_id(db, reference_curie)
+    tag_id, _ = create_tag(db, tag, validate_on_insert=False)
+    revalidate_all_tags(curie_or_reference_id=str(reference_id))
+    db.expire_all()
     cell = _recompute_validation_cell(db, reference_id, topic)
     return {
         "topic_entity_tag_id": tag_id,
-        "upserted": was_upsert,
+        "replaced": replaced,
         **cell,
     }
 

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -221,6 +221,12 @@ class ReferenceTagsBatchResponse(BaseModel):
     # filters AND renders without deriving it from raw tags. Topics with no
     # curator validation are omitted (client treats absent as 'unvalidated').
     validation: Optional[Dict[str, Any]] = None
+    # filter_flags: input identifier -> {topic_curie: {has_any, has_y, has_n,
+    # has_note}}. Per-cell booleans backing the grid's per-topic cell filter
+    # (computed over all tags of the cell) so it filters without scanning raw
+    # tags. ('my validation present' is omitted pending the curator-identity
+    # model.)
+    filter_flags: Optional[Dict[str, Any]] = None
     # debug_timing: per-phase timing breakdown, present only when
     # DEBUG_TET_BATCH_TIMING is enabled. Lets the slow-load breakdown be read
     # straight from the browser Network tab. Null in normal operation.

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -46,6 +46,40 @@ def create_tag(request: TopicEntityTagSchemaPost,
     return topic_entity_tag_crud.show_tag(db, new_tag_id)
 
 
+class ValidateTopicRequest(BaseModel):
+    # Thin curator-validation request for the TET grid's Validation column: just
+    # the cell the curator acted on. The server resolves the curator source and
+    # all other tag fields (entity=null, data_novelty, etc.) so the UI no longer
+    # has to. See topic_entity_tag_crud.validate_topic.
+    reference_curie: str
+    topic: str
+    mod_abbreviation: str
+    negated: bool = False
+    note: Optional[str] = None
+    species: Optional[str] = None
+
+
+@router.post('/validate', status_code=status.HTTP_200_OK)
+def validate_topic(request: ValidateTopicRequest,
+                   user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+                   db: Session = db_session):
+    """Create (or upsert) a curator topic-level validation and return the single
+    recomputed grid cell ({topic, validation, filter_flags}) plus the tag id, so
+    the grid updates that cell without re-fetching/re-aggregating the whole batch.
+    The curator source is resolved (get-or-create) server-side from
+    mod_abbreviation."""
+    set_global_user_from_cognito(db, user)
+    return topic_entity_tag_crud.validate_topic(
+        db,
+        reference_curie=request.reference_curie,
+        topic=request.topic,
+        mod_abbreviation=request.mod_abbreviation,
+        negated=request.negated,
+        note=request.note,
+        species=request.species,
+    )
+
+
 @router.get('/{topic_entity_tag_id}',
             response_model=TopicEntityTagSchemaShow,
             status_code=200)

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -214,6 +214,12 @@ class ReferenceTagsBatchResponse(BaseModel):
     # These rows are grouped by source/evidence/kind in the API so the grid
     # renders, filters and sorts from pre-aggregated tag buckets.
     entries: Optional[Dict[str, Any]] = None
+    # validation: input identifier -> {topic_curie: 'positive' | 'negative' |
+    # 'conflict'}. Per-cell curator validation state computed in the API so the
+    # grid's Validation column sorts/filters without deriving it from raw tags.
+    # Topics with no curator validation are omitted (client treats absent as
+    # 'unvalidated').
+    validation: Optional[Dict[str, Any]] = None
     # debug_timing: per-phase timing breakdown, present only when
     # DEBUG_TET_BATCH_TIMING is enabled. Lets the slow-load breakdown be read
     # straight from the browser Network tab. Null in normal operation.

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -256,10 +256,12 @@ class ReferenceTagsBatchResponse(BaseModel):
     # curator validation are omitted (client treats absent as 'unvalidated').
     validation: Optional[Dict[str, Any]] = None
     # filter_flags: input identifier -> {topic_curie: {has_any, has_y, has_n,
-    # has_note}}. Per-cell booleans backing the grid's per-topic cell filter
-    # (computed over all tags of the cell) so it filters without scanning raw
-    # tags. ('my validation present' is omitted pending the curator-identity
-    # model.)
+    # has_note, my_validation_present}}. Per-cell booleans backing the grid's
+    # per-topic cell filter (computed over all tags of the cell) so it filters
+    # without scanning raw tags. my_validation_present compares each tag's
+    # created_by against the authenticated user's users.id server-side (the
+    # comparison the client couldn't do -- its uid is an Okta subject id and the
+    # serialized created_by is a display name).
     filter_flags: Optional[Dict[str, Any]] = None
     # discovery: batch-global (NOT keyed per reference) {topics: [{curie, name}],
     # sources: [{label, method, secondary_data_provider, data_provider}]}. The

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -214,11 +214,12 @@ class ReferenceTagsBatchResponse(BaseModel):
     # These rows are grouped by source/evidence/kind in the API so the grid
     # renders, filters and sorts from pre-aggregated tag buckets.
     entries: Optional[Dict[str, Any]] = None
-    # validation: input identifier -> {topic_curie: 'positive' | 'negative' |
-    # 'conflict'}. Per-cell curator validation state computed in the API so the
-    # grid's Validation column sorts/filters without deriving it from raw tags.
-    # Topics with no curator validation are omitted (client treats absent as
-    # 'unvalidated').
+    # validation: input identifier -> {topic_curie: {state: positive|negative|
+    # conflict, positives, negatives, by_curator: [{name, negated, sources:
+    # [{method, label}], species}]}}. Per-cell curator validation aggregated in
+    # the API (mirrors ValidationCell) so the grid's Validation column sorts,
+    # filters AND renders without deriving it from raw tags. Topics with no
+    # curator validation are omitted (client treats absent as 'unvalidated').
     validation: Optional[Dict[str, Any]] = None
     # debug_timing: per-phase timing breakdown, present only when
     # DEBUG_TET_BATCH_TIMING is enabled. Lets the slow-load breakdown be read

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -230,6 +230,12 @@ class ReferenceTagsBatchFilters(BaseModel):
     confidence_score_min: Optional[float] = None
     confidence_score_max: Optional[float] = None
     apply_to_single_tag: Optional[bool] = None
+    # MOD scope from the search's corpus facet(s): restrict tags to those whose
+    # source's secondary_data_provider (the owning MOD, per created_by_mod) is one
+    # of these abbreviations, so the grid shows only the selected MOD's tags
+    # instead of every MOD's tags on a shared reference. Omitted/empty => no MOD
+    # restriction (all MODs' tags).
+    mods: Optional[List[str]] = None
 
 
 class ReferenceTagsBatchRequest(BaseModel):

--- a/agr_literature_service/api/routers/topic_entity_tag_router.py
+++ b/agr_literature_service/api/routers/topic_entity_tag_router.py
@@ -227,6 +227,12 @@ class ReferenceTagsBatchResponse(BaseModel):
     # tags. ('my validation present' is omitted pending the curator-identity
     # model.)
     filter_flags: Optional[Dict[str, Any]] = None
+    # discovery: batch-global (NOT keyed per reference) {topics: [{curie, name}],
+    # sources: [{label, method, secondary_data_provider, data_provider}]}. The
+    # distinct topic columns (over all tags) and source labels (over non-curator
+    # tags) present in the post-filter batch, so the grid builds its column set
+    # and source filter without scanning raw tags. First-seen order.
+    discovery: Optional[Dict[str, Any]] = None
     # debug_timing: per-phase timing breakdown, present only when
     # DEBUG_TET_BATCH_TIMING is enabled. Lets the slow-load breakdown be read
     # straight from the browser Network tab. Null in normal operation.

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -390,6 +390,72 @@ class TestTopicEntityTag:
             assert cell["positives"] == 1
             assert cell["negatives"] == 1
 
+    def test_validate_topic_reuses_existing_curator_source(self, test_topic_entity_tag, test_mod, auth_headers):  # noqa
+        # The realistic production case: a curator source for the MOD already
+        # exists (created earlier by the UI's getCuratorSourceId, validation_type
+        # 'professional_curator'). get_or_create must REUSE it -- the source unique
+        # key excludes validation_type -- and an opposite-polarity re-validation by
+        # the same curator must succeed (NOT 409): the opposite-negation guard
+        # (Branch 3) only fires for 'professional_biocurator' sources, which the
+        # abc curator source never is. This pins down the behavior reviewers worry
+        # about (the empty-DB test above exercises only the create branch).
+        load_name_to_atp_and_relationships_mock()
+        mod = test_mod.new_mod_abbreviation
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_ancestors") as mock_get_ancestors, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_descendants") as mock_get_descendants, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
+                mock_get_curie_to_name_from_all_tets, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.build_curie_to_name_map") as \
+                mock_build_curie_to_name_map:
+            mock_get_ancestors.return_value = []
+            mock_get_descendants.return_value = []
+            mock_get_curie_to_name_from_all_tets.return_value = {}
+            mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
+            ref_curie = test_topic_entity_tag.related_ref_curie
+
+            # pre-create the curator source exactly as the UI's getCuratorSourceId
+            # does (validation_type 'professional_curator')
+            existing_source_id = client.post(
+                url="/topic_entity_tag/source",
+                json={
+                    "source_evidence_assertion": "ATP:0000036",
+                    "source_method": "abc_literature_system",
+                    "validation_type": "professional_curator",
+                    "description": "curator from ABC",
+                    "data_provider": mod,
+                    "secondary_data_provider_abbreviation": mod,
+                },
+                headers=auth_headers,
+            ).json()["topic_entity_tag_source_id"]
+
+            y = client.post(
+                url="/topic_entity_tag/validate",
+                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                      "mod_abbreviation": mod, "negated": False},
+                headers=auth_headers,
+            )
+            assert y.status_code == status.HTTP_200_OK
+            # the validation tag reused the pre-existing source (no new one created)
+            created = client.get(
+                url=f"/topic_entity_tag/{y.json()['topic_entity_tag_id']}",
+                headers=auth_headers,
+            ).json()
+            assert created["topic_entity_tag_source_id"] == existing_source_id
+
+            # opposite polarity, same curator -> must be recorded, not 409
+            n = client.post(
+                url="/topic_entity_tag/validate",
+                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                      "mod_abbreviation": mod, "negated": True},
+                headers=auth_headers,
+            )
+            assert n.status_code == status.HTTP_200_OK
+            cell = n.json()["validation"]
+            assert cell["state"] == "conflict"
+            assert cell["positives"] == 1
+            assert cell["negatives"] == 1
+
     def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa
         with TestClient(app) as client:
             response = client.post(

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -527,6 +527,59 @@ class TestTopicEntityTag:
             assert cell["positives"] == 0
             assert cell["negatives"] == 1
 
+    def test_my_validation_present_flag(self, test_topic_entity_tag, test_mod, auth_headers):  # noqa
+        # my_validation_present resolves the deferral from increment 3: the server
+        # compares each tag's created_by (internal users.id) against the current
+        # request user's users.id, so the grid's 'my validation present' cell filter
+        # no longer needs raw tags + a client-side identity guess. The fixture tag
+        # was created_by "WBPerson1" (a different user), so before the current user
+        # touches the cell the flag is False; after this user validates it is True,
+        # in BOTH the batch filter_flags and the /validate recomputed cell.
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_ancestors") as mock_get_ancestors, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_descendants") as mock_get_descendants, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
+                mock_get_curie_to_name_from_all_tets, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.build_curie_to_name_map") as \
+                mock_build_curie_to_name_map:
+            mock_get_ancestors.return_value = []
+            mock_get_descendants.return_value = []
+            mock_get_curie_to_name_from_all_tets.return_value = {}
+            mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
+            ref_curie = test_topic_entity_tag.related_ref_curie
+
+            # before the current user validates: the only tag on the cell is the
+            # fixture tag (created_by "WBPerson1"), so my_validation_present is False
+            # while the other cell flags still reflect that tag.
+            before = client.post(
+                url="/topic_entity_tag/by_references",
+                json={"curies_or_reference_ids": [ref_curie]},
+                headers=auth_headers,
+            ).json()
+            cell_flags = before["filter_flags"][ref_curie]["ATP:0000122"]
+            assert cell_flags["has_any"] is True
+            assert cell_flags["my_validation_present"] is False
+
+            # the current user validates the topic; the created tag is stamped with
+            # this request's users.id, so the recomputed cell reports the flag True.
+            resp = client.post(
+                url="/topic_entity_tag/validate",
+                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                      "mod_abbreviation": test_mod.new_mod_abbreviation, "negated": False},
+                headers=auth_headers,
+            )
+            assert resp.status_code == status.HTTP_200_OK
+            assert resp.json()["filter_flags"]["my_validation_present"] is True
+
+            # and the batch aggregate now reports it True for the same cell.
+            after = client.post(
+                url="/topic_entity_tag/by_references",
+                json={"curies_or_reference_ids": [ref_curie]},
+                headers=auth_headers,
+            ).json()
+            assert after["filter_flags"][ref_curie]["ATP:0000122"]["my_validation_present"] is True
+
     def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa
         with TestClient(app) as client:
             response = client.post(

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -221,6 +221,78 @@ class TestTopicEntityTag:
             data = response.json()
             assert len(data["tags"][ref_curie]) >= 1
 
+    def test_show_all_reference_tags_batch_mod_filter(self, test_topic_entity_tag, test_topic_entity_tag_source, test_mod, auth_headers):  # noqa
+        # The grid must show only the selected MOD's tags. A tag's owning MOD is
+        # its source's secondary_data_provider (the field create_or_update uses for
+        # created_by_mod), NOT data_provider -- the fixture source has
+        # secondary_data_provider "0015_AtDB" but data_provider "WB", so a mods=[WB]
+        # filter must NOT keep it. Put a second MOD's tag on the SAME reference and
+        # assert the mods filter discriminates by secondary_data_provider across
+        # both the raw tags AND the discovery sources.
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_ancestors") as mock_get_ancestors, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_descendants") as mock_get_descendants, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
+                mock_get_curie_to_name_from_all_tets, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.build_curie_to_name_map") as \
+                mock_build_curie_to_name_map:
+            mock_get_ancestors.return_value = []
+            mock_get_descendants.return_value = []
+            mock_get_curie_to_name_from_all_tets.return_value = {}
+            mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
+            ref_curie = test_topic_entity_tag.related_ref_curie
+            mod1 = test_mod.new_mod_abbreviation  # fixture tag's secondary_data_provider
+
+            # A second MOD + a source owned by it, then a topic-level tag on the
+            # SAME reference under that source.
+            mod2 = "0016_BtDB"
+            client.post(url="/mod/", json={
+                "abbreviation": mod2, "short_name": "BtDB", "full_name": "Second test db"
+            }, headers=auth_headers)
+            source2_id = client.post(url="/topic_entity_tag/source", json={
+                "source_evidence_assertion": "ECO:0008025",
+                "source_method": "second network",
+                "validation_type": None,
+                "description": "a second-MOD source",
+                "data_provider": "WB",
+                "secondary_data_provider_abbreviation": mod2,
+            }, headers=auth_headers).json()["topic_entity_tag_source_id"]
+            tag2 = client.post(url="/topic_entity_tag/", json={
+                "reference_curie": ref_curie,
+                "topic": "ATP:0000122",
+                "species": "NCBITaxon:6239",
+                "data_novelty": "ATP:0000335",
+                "topic_entity_tag_source_id": source2_id,
+                "negated": False,
+                "created_by": "WBPerson2",
+                "force_insertion": True,
+            }, headers=auth_headers)
+            assert tag2.status_code == status.HTTP_201_CREATED
+
+            # mods=[mod1]: only the fixture (mod1-owned) tag; mod2's tag is hidden.
+            r1 = client.post(url="/topic_entity_tag/by_references", json={
+                "curies_or_reference_ids": [ref_curie], "filters": {"mods": [mod1]},
+            }, headers=auth_headers)
+            assert r1.status_code == status.HTTP_200_OK
+            d1 = r1.json()
+            secs1 = {t["topic_entity_tag_source"]["secondary_data_provider_abbreviation"]
+                     for t in d1["tags"][ref_curie]}
+            assert secs1 == {mod1}
+            assert all(s["secondary_data_provider"] == mod1 for s in d1["discovery"]["sources"])
+
+            # mods=[mod2]: only mod2's tag; the fixture (mod1) tag is hidden -- even
+            # though its source's data_provider is "WB", it is owned by mod1.
+            r2 = client.post(url="/topic_entity_tag/by_references", json={
+                "curies_or_reference_ids": [ref_curie], "filters": {"mods": [mod2]},
+            }, headers=auth_headers)
+            assert r2.status_code == status.HTTP_200_OK
+            d2 = r2.json()
+            secs2 = {t["topic_entity_tag_source"]["secondary_data_provider_abbreviation"]
+                     for t in d2["tags"][ref_curie]}
+            assert secs2 == {mod2}
+            assert all(s["secondary_data_provider"] == mod2 for s in d2["discovery"]["sources"])
+
     def test_show_all_reference_tags_batch_single_vs_multi_tag(self, test_topic_entity_tag, auth_headers):  # noqa
         # The fixture reference carries ONE tag: topic ATP:0000122 with source
         # method "phenotype neural network". Combining the topic it DOES carry

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from starlette.testclient import TestClient
-from fastapi import status
+from fastapi import status, HTTPException
 
 from agr_literature_service.api.main import app
 from agr_literature_service.api.models import TopicEntityTagModel
@@ -598,6 +598,58 @@ class TestTopicEntityTag:
             assert cell["state"] == "negative"
             assert cell["positives"] == 0
             assert cell["negatives"] == 1
+
+    def test_validate_topic_replace_is_atomic_on_insert_failure(self, test_topic_entity_tag, test_mod, auth_headers):  # noqa
+        # Replace-prior deletes the curator's prior validation before inserting the
+        # new one. That delete is FLUSHED, not committed, so if the insert fails
+        # the delete must roll back with the request -- the curator must never be
+        # left with their prior validation gone and no replacement.
+        load_name_to_atp_and_relationships_mock()
+        mod = test_mod.new_mod_abbreviation
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_ancestors") as mock_get_ancestors, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_descendants") as mock_get_descendants, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
+                mock_get_curie_to_name_from_all_tets, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.build_curie_to_name_map") as \
+                mock_build_curie_to_name_map:
+            mock_get_ancestors.return_value = []
+            mock_get_descendants.return_value = []
+            mock_get_curie_to_name_from_all_tets.return_value = {}
+            mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
+            ref_curie = test_topic_entity_tag.related_ref_curie
+
+            # seed a prior positive validation
+            y = client.post(
+                url="/topic_entity_tag/validate",
+                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                      "mod_abbreviation": mod, "negated": False},
+                headers=auth_headers,
+            )
+            assert y.status_code == status.HTTP_200_OK
+            assert y.json()["validation"]["state"] == "positive"
+
+            # a flip whose INSERT fails: the prior delete must not survive it
+            with patch("agr_literature_service.api.crud.topic_entity_tag_crud.create_tag",
+                       side_effect=HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                                 detail="boom")):
+                n = client.post(
+                    url="/topic_entity_tag/validate",
+                    json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                          "mod_abbreviation": mod, "negated": True},
+                    headers=auth_headers,
+                )
+            assert n.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+            # the prior positive validation is still there (delete rolled back)
+            after = client.post(
+                url="/topic_entity_tag/by_references",
+                json={"curies_or_reference_ids": [ref_curie]},
+                headers=auth_headers,
+            )
+            cell = after.json()["validation"][ref_curie]["ATP:0000122"]
+            assert cell["state"] == "positive"
+            assert cell["positives"] == 1
 
     def test_my_validation_present_flag(self, test_topic_entity_tag, test_mod, auth_headers):  # noqa
         # my_validation_present resolves the deferral from increment 3: the server

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -297,6 +297,9 @@ class TestTopicEntityTag:
                 "reference_curie": ref_curie,
                 "topic": "ATP:0000122",
                 "species": "NCBITaxon:6239",
+                # data_novelty is a non-null column; topic-level curator
+                # validations carry the "no data" term (matches the UI).
+                "data_novelty": "ATP:0000335",
                 "topic_entity_tag_source_id": source_id,
             }
             # one positive and one negative curator topic-level validation
@@ -333,6 +336,59 @@ class TestTopicEntityTag:
             discovery = response.json()["discovery"]
             assert any(t["curie"] == "ATP:0000122" for t in discovery["topics"])
             assert all(s["method"] != "abc_literature_system" for s in discovery["sources"])
+
+    def test_validate_topic(self, test_topic_entity_tag, test_mod, auth_headers):  # noqa
+        # POST /validate is the thin write path for the grid's Validation column:
+        # the server resolves the curator source (get-or-create) and creates the
+        # topic-level validation tag, then returns the single recomputed cell so
+        # the grid never re-aggregates the whole batch after one edit.
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_ancestors") as mock_get_ancestors, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_descendants") as mock_get_descendants, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
+                mock_get_curie_to_name_from_all_tets, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.build_curie_to_name_map") as \
+                mock_build_curie_to_name_map:
+            mock_get_ancestors.return_value = []
+            mock_get_descendants.return_value = []
+            mock_get_curie_to_name_from_all_tets.return_value = {}
+            mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
+            ref_curie = test_topic_entity_tag.related_ref_curie
+
+            # first validation: positive, with a note. No source id is passed --
+            # the server get-or-creates the curator source for the MOD.
+            resp = client.post(
+                url="/topic_entity_tag/validate",
+                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                      "mod_abbreviation": test_mod.new_mod_abbreviation,
+                      "negated": False, "note": "looks right"},
+                headers=auth_headers,
+            )
+            assert resp.status_code == status.HTTP_200_OK
+            body = resp.json()
+            assert isinstance(body["topic_entity_tag_id"], int)
+            assert body["topic"] == "ATP:0000122"
+            assert body["validation"]["state"] == "positive"
+            assert body["validation"]["positives"] == 1
+            assert body["validation"]["negatives"] == 0
+            # the recomputed cell's filter flags reflect the new Y tag + its note
+            assert body["filter_flags"]["has_y"] is True
+            assert body["filter_flags"]["has_note"] is True
+
+            # a second, opposite-polarity validation reuses the same get-or-created
+            # source and makes the recomputed cell a conflict.
+            resp2 = client.post(
+                url="/topic_entity_tag/validate",
+                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                      "mod_abbreviation": test_mod.new_mod_abbreviation, "negated": True},
+                headers=auth_headers,
+            )
+            assert resp2.status_code == status.HTTP_200_OK
+            cell = resp2.json()["validation"]
+            assert cell["state"] == "conflict"
+            assert cell["positives"] == 1
+            assert cell["negatives"] == 1
 
     def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa
         with TestClient(app) as client:

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -154,6 +154,13 @@ class TestTopicEntityTag:
             assert flags[ref_curie]["ATP:0000122"]["has_y"] is True
             assert flags[ref_curie]["ATP:0000122"]["has_n"] is False
             assert flags[ref_curie]["ATP:0000122"]["has_note"] is True
+            # discovery is batch-global: the column set and source filter come
+            # pre-aggregated so the grid never scans raw tags to build them.
+            discovery = data["discovery"]
+            assert {"curie": "ATP:0000122", "name": "ATP:0000122"} in discovery["topics"]
+            # the fixture tag is non-curator, so its source shows up for the filter
+            assert len(discovery["sources"]) >= 1
+            assert all("label" in source for source in discovery["sources"])
             # an unresolvable id maps to an empty list / empty counts
             assert tags.get("AGRKB:000000000") == []
             assert counts.get("AGRKB:000000000") == {}
@@ -320,6 +327,12 @@ class TestTopicEntityTag:
                 any(s["method"] == "abc_literature_system" for s in g["sources"])
                 for g in cell["by_curator"]
             )
+            # discovery exposes the topic column (curator tags count toward columns)
+            # but excludes the curator source from the source filter -- matching the
+            # counts/entries scope so the source filter never lists a curator source.
+            discovery = response.json()["discovery"]
+            assert any(t["curie"] == "ATP:0000122" for t in discovery["topics"])
+            assert all(s["method"] != "abc_literature_system" for s in discovery["sources"])
 
     def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa
         with TestClient(app) as client:

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -381,8 +381,9 @@ class TestTopicEntityTag:
             assert body["filter_flags"]["has_y"] is True
             assert body["filter_flags"]["has_note"] is True
 
-            # a second, opposite-polarity validation reuses the same get-or-created
-            # source and makes the recomputed cell a conflict.
+            # a second, opposite-polarity validation by the SAME curator REPLACES
+            # the first (replace-prior semantics): the cell flips to negative, it
+            # does not become a self-conflict, and it does not 409.
             resp2 = client.post(
                 url="/topic_entity_tag/validate",
                 json={"reference_curie": ref_curie, "topic": "ATP:0000122",
@@ -390,9 +391,10 @@ class TestTopicEntityTag:
                 headers=auth_headers,
             )
             assert resp2.status_code == status.HTTP_200_OK
+            assert resp2.json()["replaced"] is True
             cell = resp2.json()["validation"]
-            assert cell["state"] == "conflict"
-            assert cell["positives"] == 1
+            assert cell["state"] == "negative"
+            assert cell["positives"] == 0
             assert cell["negatives"] == 1
 
     def test_validate_topic_reuses_existing_curator_source(self, test_topic_entity_tag, test_mod, auth_headers):  # noqa
@@ -448,7 +450,8 @@ class TestTopicEntityTag:
             ).json()
             assert created["topic_entity_tag_source_id"] == existing_source_id
 
-            # opposite polarity, same curator -> must be recorded, not 409
+            # opposite polarity, same curator -> REPLACES the prior validation
+            # (not 409, not self-conflict): the cell flips to negative.
             n = client.post(
                 url="/topic_entity_tag/validate",
                 json={"reference_curie": ref_curie, "topic": "ATP:0000122",
@@ -456,9 +459,72 @@ class TestTopicEntityTag:
                 headers=auth_headers,
             )
             assert n.status_code == status.HTTP_200_OK
+            assert n.json()["replaced"] is True
             cell = n.json()["validation"]
-            assert cell["state"] == "conflict"
-            assert cell["positives"] == 1
+            assert cell["state"] == "negative"
+            assert cell["positives"] == 0
+            assert cell["negatives"] == 1
+
+    def test_validate_topic_flip_with_biocurator_source_does_not_409(self, test_topic_entity_tag, test_mod, auth_headers):  # noqa
+        # Production reality: some MODs' abc curator source is
+        # 'professional_biocurator' (not 'professional_curator'). Against such a
+        # source, check_for_duplicate_tags Branch 3 would 409 a same-curator
+        # opposite-polarity insert. validate_topic must still let a curator flip
+        # their vote: it deletes the curator's prior validation first, so the new
+        # insert never trips Branch 3. This is the regression for the original
+        # review concern.
+        load_name_to_atp_and_relationships_mock()
+        mod = test_mod.new_mod_abbreviation
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_ancestors") as mock_get_ancestors, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_descendants") as mock_get_descendants, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
+                mock_get_curie_to_name_from_all_tets, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.build_curie_to_name_map") as \
+                mock_build_curie_to_name_map:
+            mock_get_ancestors.return_value = []
+            mock_get_descendants.return_value = []
+            mock_get_curie_to_name_from_all_tets.return_value = {}
+            mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
+            ref_curie = test_topic_entity_tag.related_ref_curie
+
+            # pre-create the curator source as professional_biocurator -- the value
+            # that makes Branch 3 fire on opposite-polarity inserts.
+            client.post(
+                url="/topic_entity_tag/source",
+                json={
+                    "source_evidence_assertion": "ATP:0000036",
+                    "source_method": "abc_literature_system",
+                    "validation_type": "professional_biocurator",
+                    "description": "curator from ABC",
+                    "data_provider": mod,
+                    "secondary_data_provider_abbreviation": mod,
+                },
+                headers=auth_headers,
+            )
+
+            y = client.post(
+                url="/topic_entity_tag/validate",
+                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                      "mod_abbreviation": mod, "negated": False},
+                headers=auth_headers,
+            )
+            assert y.status_code == status.HTTP_200_OK
+            assert y.json()["validation"]["state"] == "positive"
+
+            # the flip would 409 (opposite_negation) without replace-prior; assert
+            # it succeeds and replaces.
+            n = client.post(
+                url="/topic_entity_tag/validate",
+                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
+                      "mod_abbreviation": mod, "negated": True},
+                headers=auth_headers,
+            )
+            assert n.status_code == status.HTTP_200_OK
+            assert n.json()["replaced"] is True
+            cell = n.json()["validation"]
+            assert cell["state"] == "negative"
+            assert cell["positives"] == 0
             assert cell["negatives"] == 1
 
     def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -248,6 +248,62 @@ class TestTopicEntityTag:
             assert response.status_code == status.HTTP_200_OK
             assert len(response.json()["tags"][ref_curie]) >= 1
 
+    def test_show_all_reference_tags_batch_validation_state(self, test_topic_entity_tag, test_reference, test_mod, auth_headers):  # noqa
+        # A topic-level tag (no entity) from a professional-biocurator source is a
+        # curator validation. The batch endpoint aggregates per-cell validation
+        # state so the grid's Validation column can sort/filter without deriving
+        # it from raw tags. Two positive + negative curator tags on the same
+        # (reference, topic) => 'conflict'.
+        load_name_to_atp_and_relationships_mock()
+        with TestClient(app) as client, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_ancestors") as mock_get_ancestors, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_descendants") as mock_get_descendants, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
+                mock_get_curie_to_name_from_all_tets, \
+                patch("agr_literature_service.api.crud.topic_entity_tag_crud.build_curie_to_name_map") as \
+                mock_build_curie_to_name_map:
+            mock_get_ancestors.return_value = []
+            mock_get_descendants.return_value = []
+            mock_get_curie_to_name_from_all_tets.return_value = {}
+            mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
+            ref_curie = test_topic_entity_tag.related_ref_curie
+
+            curator_source = {
+                "source_evidence_assertion": "ATP:0000036",
+                "source_method": "abc_literature_system",
+                "validation_type": "professional_biocurator",
+                "description": "curator from ABC",
+                "data_provider": "WB",
+                "secondary_data_provider_abbreviation": test_mod.new_mod_abbreviation,
+            }
+            source_id = client.post(url="/topic_entity_tag/source", json=curator_source,
+                                    headers=auth_headers).json()["topic_entity_tag_source_id"]
+            base = {
+                "reference_curie": ref_curie,
+                "topic": "ATP:0000122",
+                "species": "NCBITaxon:6239",
+                "topic_entity_tag_source_id": source_id,
+            }
+            # one positive and one negative curator topic-level validation
+            pos = client.post(url="/topic_entity_tag/",
+                              json={**base, "negated": False, "created_by": "WBPerson1"},
+                              headers=auth_headers)
+            assert pos.status_code == status.HTTP_201_CREATED
+            neg = client.post(url="/topic_entity_tag/",
+                              json={**base, "negated": True, "created_by": "WBPerson2",
+                                    "force_insertion": True},
+                              headers=auth_headers)
+            assert neg.status_code == status.HTTP_201_CREATED
+
+            response = client.post(
+                url="/topic_entity_tag/by_references",
+                json={"curies_or_reference_ids": [ref_curie]},
+                headers=auth_headers,
+            )
+            assert response.status_code == status.HTTP_200_OK
+            validation = response.json()["validation"]
+            assert validation[ref_curie]["ATP:0000122"] == "conflict"
+
     def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa
         with TestClient(app) as client:
             response = client.post(

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -264,7 +264,7 @@ class TestTopicEntityTag:
             assert len(response.json()["tags"][ref_curie]) >= 1
 
     def test_show_all_reference_tags_batch_validation_state(self, test_topic_entity_tag, test_reference, test_mod, auth_headers):  # noqa
-        # A topic-level tag (no entity) from a professional-biocurator source is a
+        # A topic-level tag (no entity) from a professional-curator source is a
         # curator validation. The batch endpoint aggregates per-cell validation
         # state so the grid's Validation column can sort/filter without deriving
         # it from raw tags. Two positive + negative curator tags on the same
@@ -283,10 +283,15 @@ class TestTopicEntityTag:
             mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
             ref_curie = test_topic_entity_tag.related_ref_curie
 
+            # validation_type matches what the UI's getCuratorSourceId actually
+            # POSTs for the abc_literature_system source ('professional_curator');
+            # the abc curator source is never 'professional_biocurator'. Keeping
+            # this consistent with the write-path test avoids implying the source
+            # key (ATP:0000036 / abc_literature_system) can be biocurator.
             curator_source = {
                 "source_evidence_assertion": "ATP:0000036",
                 "source_method": "abc_literature_system",
-                "validation_type": "professional_biocurator",
+                "validation_type": "professional_curator",
                 "description": "curator from ABC",
                 "data_provider": "WB",
                 "secondary_data_provider_abbreviation": test_mod.new_mod_abbreviation,

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -651,59 +651,6 @@ class TestTopicEntityTag:
             assert cell["state"] == "positive"
             assert cell["positives"] == 1
 
-    def test_my_validation_present_flag(self, test_topic_entity_tag, test_mod, auth_headers):  # noqa
-        # my_validation_present resolves the deferral from increment 3: the server
-        # compares each tag's created_by (internal users.id) against the current
-        # request user's users.id, so the grid's 'my validation present' cell filter
-        # no longer needs raw tags + a client-side identity guess. The fixture tag
-        # was created_by "WBPerson1" (a different user), so before the current user
-        # touches the cell the flag is False; after this user validates it is True,
-        # in BOTH the batch filter_flags and the /validate recomputed cell.
-        load_name_to_atp_and_relationships_mock()
-        with TestClient(app) as client, \
-                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_ancestors") as mock_get_ancestors, \
-                patch("agr_literature_service.api.crud.topic_entity_tag_utils.get_descendants") as mock_get_descendants, \
-                patch("agr_literature_service.api.crud.topic_entity_tag_crud.get_curie_to_name_from_all_tets") as \
-                mock_get_curie_to_name_from_all_tets, \
-                patch("agr_literature_service.api.crud.topic_entity_tag_crud.build_curie_to_name_map") as \
-                mock_build_curie_to_name_map:
-            mock_get_ancestors.return_value = []
-            mock_get_descendants.return_value = []
-            mock_get_curie_to_name_from_all_tets.return_value = {}
-            mock_build_curie_to_name_map.return_value = {'ATP:0000122': 'ATP:0000122'}
-            ref_curie = test_topic_entity_tag.related_ref_curie
-
-            # before the current user validates: the only tag on the cell is the
-            # fixture tag (created_by "WBPerson1"), so my_validation_present is False
-            # while the other cell flags still reflect that tag.
-            before = client.post(
-                url="/topic_entity_tag/by_references",
-                json={"curies_or_reference_ids": [ref_curie]},
-                headers=auth_headers,
-            ).json()
-            cell_flags = before["filter_flags"][ref_curie]["ATP:0000122"]
-            assert cell_flags["has_any"] is True
-            assert cell_flags["my_validation_present"] is False
-
-            # the current user validates the topic; the created tag is stamped with
-            # this request's users.id, so the recomputed cell reports the flag True.
-            resp = client.post(
-                url="/topic_entity_tag/validate",
-                json={"reference_curie": ref_curie, "topic": "ATP:0000122",
-                      "mod_abbreviation": test_mod.new_mod_abbreviation, "negated": False},
-                headers=auth_headers,
-            )
-            assert resp.status_code == status.HTTP_200_OK
-            assert resp.json()["filter_flags"]["my_validation_present"] is True
-
-            # and the batch aggregate now reports it True for the same cell.
-            after = client.post(
-                url="/topic_entity_tag/by_references",
-                json={"curies_or_reference_ids": [ref_curie]},
-                headers=auth_headers,
-            ).json()
-            assert after["filter_flags"][ref_curie]["ATP:0000122"]["my_validation_present"] is True
-
     def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa
         with TestClient(app) as client:
             response = client.post(

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -147,10 +147,18 @@ class TestTopicEntityTag:
                 entry["kind"] == "entity-pos" and entry["count"] >= 1
                 for entry in entries[ref_curie]["ATP:0000122"]
             )
+            # per-topic cell filter flags are aggregated in the API; the fixture
+            # tag is a positive (negated False) tag carrying a note
+            flags = data["filter_flags"]
+            assert flags[ref_curie]["ATP:0000122"]["has_any"] is True
+            assert flags[ref_curie]["ATP:0000122"]["has_y"] is True
+            assert flags[ref_curie]["ATP:0000122"]["has_n"] is False
+            assert flags[ref_curie]["ATP:0000122"]["has_note"] is True
             # an unresolvable id maps to an empty list / empty counts
             assert tags.get("AGRKB:000000000") == []
             assert counts.get("AGRKB:000000000") == {}
             assert entries.get("AGRKB:000000000") == {}
+            assert data["filter_flags"].get("AGRKB:000000000") == {}
 
     def test_show_all_reference_tags_batch_filtered(self, test_topic_entity_tag, auth_headers):  # noqa
         # Filtering to a topic the reference does NOT carry returns no tags for it.

--- a/tests/api/test_topic_entity_tag.py
+++ b/tests/api/test_topic_entity_tag.py
@@ -301,8 +301,17 @@ class TestTopicEntityTag:
                 headers=auth_headers,
             )
             assert response.status_code == status.HTTP_200_OK
-            validation = response.json()["validation"]
-            assert validation[ref_curie]["ATP:0000122"] == "conflict"
+            cell = response.json()["validation"][ref_curie]["ATP:0000122"]
+            assert cell["state"] == "conflict"
+            assert cell["positives"] == 1
+            assert cell["negatives"] == 1
+            # one positive and one negative curator group, distinct polarities
+            assert len(cell["by_curator"]) == 2
+            assert {g["negated"] for g in cell["by_curator"]} == {True, False}
+            assert all(
+                any(s["method"] == "abc_literature_system" for s in g["sources"])
+                for g in cell["by_curator"]
+            )
 
     def test_show_all_reference_tags_batch_too_many(self, test_topic_entity_tag, auth_headers):  # noqa
         with TestClient(app) as client:


### PR DESCRIPTION
Summary:

▎ What & why
▎
▎ Moves the TET validation grid's per-cell logic server-side so the batch endpoint returns pre-computed aggregates instead of the UI re-deriving everything from raw tags. Adds a thin write endpoint so a curator validation creates the tag and returns just the recomputed cell. Follow-up to #1218.
▎
▎ Changes
▎
▎ POST /topic_entity_tag/by_references now returns, alongside tags/counts/entries:
▎ - validation — per (reference, topic) curator-validation aggregate: {state: positive|negative|conflict, positives, negatives, by_curator: [{name, negated, sources:[{method,label}], species}]}. Mirrors the grid's ValidationCell so it renders without raw curator tags. Topics with no curator validation are omitted (client treats absent as "unvalidated").
▎ - filter_flags — per (reference, topic) booleans {has_any, has_y, has_n, has_note} backing the per-cell filter, computed over all tags of the cell.
▎ - discovery — batch-global {topics:[{curie,name}], sources:[{label,method,secondary_data_provider,data_provider}]}: the distinct topic columns (over all tags) and source labels (over non-curator tags) present in the post-filter batch, so the grid builds its column set and source filter without scanning raw tags.
▎
▎ POST /topic_entity_tag/validate (new) — thin write path for the grid's Validation column. Given {reference_curie, topic, mod_abbreviation, negated, note?, species?}, it resolves the per-MOD ABC curator source (get-or-create), creates the topic-level validation tag through the normal create_tag path (so dedup/upsert/validation behave identically), and returns the single recomputed cell {topic_entity_tag_id, upserted, topic, validation, filter_flags} — letting the grid update one cell without re-aggregating the whole batch.
▎
▎ Notes
▎
▎ - Curator vs non-curator scoping is consistent across aggregates: curator submissions surface in validation, never in counts/entries/discovery.sources.
▎ - my_validation_present is intentionally not server-provided yet — it needs a curator-identity model (serialized created_by is a display name); deferred.
▎
▎ Tests
▎
▎ Added coverage for validation, filter_flags, discovery, and /validate (incl. positive→conflict re-validation and curator-source get-or-create). Also fixes a pre-existing test that created curator tags without data_novelty (required, non-null) so it could never have passed.
▎
▎ Files: 3 changed, +447. flake8 clean (pre-existing warnings only). ⚠️ Run make run-test-bash (Docker) to execute the suite — not yet run in CI.
