### PR TITLE
feat(SCRUM-6238): one-shot person_lineage validate with curator overr…

### DIFF
--- a/agr_literature_service/api/crud/person_lineage_crud.py
+++ b/agr_literature_service/api/crud/person_lineage_crud.py
@@ -8,7 +8,7 @@ from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, selectinload
 
-from agr_literature_service.api.models import PersonLineageModel
+from agr_literature_service.api.models import PersonLineageModel, PersonLineageSubmissionModel
 from agr_literature_service.api.schemas import SYMMETRIC_RELATIONSHIPS, PersonPersonRole
 from agr_literature_service.api.crud import person_crud
 from agr_literature_service.api.crud.user_utils import map_to_user_id
@@ -170,6 +170,16 @@ def patch(db: Session, person_lineage_id: int, patch_dict: Dict[str, Any]) -> Di
     if "updated_by" in data and data["updated_by"] is not None:
         data["updated_by"] = map_to_user_id(data["updated_by"], db)
 
+    # Person corrections: resolve curie-or-id and repoint the canonical. The
+    # submission link (person_lineage_id) is independent of which persons the
+    # canonical references, so any linked submissions stay attached — their name
+    # claim is now simply resolved to the corrected person.
+    if "person_subject_curie_or_id" in data and data["person_subject_curie_or_id"] is not None:
+        obj.person_subject_id = person_crud.resolve_person_id(db, str(data["person_subject_curie_or_id"]))
+    if "person_object_curie_or_id" in data and data["person_object_curie_or_id"] is not None:
+        obj.person_object_id = person_crud.resolve_person_id(db, str(data["person_object_curie_or_id"]))
+    _reject_self_pair(obj.person_subject_id, obj.person_object_id)
+
     for field, value in data.items():
         if field not in _SCALAR_FIELDS:
             continue
@@ -206,5 +216,13 @@ def destroy(db: Session, person_lineage_id: int) -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"PersonLineage with id {person_lineage_id} not found",
         )
+    # Submissions promoted to this canonical have person_lineage_id cleared by the
+    # FK's ON DELETE SET NULL, but their status would stay 'validated'/'duplicate'.
+    # Reset those back to 'pending' so they return to the unvalidated pool cleanly
+    # and can be re-validated.
+    db.query(PersonLineageSubmissionModel).filter(
+        PersonLineageSubmissionModel.person_lineage_id == person_lineage_id,
+        PersonLineageSubmissionModel.status.in_(["validated", "duplicate"]),
+    ).update({"status": "pending"}, synchronize_session=False)
     db.delete(obj)
     db.commit()

--- a/agr_literature_service/api/crud/person_lineage_submission_crud.py
+++ b/agr_literature_service/api/crud/person_lineage_submission_crud.py
@@ -148,18 +148,35 @@ def destroy(db: Session, person_lineage_submission_id: int) -> None:
     db.commit()
 
 
-def validate(db: Session, person_lineage_submission_id: int) -> PersonLineageSubmissionModel:
+def validate(
+    db: Session,
+    person_lineage_submission_id: int,
+    overrides: Optional[Dict[str, Any]] = None,
+) -> PersonLineageSubmissionModel:
     """Promote a fully-resolved submission to a canonical person_lineage.
 
     Requires both person ids to be resolved. Finds or creates the canonical PPR
     for (person_subject_id, person_object_id, relationship), links the submission to it,
     and sets status to 'validated' (new canonical) or 'duplicate' (already existed).
 
+    Curator overrides (one-shot promote): `overrides` may carry the people
+    (`person_subject_curie_or_id`, `person_object_curie_or_id`), `relationship`,
+    `start_date` and/or `end_date` used to build the canonical row instead of the
+    submission's submitted values (the user's claim could be wrong). A key absent
+    from `overrides` falls back to the submission's value; `relationship` is never
+    taken as null. The submission row is never modified by validate — its names,
+    relationship, dates and person-id links stay as submitted; only the canonical
+    row uses the curated values, and later edits go to PATCH /person_lineage. (The
+    submission's `status` and `person_lineage_id` link are the promotion outcome,
+    not part of the claim, and are set below.)
+
     Guards:
       - a 'rejected' submission is refused (422) until its status is reset, so a
         rejection is never silently reversed;
-      - an already-linked submission is an idempotent no-op (returned unchanged).
+      - an already-linked submission is an idempotent no-op (returned unchanged);
+      - both people must resolve (from the override body or the submission).
     """
+    overrides = overrides or {}
     obj = show(db, person_lineage_submission_id)
 
     # A rejected submission must be deliberately un-rejected (its status reset)
