### PR TITLE
fix(pdf2md): backfill index-based matching + bypass in-progress guard (SCRUM-6246)

### DIFF
--- a/agr_literature_service/api/crud/referencefile_crud.py
+++ b/agr_literature_service/api/crud/referencefile_crud.py
@@ -51,27 +51,34 @@ text_conversion_process_atp_id = "ATP:0000161"
 
 # TRANSIENT (SCRUM-6246 figure-metadata backfill): a one-off process may flip
 # this so file_upload() persists *auxiliary* files (e.g. the figure-metadata
-# JSON sidecars) WITHOUT firing transition_WFT_for_uploaded_file or pruning
-# superseded main PDFs via cleanup_old_pdf_file. The reference's file-upload
-# workflow status was already set when the figures were originally converted, so
-# re-attaching descriptor files must not move it or trigger downstream
-# reprocessing. Default is False, so the live API / conversion path is
-# unaffected — only the backfill script activates it, for the duration of its
-# run (see lit_processing/pdf2md/backfill_figure_metadata.py). Process-level
-# (module global): the standalone backfill runs in its own process, so this
-# never leaks into the API or cron conversion processes.
-_suppress_post_upload_workflow = False
+# JSON sidecars) without the guardrails meant for interactive/live uploads.
+# When set, file_upload():
+#   - skips the is_file_upload_blocked "job in progress" guard, so a downstream
+#     process running on the reference (entity extraction / classification) does
+#     not block attaching descriptor files; and
+#   - skips the post-upload side effects transition_WFT_for_uploaded_file and
+#     cleanup_old_pdf_file — the reference's file-upload workflow status was
+#     already set when the figures were originally converted, so re-attaching
+#     descriptor files must not move it or trigger downstream reprocessing.
+# Default is False, so the live API / conversion path is unaffected — only the
+# backfill script activates it, for the duration of its run (see
+# lit_processing/pdf2md/backfill_figure_metadata.py). Process-level (module
+# global): the standalone backfill runs in its own process, so this never leaks
+# into the API or cron conversion processes.
+_suppress_upload_guardrails = False
 
 
-def set_suppress_post_upload_workflow(value: bool) -> None:
-    """Toggle suppression of file_upload()'s post-upload workflow side effects
-    (transition + main-PDF cleanup). See ``_suppress_post_upload_workflow``."""
-    global _suppress_post_upload_workflow
-    _suppress_post_upload_workflow = bool(value)
+def set_suppress_upload_guardrails(value: bool) -> None:
+    """Toggle suppression of file_upload()'s interactive-upload guardrails: the
+    is_file_upload_blocked "job in progress" check and the post-upload side
+    effects (workflow transition + main-PDF cleanup). See
+    ``_suppress_upload_guardrails``."""
+    global _suppress_upload_guardrails
+    _suppress_upload_guardrails = bool(value)
 
 
-def is_post_upload_workflow_suppressed() -> bool:
-    return _suppress_post_upload_workflow
+def is_upload_guardrails_suppressed() -> bool:
+    return _suppress_upload_guardrails
 
 
 def get_main_pdf_referencefile_id(db: Session, curie_or_reference_id: str,
@@ -480,10 +487,14 @@ def file_upload(db: Session, metadata: dict, file: UploadFile, upload_if_already
         if not inCorpus:
             raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                                 detail=f"This paper ({metadata['reference_curie']}) is not in {metadata['mod_abbreviation']}.")
-        job_type = is_file_upload_blocked(db, metadata["reference_curie"], metadata["mod_abbreviation"])
-        if job_type:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                                detail=f"The {job_type} for reference {metadata['reference_curie']} is currently in progress. Please wait until the {job_type} process is complete before uploading any files for this paper.")
+        # The one-off backfill (auxiliary metadata sidecars) suppresses this
+        # guard: a downstream job in progress (entity extraction / classification)
+        # must not block attaching descriptor files, which those jobs don't read.
+        if not _suppress_upload_guardrails:
+            job_type = is_file_upload_blocked(db, metadata["reference_curie"], metadata["mod_abbreviation"])
+            if job_type:
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                                    detail=f"The {job_type} for reference {metadata['reference_curie']} is currently in progress. Please wait until the {job_type} process is complete before uploading any files for this paper.")
 
     if (
         metadata["file_class"] == 'main'
@@ -539,7 +550,7 @@ def file_upload(db: Session, metadata: dict, file: UploadFile, upload_if_already
     else:
         created_referencefiles.append(file_upload_single(db, metadata, file))
     mod_abbreviation = metadata["mod_abbreviation"] if "mod_abbreviation" in metadata else None
-    if _suppress_post_upload_workflow:
+    if _suppress_upload_guardrails:
         # Auxiliary upload (e.g. figure-metadata sidecar): persist the file but
         # do not move the reference's workflow status or prune its main PDFs.
         # transition_WFT_for_uploaded_file is normally the committing step, so

--- a/agr_literature_service/lit_processing/pdf2md/backfill_figure_metadata.py
+++ b/agr_literature_service/lit_processing/pdf2md/backfill_figure_metadata.py
@@ -21,9 +21,11 @@ of an identical sidecar a no-op. Safe to re-run after an interruption.
 
 Note: each sidecar goes through the standard ``file_upload`` path. Because these
 references were already converted, this run activates
-``set_suppress_post_upload_workflow(True)`` so attaching the descriptor sidecars
-does NOT re-fire ``transition_WFT_for_uploaded_file`` or prune main PDFs — it
-must not move the reference's file-upload workflow status or trigger downstream
+``set_suppress_upload_guardrails(True)`` so attaching the descriptor sidecars
+(a) is NOT blocked by ``is_file_upload_blocked`` when a downstream job (entity
+extraction / classification) is running on the reference, and (b) does NOT
+re-fire ``transition_WFT_for_uploaded_file`` or prune main PDFs — it must not
+move the reference's file-upload workflow status or trigger downstream
 reprocessing. (Firing the transition here also breaks on the 2nd+ sidecar of a
 reference: when the ATP descendants cache is cold the status lookup returns
 None, so every upload retries the create and collides on the unique
@@ -55,7 +57,7 @@ from agr_cognito_py import ModAccess, get_admin_token
 
 from agr_literature_service.api.crud.referencefile_crud import (
     download_file,
-    set_suppress_post_upload_workflow,
+    set_suppress_upload_guardrails,
 )
 from agr_literature_service.api.models import (
     ModModel,
@@ -138,12 +140,14 @@ def plan_sidecars_for_source(
     """Pure planning step: decide which figure PNGs of one source PDF still
     need a metadata sidecar and which regenerated manifest entry feeds each.
 
-    The existing figures are sorted by display_name (which sorts by the
-    ``_image_NNN`` index) and paired positionally with the manifest images
-    (PDFX/Marker emits images in a stable order for a given PDF). A figure
-    whose display_name is already in ``existing_metadata_names`` is skipped
-    (idempotency/resume). ``figure_index`` is parsed from each PNG's
-    display_name so it stays consistent with the live conversion path.
+    Each figure PNG's ``_image_NNN`` suffix is its 1-based position in the
+    original manifest, so we match every PNG to ``manifest_images[NNN-1]`` by
+    that index rather than by sorted position. This tolerates
+    md5-deduplicated figures: identical repeated images collapse to a single
+    stored PNG at upload time, which leaves gaps in the ``_image_NNN``
+    numbering and makes ``len(png_rows) < len(manifest_images)`` even though
+    the extraction is unchanged. A figure whose display_name is already in
+    ``existing_metadata_names`` is skipped (idempotency/resume).
 
     Returns ``(planned, skipped_existing, skip_reason)`` where:
       - ``planned`` is a list of ``{figure_index, figure_display_name, image}``
@@ -151,13 +155,15 @@ def plan_sidecars_for_source(
       - ``skipped_existing`` counts figures that already had a sidecar;
       - ``skip_reason`` is None when planning succeeded, else a human-readable
         reason the WHOLE source was skipped. We refuse to plan (rather than
-        risk attaching a caption to the wrong figure — the exact failure the
-        provenance feature must avoid) when either:
+        risk attaching a caption to the wrong figure) when either:
           * any existing figure PNG has a non-canonical name (e.g. a prior
-            re-conversion left a ``_N`` rename suffix), so sorted order no
-            longer reliably equals manifest order; or
-          * the regenerated manifest's image count differs from the number of
-            existing figures.
+            re-conversion left a ``_N`` rename suffix); or
+          * the regenerated manifest's image count differs from the highest
+            stored ``_image_NNN`` index. Equal counts mean the extraction
+            produced the same number of images as the original run, so index
+            ``NNN`` still refers to the same figure; a difference means the
+            extraction changed (or the top images were deduped) and
+            index-based alignment can no longer be trusted.
     """
     sorted_pngs = sorted(png_rows, key=lambda r: r.display_name or "")
 
@@ -169,25 +175,35 @@ def plan_sidecars_for_source(
         return [], 0, (
             f"{len(non_canonical)} figure PNG(s) have non-canonical names "
             f"(e.g. {non_canonical[0]!r}); cannot reliably align them to the "
-            f"regenerated manifest by order"
+            f"regenerated manifest by index"
         )
-    if len(sorted_pngs) != len(manifest_images):
+
+    indexed = [
+        (_figure_index_from_display_name(p.display_name, 0), p)
+        for p in sorted_pngs
+    ]
+    if not indexed:
+        return [], 0, None
+
+    max_index = max(idx for idx, _ in indexed)
+    if len(manifest_images) != max_index:
         return [], 0, (
-            f"regenerated manifest has {len(manifest_images)} image(s) but "
-            f"{len(sorted_pngs)} existing figure(s)"
+            f"regenerated manifest has {len(manifest_images)} image(s) but the "
+            f"highest stored figure index is {max_index} (extraction differs); "
+            f"cannot align by index"
         )
 
     planned: List[Dict] = []
     skipped_existing = 0
-    for pos, (png, image) in enumerate(zip(sorted_pngs, manifest_images), start=1):
+    for idx, png in indexed:
         display_name = png.display_name
         if display_name in existing_metadata_names:
             skipped_existing += 1
             continue
         planned.append({
-            "figure_index": _figure_index_from_display_name(display_name, pos),
+            "figure_index": idx,
             "figure_display_name": display_name,
-            "image": image,
+            "image": manifest_images[idx - 1],
         })
     return planned, skipped_existing, None
 
@@ -467,12 +483,14 @@ def backfill(  # pragma: no cover
     stats: Dict[str, int] = defaultdict(int)
 
     # These references were already converted; their file-upload workflow status
-    # is set. Attaching metadata sidecars must NOT re-fire the file-upload
-    # transition (which would spuriously create a "file upload in progress" tag
-    # and, on the 2nd+ sidecar of a reference, fail with a duplicate-WFT 422) or
-    # prune main PDFs. Suppress those post-upload side effects for this one-off
-    # run; the descriptor files are still persisted and md5-deduped as usual.
-    set_suppress_post_upload_workflow(True)
+    # is set. Suppress file_upload's interactive-upload guardrails for this
+    # one-off run so attaching metadata sidecars: (a) is not blocked when a
+    # downstream job (entity extraction / classification) is in progress on the
+    # reference, and (b) does not re-fire the file-upload transition (which would
+    # spuriously create a "file upload in progress" tag and, on the 2nd+ sidecar
+    # of a reference, fail with a duplicate-WFT 422) or prune main PDFs. The
+    # descriptor files are still persisted and md5-deduped as usual.
+    set_suppress_upload_guardrails(True)
 
     def get_token() -> str:
         # Re-fetch per source PDF so a long run never trips an expired token.
@@ -513,7 +531,7 @@ def backfill(  # pragma: no cover
                 logger.error("Error backfilling %s: %s", ref_obj.curie, exc)
                 db.rollback()
     finally:
-        set_suppress_post_upload_workflow(False)
+        set_suppress_upload_guardrails(False)
         _log_summary(stats, dry_run)
         db.close()
     return dict(stats)

--- a/tests/api/test_file_conversion.py
+++ b/tests/api/test_file_conversion.py
@@ -18,7 +18,7 @@ from unittest.mock import patch, MagicMock
 
 import agr_literature_service.api.crud.referencefile_crud as referencefile_crud
 
-from fastapi import status
+from fastapi import HTTPException, status
 from starlette.testclient import TestClient
 
 from agr_literature_service.api.main import app
@@ -55,19 +55,21 @@ def manager():
     return ConversionJobManager()
 
 
-class TestSuppressPostUploadWorkflow:
-    """SCRUM-6246: a one-off process (the figure-metadata backfill) can flip a
-    process-level toggle so file_upload() persists auxiliary files WITHOUT
-    firing the file-upload workflow transition or pruning superseded main PDFs.
-    Default (live API / conversion path) is unchanged: the transition fires."""
+class TestSuppressUploadGuardrails:
+    """SCRUM-6246: a one-off process (the figure-metadata backfill) flips a
+    process-level toggle so file_upload() persists auxiliary files WITHOUT the
+    interactive-upload guardrails -- it skips the is_file_upload_blocked
+    "job in progress" check and the post-upload workflow transition / main-PDF
+    cleanup. Default (live API / conversion path) is unchanged."""
 
     @staticmethod
-    def _metadata():
-        # A figure-metadata sidecar: not main/pdf/final, mod-less so the
-        # corpus / upload-blocked guards are skipped (mod_abbreviation is None).
+    def _metadata(mod=None):
+        # A figure-metadata sidecar: not main/pdf/final. mod-less by default so
+        # the corpus / upload-blocked guards don't run; pass a mod to exercise
+        # the is_file_upload_blocked guard.
         return {
             "reference_curie": "AGRKB:101000000000001",
-            "mod_abbreviation": None,
+            "mod_abbreviation": mod,
             "file_class": "converted_main_figure_metadata",
             "file_publication_status": "final",
             "file_extension": "json",
@@ -96,25 +98,60 @@ class TestSuppressPostUploadWorkflow:
                 patch.object(referencefile_crud, "cleanup_old_pdf_file") as cleanup, \
                 patch.object(referencefile_crud,
                              "transition_WFT_for_uploaded_file") as transition:
-            referencefile_crud.set_suppress_post_upload_workflow(True)
+            referencefile_crud.set_suppress_upload_guardrails(True)
             try:
                 referencefile_crud.file_upload(mock_db, self._metadata(), MagicMock())
             finally:
-                referencefile_crud.set_suppress_post_upload_workflow(False)
+                referencefile_crud.set_suppress_upload_guardrails(False)
             transition.assert_not_called()
             cleanup.assert_not_called()
             # The created referencefile must still be persisted even though the
             # transition (which used to be the committing step) was skipped.
             mock_db.commit.assert_called_once()
 
+    def test_default_blocks_upload_when_job_in_progress(self):
+        mock_db = MagicMock()
+        with patch.object(referencefile_crud, "normalize_reference_curie",
+                          side_effect=lambda _db, curie: curie), \
+                patch.object(referencefile_crud, "check_if_paper_in_corpus",
+                             return_value=True), \
+                patch.object(referencefile_crud, "is_file_upload_blocked",
+                             return_value="entity extraction"), \
+                patch.object(referencefile_crud, "file_upload_single") as single:
+            with pytest.raises(HTTPException) as exc:
+                referencefile_crud.file_upload(mock_db, self._metadata(mod="WB"), MagicMock())
+        assert exc.value.status_code == 422
+        assert "in progress" in exc.value.detail
+        single.assert_not_called()  # blocked before the upload happens
+
+    def test_suppress_bypasses_job_in_progress_block(self):
+        mock_db = MagicMock()
+        with patch.object(referencefile_crud, "normalize_reference_curie",
+                          side_effect=lambda _db, curie: curie), \
+                patch.object(referencefile_crud, "check_if_paper_in_corpus",
+                             return_value=True), \
+                patch.object(referencefile_crud, "is_file_upload_blocked",
+                             return_value="entity extraction") as blocked, \
+                patch.object(referencefile_crud, "file_upload_single",
+                             return_value=MagicMock()) as single, \
+                patch.object(referencefile_crud, "cleanup_old_pdf_file"), \
+                patch.object(referencefile_crud, "transition_WFT_for_uploaded_file"):
+            referencefile_crud.set_suppress_upload_guardrails(True)
+            try:
+                referencefile_crud.file_upload(mock_db, self._metadata(mod="WB"), MagicMock())
+            finally:
+                referencefile_crud.set_suppress_upload_guardrails(False)
+            single.assert_called_once()   # upload proceeded despite the in-progress job
+            blocked.assert_not_called()   # the guard was skipped entirely
+
     def test_setter_toggles_and_resets_module_state(self):
-        assert referencefile_crud.is_post_upload_workflow_suppressed() is False
-        referencefile_crud.set_suppress_post_upload_workflow(True)
+        assert referencefile_crud.is_upload_guardrails_suppressed() is False
+        referencefile_crud.set_suppress_upload_guardrails(True)
         try:
-            assert referencefile_crud.is_post_upload_workflow_suppressed() is True
+            assert referencefile_crud.is_upload_guardrails_suppressed() is True
         finally:
-            referencefile_crud.set_suppress_post_upload_workflow(False)
-        assert referencefile_crud.is_post_upload_workflow_suppressed() is False
+            referencefile_crud.set_suppress_upload_guardrails(False)
+        assert referencefile_crud.is_upload_guardrails_suppressed() is False
 
 
 class TestConversionJob:

--- a/tests/lit_processing/pdf2md/test_backfill_figure_metadata.py
+++ b/tests/lit_processing/pdf2md/test_backfill_figure_metadata.py
@@ -35,17 +35,23 @@ class TestPlanSidecarsForSource:
         assert planned[0]["image"] == {"caption_text": "first"}
         assert planned[1]["image"] == {"caption_text": "second"}
 
-    def test_figure_index_parsed_from_display_name_not_position(self):
-        """figure_index comes from the PNG's ``_image_NNN`` ordinal, so a
-        gap (e.g. image 002 failed to download originally) yields [1, 3], not
-        the positional [1, 2] — keeping it consistent with the live path."""
-        png_rows = [_png("paper_image_001"), _png("paper_image_003")]
-        images = [{"a": 1}, {"a": 2}]
-        planned, _skipped, skip_reason = plan_sidecars_for_source(
+    def test_dedup_gap_matches_by_index_not_position(self):
+        """md5-dedup leaves gaps in the ``_image_NNN`` numbering (fewer stored
+        PNGs than manifest images). Each PNG is matched to ``manifest[NNN-1]``
+        by its index, so the gap doesn't shift later figures onto the wrong
+        image. Allowed because the manifest count equals the highest stored
+        index (extraction unchanged)."""
+        png_rows = [_png("paper_image_001"), _png("paper_image_002"),
+                    _png("paper_image_004")]
+        images = [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}]  # index 003 was deduped
+        planned, skipped, skip_reason = plan_sidecars_for_source(
             png_rows, images, existing_metadata_names=set()
         )
         assert skip_reason is None
-        assert [p["figure_index"] for p in planned] == [1, 3]
+        assert skipped == 0
+        assert [p["figure_index"] for p in planned] == [1, 2, 4]
+        # image_004 maps to manifest[3] ({"a": 4}), NOT the positional manifest[2]
+        assert [p["image"] for p in planned] == [{"a": 1}, {"a": 2}, {"a": 4}]
 
     def test_skips_pngs_that_already_have_a_sidecar(self):
         png_rows = [_png("paper_image_001"), _png("paper_image_002")]
@@ -72,13 +78,15 @@ class TestPlanSidecarsForSource:
         assert skip_reason is None
 
     def test_count_mismatch_skips_source(self):
+        # manifest (3) exceeds the highest stored index (2): extraction differs
+        # from the original run, so index alignment can't be trusted -> skip.
         png_rows = [_png("paper_image_001"), _png("paper_image_002")]
         images = [{"a": 1}, {"a": 2}, {"a": 3}]  # one extra image
         planned, skipped, skip_reason = plan_sidecars_for_source(
             png_rows, images, existing_metadata_names=set()
         )
         assert skip_reason is not None
-        assert "manifest has 3 image(s) but 2 existing" in skip_reason
+        assert "manifest has 3 image(s) but the highest stored figure index is 2" in skip_reason
         assert planned == []
         assert skipped == 0
 


### PR DESCRIPTION
## Summary

Two follow-up fixes for the figure-metadata backfill (SCRUM-6246), both surfaced while running it on **production** (275 refs; 1,851 sidecars added, but 331 blocked + 23 skipped).

### 1. Index-based sidecar matching (recovers the 23 skips)
`plan_sidecars_for_source` matched figure PNGs to manifest images by **sorted position** and required **equal counts** — so any reference whose figures were **md5-deduped** at upload was skipped as a "count mismatch." Identical repeated images (logos, repeated panels) collapse to a single stored PNG via `file_upload`'s md5 dedup, leaving **gaps** in the `_image_NNN` numbering (e.g. stored 31 of a 34-image manifest, gaps at 15/27/31). Verified on prod: the max stored `_image_NNN` index **equals** the current manifest count, i.e. the extractor is unchanged — it's dedup, not version drift.

Now each PNG is matched to `manifest[NNN-1]` by its `_image_NNN` **index**, tolerating gaps. The source is skipped only when the manifest count `!=` the highest stored index (extraction genuinely changed / top images deduped — ambiguous, so we don't risk mis-association) or a PNG has a non-canonical name.

### 2. Bypass `is_file_upload_blocked` for the backfill (fixes the 331 blocks)
All 331 `sidecar_errors` were `422: entity extraction … is currently in progress` — `file_upload`'s **pre-upload "job in progress" guard** firing while the live curation pipeline ran entity extraction on ~40 actively-curated refs. That guard is meant for interactive uploads of real source files; it's a false positive for attaching auxiliary metadata sidecars, which those jobs don't read.

Generalized the existing SCRUM-6246 toggle `set_suppress_post_upload_workflow` → **`set_suppress_upload_guardrails`**: when active, `file_upload` also **skips `is_file_upload_blocked`** (in addition to the workflow transition + main-PDF cleanup it already skipped). The backfill activates it for its run only; the live API/conversion path is unaffected (default off, process-level global). Mirrors the old SCRUM-5795 `converted_*` bypass (removed in SCRUM-5867).

## Tests
- `test_backfill_figure_metadata`: dedup-gap index matching (image_004 → `manifest[3]`, not positional `manifest[2]`), extraction-differs skip.
- `test_file_conversion`: renamed guardrails toggle tests + new `job in progress` cases — default **blocks** (422, upload not attempted) vs suppressed **bypasses** (upload proceeds, guard not called).
- flake8 + mypy clean.

## Rollout
Deploy to prod (rebuild the `automated_scripts` image), then re-run the backfill — idempotent, so it mops up the ~40 previously-blocked refs and the ~23 dedup-mismatch refs. (Prod PDFX cold-start is a separate issue already flagged to Chris.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)