@@ -178,11 +195,29 @@ def validate(db: Session, person_lineage_submission_id: int) -> PersonLineageSub
     if obj.person_lineage_id is not None:
         return obj
 
-    if obj.person_subject_id is None or obj.person_object_id is None:
+    # Resolve the canonical's people from the override body when supplied, else
+    # fall back to the submission's stored links. Resolution does NOT write back to
+    # the submission — only the canonical uses these ids. relationship/dates follow
+    # the same fall-back rule; relationship must remain non-null (unique key).
+    if "person_subject_curie_or_id" in overrides:
+        subject_id = _resolve_person(db, overrides["person_subject_curie_or_id"])
+    else:
+        subject_id = obj.person_subject_id
+    if "person_object_curie_or_id" in overrides:
+        object_id = _resolve_person(db, overrides["person_object_curie_or_id"])
+    else:
+        object_id = obj.person_object_id
+
+    if subject_id is None or object_id is None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Both person_subject_id and person_object_id must be resolved before validating.",
+            detail="Both subject and object persons must be resolved (via the validate "
+                   "body or the submission) before validating.",
         )
+
+    relationship = overrides.get("relationship") or obj.relationship
+    start_date = overrides["start_date"] if "start_date" in overrides else obj.start_date
+    end_date = overrides["end_date"] if "end_date" in overrides else obj.end_date
 
     # Wrap find_or_create (which flushes a new canonical) through commit, so a
     # concurrent validation creating the same (subject, object, relationship) row
@@ -190,11 +225,11 @@ def validate(db: Session, person_lineage_submission_id: int) -> PersonLineageSub
     try:
         canonical, created = person_lineage_crud.find_or_create(
             db,
-            person_subject_id=obj.person_subject_id,
-            person_object_id=obj.person_object_id,
-            relationship=obj.relationship,
-            start_date=obj.start_date,
-            end_date=obj.end_date,
+            person_subject_id=subject_id,
+            person_object_id=object_id,
+            relationship=relationship,
+            start_date=start_date,
+            end_date=end_date,
         )
         obj.person_lineage_id = canonical.person_lineage_id
         obj.status = "validated" if created else "duplicate"

--- a/agr_literature_service/api/models/person_lineage_model.py
+++ b/agr_literature_service/api/models/person_lineage_model.py
@@ -53,6 +53,16 @@ class PersonLineageModel(Base, AuditedModel):
         """Convenience for serializers — the curie of the resolved person_object."""
         return self.person_object_obj.curie if self.person_object_obj else None
 
+    @property
+    def person_subject_name(self):
+        """Convenience for serializers — display name of the resolved person_subject."""
+        return self.person_subject_obj.display_name if self.person_subject_obj else None
+
+    @property
+    def person_object_name(self):
+        """Convenience for serializers — display name of the resolved person_object."""
+        return self.person_object_obj.display_name if self.person_object_obj else None
+
     __table_args__ = (
         UniqueConstraint(
             "person_subject_id", "person_object_id", "relationship",

--- a/agr_literature_service/api/routers/person_lineage_submission_router.py
+++ b/agr_literature_service/api/routers/person_lineage_submission_router.py
@@ -10,6 +10,7 @@ from agr_literature_service.api.schemas import (
     PersonLineageSubmissionSchemaCreate,
     PersonLineageSubmissionSchemaUpdate,
     PersonLineageSubmissionSchemaShow,
+    PersonLineageSubmissionValidateSchema,
 )
 from agr_literature_service.api.user import set_global_user_from_cognito
 from agr_literature_service.api.auth import get_authenticated_user
@@ -44,11 +45,15 @@ def create(
 )
 def validate(
     person_lineage_submission_id: int,
+    request: Optional[PersonLineageSubmissionValidateSchema] = None,
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
     set_global_user_from_cognito(db, user)
-    return person_lineage_submission_crud.validate(db, person_lineage_submission_id)
+    # exclude_unset so an omitted field falls back to the submission's value,
+    # while an explicit null (start_date/end_date) still clears that date.
+    overrides = request.model_dump(exclude_unset=True) if request else {}
+    return person_lineage_submission_crud.validate(db, person_lineage_submission_id, overrides)
 
 
 # Submissions in which a person is resolved, on either side.

--- a/agr_literature_service/api/schemas/__init__.py
+++ b/agr_literature_service/api/schemas/__init__.py
@@ -175,6 +175,7 @@ from .person_lineage_submission_schemas import (
     PersonLineageSubmissionSchemaUpdate,
     PersonLineageSubmissionSchemaShow,
     PersonLineageSubmissionSchemaRelated,
+    PersonLineageSubmissionValidateSchema,
 )
 from .laboratory_position_enum import LabPosition
 from .laboratory_cross_reference_schemas import (

--- a/agr_literature_service/api/schemas/person_lineage_schemas.py
+++ b/agr_literature_service/api/schemas/person_lineage_schemas.py
@@ -24,6 +24,11 @@ class PersonLineageSchemaCreate(BaseModel):
 class PersonLineageSchemaUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid", from_attributes=True)
 
+    # Curators may correct a mis-resolved person on the canonical (by curie OR id).
+    # The submission's name claim is unchanged; this only fixes which person the
+    # name was resolved to, and the submission link is preserved.
+    person_subject_curie_or_id: Optional[Union[str, int]] = None
+    person_object_curie_or_id: Optional[Union[str, int]] = None
     relationship: Optional[PersonPersonRole] = None
     start_date: Optional[datetime] = None
     end_date: Optional[datetime] = None
@@ -35,8 +40,10 @@ class PersonLineageSchemaShow(AuditedObjectModelSchema):
     person_lineage_id: int
     person_subject_id: int
     person_subject_curie: Optional[str] = None
+    person_subject_name: Optional[str] = None
     person_object_id: int
     person_object_curie: Optional[str] = None
+    person_object_name: Optional[str] = None
     relationship: str
     start_date: Optional[datetime] = None
     end_date: Optional[datetime] = None

--- a/agr_literature_service/api/schemas/person_lineage_submission_schemas.py
+++ b/agr_literature_service/api/schemas/person_lineage_submission_schemas.py
@@ -76,6 +76,31 @@ class PersonLineageSubmissionSchemaUpdate(BaseModel):
         return data
 
 
+class PersonLineageSubmissionValidateSchema(BaseModel):
+    """Curator-supplied values for promoting a submission to a canonical
+    person_lineage, in one shot.
+
+    Validate does not modify the submission's claim — its names, relationship,
+    dates and person-id links stay as the user submitted them — but it does set the
+    submission's status and person_lineage_id link to record the promotion. The
+    fields below only steer the canonical row that validate creates; any one left
+    unset falls back to the submission's own value, so an empty body reproduces the
+    original promote behavior:
+      - person_subject_curie_or_id / person_object_curie_or_id: resolve the people
+        for the canonical (fall back to the submission's stored ids when omitted);
+      - relationship: never taken as null (part of the canonical unique key);
+      - start_date / end_date: may be sent as null to create the canonical without
+        that date.
+    """
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
+
+    person_subject_curie_or_id: Optional[Union[str, int]] = None
+    person_object_curie_or_id: Optional[Union[str, int]] = None
+    relationship: Optional[PersonPersonRole] = None
+    start_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None
+
+
 class PersonLineageSubmissionSchemaShow(AuditedObjectModelSchema):
     model_config = ConfigDict(extra="forbid", from_attributes=True)
 

--- a/tests/api/test_person_lineage.py
+++ b/tests/api/test_person_lineage.py
@@ -244,3 +244,47 @@ class TestPersonLineage:
             assert res.status_code == status.HTTP_204_NO_CONTENT
             res = client.get(f"/person_lineage/{test_lineage.new_id}", headers=auth_headers)
             assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_patch_corrects_object_person(self, db, auth_headers, test_lineage):  # noqa
+        # A curator can correct a mis-resolved person on the canonical (object B -> C).
+        person_c = PersonModel(display_name="Canon Three", curie="AGRKB:test-canon-3")
+        db.add(person_c)
+        db.commit()
+        db.refresh(person_c)
+        with TestClient(app) as client:
+            res = client.patch(
+                f"/person_lineage/{test_lineage.new_id}",
+                json={"person_object_curie_or_id": person_c.curie},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_200_OK
+            fetched = client.get(f"/person_lineage/{test_lineage.new_id}", headers=auth_headers).json()
+            assert fetched["person_subject_id"] == test_lineage.person_subject_id
+            assert fetched["person_object_id"] == person_c.person_id
+            assert fetched["person_object_curie"] == person_c.curie
+
+    def test_patch_person_collision_rejected(self, db, auth_headers, two_people):  # noqa
+        # Correcting a person into an existing (subject, object, relationship) triple
+        # must be rejected, not 500.
+        person_c = PersonModel(display_name="Canon Three", curie="AGRKB:test-canon-3b")
+        db.add(person_c)
+        db.commit()
+        db.refresh(person_c)
+        with TestClient(app) as client:
+            base = {
+                "person_subject_curie_or_id": two_people["person_subject_id"],
+                "relationship": "phd_supervisor_of",
+            }
+            # A -> B
+            r1 = client.post("/person_lineage/", json={**base, "person_object_curie_or_id": two_people["person_object_id"]}, headers=auth_headers)
+            assert r1.status_code == status.HTTP_201_CREATED
+            # A -> C
+            r2 = client.post("/person_lineage/", json={**base, "person_object_curie_or_id": person_c.person_id}, headers=auth_headers)
+            assert r2.status_code == status.HTTP_201_CREATED
+            # Patching A->B's object to C would collide with A->C.
+            p = client.patch(
+                f"/person_lineage/{r1.json()['person_lineage_id']}",
+                json={"person_object_curie_or_id": person_c.person_id},
+                headers=auth_headers,
+            )
+            assert p.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/tests/api/test_person_lineage_submission.py
+++ b/tests/api/test_person_lineage_submission.py
@@ -447,3 +447,149 @@ class TestPersonLineageSubmission:
                 f"/person_lineage_submission/{test_submission.new_id}", headers=auth_headers
             )
             assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_validate_relationship_override_steers_canonical(self, db, auth_headers, two_people):  # noqa
+        # Curator promotes with a corrected relationship: the canonical row uses the
+        # override, while the submission's claimed relationship is preserved.
+        with TestClient(app) as client:
+            r = client.post(
+                "/person_lineage_submission/",
+                json={
+                    "person_subject_name": "A", "person_object_name": "B",
+                    "relationship": "phd_supervisor_of", "who_sent_this": "cur",
+                    "person_subject_curie_or_id": two_people["person_subject_id"],
+                    "person_object_curie_or_id": two_people["person_object_id"],
+                },
+                headers=auth_headers,
+            )
+            sub_id = r.json()["person_lineage_submission_id"]
+
+            v = client.post(
+                f"/person_lineage_submission/{sub_id}/validate",
+                json={"relationship": "postdoc_supervisor_of"},
+                headers=auth_headers,
+            )
+            assert v.status_code == status.HTTP_200_OK
+            assert v.json()["status"] == "validated"
+            # The submission's claimed relationship is untouched.
+            assert v.json()["relationship"] == "phd_supervisor_of"
+            canonical_id = v.json()["person_lineage_id"]
+
+            canonical = client.get(f"/person_lineage/{canonical_id}", headers=auth_headers)
+            assert canonical.status_code == status.HTTP_200_OK
+            # The canonical row reflects the curator's corrected relationship.
+            assert canonical.json()["relationship"] == "postdoc_supervisor_of"
+
+    def test_validate_date_overrides_applied_to_canonical(self, db, auth_headers, two_people):  # noqa
+        with TestClient(app) as client:
+            r = client.post(
+                "/person_lineage_submission/",
+                json={
+                    "person_subject_name": "A", "person_object_name": "B",
+                    "relationship": "phd_supervisor_of", "who_sent_this": "cur",
+                    "person_subject_curie_or_id": two_people["person_subject_id"],
+                    "person_object_curie_or_id": two_people["person_object_id"],
+                },
+                headers=auth_headers,
+            )
+            sub_id = r.json()["person_lineage_submission_id"]
+
+            v = client.post(
+                f"/person_lineage_submission/{sub_id}/validate",
+                json={"start_date": "2019-09-01T00:00:00", "end_date": "2023-06-30T00:00:00"},
+                headers=auth_headers,
+            )
+            assert v.status_code == status.HTTP_200_OK
+            canonical_id = v.json()["person_lineage_id"]
+            canonical = client.get(f"/person_lineage/{canonical_id}", headers=auth_headers).json()
+            assert str(canonical["start_date"]).startswith("2019-09-01")
+            assert str(canonical["end_date"]).startswith("2023-06-30")
+
+    def test_validate_empty_body_uses_submitted_relationship(self, db, auth_headers, two_people):  # noqa
+        # Regression: validate with no body behaves as before — the canonical row
+        # uses the submission's own relationship.
+        with TestClient(app) as client:
+            sub_id = self._make_resolved_submission(client, auth_headers, two_people)
+            v = client.post(f"/person_lineage_submission/{sub_id}/validate", headers=auth_headers)
+            assert v.status_code == status.HTTP_200_OK
+            canonical_id = v.json()["person_lineage_id"]
+            canonical = client.get(f"/person_lineage/{canonical_id}", headers=auth_headers).json()
+            assert canonical["relationship"] == "phd_supervisor_of"
+
+    def test_validate_resolves_people_from_body_leaves_submission_untouched(self, db, auth_headers, two_people):  # noqa
+        # One-shot promote: a names-only submission (no person ids) is validated with
+        # the people supplied in the body. The canonical is built from the body, but
+        # the submission's own person-id fields stay null — only status + the
+        # person_lineage link are set.
+        with TestClient(app) as client:
+            r = client.post(
+                "/person_lineage_submission/",
+                json={
+                    "person_subject_name": "Some Advisor", "person_object_name": "Some Student",
+                    "relationship": "phd_supervisor_of", "who_sent_this": "cur",
+                },
+                headers=auth_headers,
+            )
+            sub_id = r.json()["person_lineage_submission_id"]
+            assert r.json()["person_subject_id"] is None
+            assert r.json()["person_object_id"] is None
+
+            v = client.post(
+                f"/person_lineage_submission/{sub_id}/validate",
+                json={
+                    "person_subject_curie_or_id": two_people["person_subject_id"],
+                    "person_object_curie_or_id": two_people["person_object_id"],
+                    "relationship": "postdoc_supervisor_of",
+                },
+                headers=auth_headers,
+            )
+            assert v.status_code == status.HTTP_200_OK
+            body = v.json()
+            assert body["status"] == "validated"
+            assert body["person_lineage_id"] is not None
+            # Submission's own person links remain unset (untouched).
+            assert body["person_subject_id"] is None
+            assert body["person_object_id"] is None
+            # Submission's claimed relationship is preserved.
+            assert body["relationship"] == "phd_supervisor_of"
+
+            canonical = client.get(
+                f"/person_lineage/{body['person_lineage_id']}", headers=auth_headers
+            ).json()
+            assert canonical["person_subject_id"] == two_people["person_subject_id"]
+            assert canonical["person_object_id"] == two_people["person_object_id"]
+            assert canonical["relationship"] == "postdoc_supervisor_of"
+
+    def test_validate_unresolved_people_rejected(self, db, auth_headers):  # noqa
+        # A names-only submission with no body (and no stored ids) still cannot be
+        # validated — both people must resolve from the body or the submission.
+        with TestClient(app) as client:
+            r = client.post(
+                "/person_lineage_submission/",
+                json={
+                    "person_subject_name": "X", "person_object_name": "Y",
+                    "relationship": "phd_supervisor_of", "who_sent_this": "cur",
+                },
+                headers=auth_headers,
+            )
+            sub_id = r.json()["person_lineage_submission_id"]
+            v = client.post(f"/person_lineage_submission/{sub_id}/validate", headers=auth_headers)
+            assert v.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_delete_canonical_resets_linked_submission(self, db, auth_headers, two_people):  # noqa
+        # Deleting a canonical unlinks its submissions (FK SET NULL) and resets their
+        # status from 'validated' back to 'pending' so they return to the unvalidated
+        # pool and can be re-validated.
+        with TestClient(app) as client:
+            sub_id = self._make_resolved_submission(client, auth_headers, two_people)
+            v = client.post(f"/person_lineage_submission/{sub_id}/validate", headers=auth_headers)
+            assert v.status_code == status.HTTP_200_OK
+            assert v.json()["status"] == "validated"
+            canonical_id = v.json()["person_lineage_id"]
+
+            d = client.delete(f"/person_lineage/{canonical_id}", headers=auth_headers)
+            assert d.status_code == status.HTTP_204_NO_CONTENT
+
+            after = client.get(f"/person_lineage_submission/{sub_id}", headers=auth_headers).json()
+            assert after["person_lineage_id"] is None
+            assert after["status"] == "pending"


### PR DESCRIPTION
…ides; editable canonical people; lineage names

person_lineage_submission validate is now one-shot: it accepts optional curator values (person_subject/object_curie_or_id, relationship, start_date, end_date) that steer the canonical via find_or_create, falling back to the submission when omitted. The submission's claim and person-id links are never modified — only status and the person_lineage_id link are set to record the promotion.

person_lineage:
- PATCH may correct a mis-resolved person (person_subject/object_curie_or_id); the submission link is preserved (its name claim is simply resolved to the corrected person). Unique-key collisions surface as 422, self-pairs rejected.
- Show now exposes person_subject_name / person_object_name (from the joined person objects) so the UI can display name + curie.
- destroy resets linked submissions (validated/duplicate -> pending) so they return to the unvalidated pool cleanly when a canonical is deleted (FK already SET NULL).

Tests cover override/one-shot validate, submission-untouched, unresolved->422, delete-resets-linked-submission, person correction, and correction collision->422.