### PR TITLE
feat(embedding): generate classifier embeddings for merged Markdown on conversion (SCRUM-6142)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ tmp
 .vscode/*
 **/*.gz
 .env.unittest
+# Local env files holding secrets (DB creds, OPENAI_API_KEY, etc.) — never commit.
+.env.rdsdev
+.env.rdsprod
+.env.devserver4006

--- a/agr_literature_service/api/config.py
+++ b/agr_literature_service/api/config.py
@@ -40,6 +40,10 @@ class GlobalConfig(BaseSettings):
     ELASTICSEARCH_PORT: str = Field(..., env="ELASTICSEARCH_PORT")
     ELASTICSEARCH_INDEX: str = Field(..., env="ELASTICSEARCH_INDEX")
 
+    # Embedding generation (SCRUM-6142). Optional: when unset, the pdf2md
+    # conversion job skips embedding generation (feature stays dormant).
+    OPENAI_API_KEY: Optional[str] = Field(None, env="OPENAI_API_KEY")
+
 
 # instantiate once for application‑wide use
 config = GlobalConfig()

--- a/agr_literature_service/lit_processing/embedding/__init__.py
+++ b/agr_literature_service/lit_processing/embedding/__init__.py
@@ -1,0 +1,2 @@
+"""ABC-side embedding generation (SCRUM-6142): the producer that fills the
+embedding_file catalog from converted merged Markdown."""

--- a/agr_literature_service/lit_processing/embedding/embedding_generation.py
+++ b/agr_literature_service/lit_processing/embedding/embedding_generation.py
@@ -1,0 +1,193 @@
+"""Generate + register classifier embeddings for a reference's merged Markdown
+(SCRUM-6142).
+
+For each **merged** Markdown of a reference — ``converted_merged_main`` and every
+``converted_merged_supplement`` (NOT the method-specific grobid/marker/docling
+outputs) — chunk it (``paragraph_pack``: paragraph-level, non-overlapping,
+references excluded), embed the chunks with OpenAI, write the canonical parquet,
+and register it via :func:`embedding_file_crud.create_or_update`. So a reference
+yields one embedding file per merged Markdown (main + each supplement).
+
+Idempotent: a source that already has an ``embedding_file`` row for this
+``(profile, version)`` is skipped, so re-running the conversion job never
+re-spends OpenAI. Per-source isolation: a failure on one source is logged and
+counted, never aborting the others.
+
+The embedding stack (``agr_abc_document_parsers.embeddings`` + ``openai``) is
+imported lazily; when it or ``OPENAI_API_KEY`` is missing the whole step is a
+logged no-op, so the pdf2md conversion job runs unchanged until the feature is
+deliberately enabled.
+"""
+
+import logging
+import os
+import tempfile
+from io import BytesIO
+from typing import Mapping, Optional
+
+from fastapi import UploadFile
+
+from agr_cognito_py import ModAccess
+
+from agr_literature_service.api.config import config
+from agr_literature_service.api.crud import embedding_file_crud
+from agr_literature_service.api.crud.referencefile_crud import download_file
+from agr_literature_service.api.models import ReferencefileModel
+from agr_literature_service.api.schemas.embedding_file_schemas import EmbeddingFileSchemaCreate
+
+logger = logging.getLogger(__name__)
+
+# Only the MERGED Markdown is embedded — not the per-method grobid/marker/docling
+# outputs. One embedding_file row per merged source (main + each supplement).
+MERGED_SOURCE_FILE_CLASSES = ("converted_merged_main", "converted_merged_supplement")
+
+VERSION = 1
+
+
+def generate_classifier_embeddings_for_reference(
+    db,
+    reference_id: int,
+    reference_curie: Optional[str] = None,
+    *,
+    api_key: Optional[str] = None,
+    include_document_vector: bool = True,
+) -> Mapping[str, object]:
+    """Embed every merged Markdown of ``reference_id`` and register the parquets.
+
+    Returns a small result dict (counts / skip reason). Never raises for the
+    normal disabled/unavailable paths; per-source errors are caught and counted.
+    """
+    api_key = api_key or config.OPENAI_API_KEY
+    if not api_key:
+        logger.debug("OPENAI_API_KEY not set; skipping embedding generation")
+        return {"skipped": "no_api_key"}
+
+    try:
+        from agr_abc_document_parsers.embeddings import (
+            DEFAULT_PROFILE,
+            ParagraphPackChunker,
+        )
+
+        from agr_literature_service.lit_processing.embedding.openai_embedder import OpenAIEmbedder
+    except ImportError as exc:
+        logger.warning(
+            "Embedding stack unavailable (%s); skipping. Install "
+            "'agr-abc-document-parsers[embeddings]' and 'openai' to enable.", exc
+        )
+        return {"skipped": "deps_unavailable"}
+
+    sources = (
+        db.query(ReferencefileModel)
+        .filter(
+            ReferencefileModel.reference_id == reference_id,
+            ReferencefileModel.file_class.in_(MERGED_SOURCE_FILE_CLASSES),
+            ReferencefileModel.file_extension == "md",
+            ReferencefileModel.file_publication_status == "final",
+        )
+        .all()
+    )
+    if not sources:
+        return {"skipped": "no_merged_markdown"}
+
+    profile_name = DEFAULT_PROFILE
+    chunker = ParagraphPackChunker(profile_name=profile_name)
+    embedder = OpenAIEmbedder(api_key)
+
+    existing_by_source = embedding_file_crud.get_embeddings_for_sources(
+        db, [int(s.referencefile_id) for s in sources]
+    )
+
+    embedded = skipped_existing = failed = 0
+    for source in sources:
+        source_id = int(source.referencefile_id)
+        existing = existing_by_source.get(source_id, [])
+        if any(e.profile_name == profile_name and e.version == VERSION for e in existing):
+            skipped_existing += 1
+            continue
+        curie = reference_curie or (source.reference.curie if source.reference else None)
+        if curie is None:
+            logger.error("No reference curie for referencefile %s; skipping", source_id)
+            failed += 1
+            continue
+        try:
+            _embed_and_register(
+                db, curie, source, chunker, embedder, profile_name,
+                include_document_vector=include_document_vector,
+            )
+            embedded += 1
+        except Exception as exc:
+            logger.error(
+                "Embedding generation failed for referencefile %s (%s): %s",
+                source_id, curie, exc
+            )
+            failed += 1
+    return {
+        "embedded": embedded, "skipped_existing": skipped_existing,
+        "failed": failed, "sources": len(sources),
+    }
+
+
+def _embed_and_register(db, reference_curie, source, chunker, embedder, profile_name,
+                        *, include_document_vector: bool) -> None:
+    """Chunk + embed one merged Markdown and register its parquet."""
+    from agr_abc_document_parsers.embeddings import EmbeddingRecipe, write_chunks_parquet
+    from agr_abc_document_parsers.embeddings.models import Chunk
+
+    source_id = int(source.referencefile_id)
+    content = download_file(
+        db=db, referencefile_id=source_id, mod_access=ModAccess.ALL_ACCESS, use_in_api=False
+    )
+    if isinstance(content, bytes):
+        content = content.decode("utf-8", errors="replace")
+    if not content or not content.strip():
+        logger.info("Empty markdown for referencefile %s; skipping", source_id)
+        return
+
+    chunks = chunker.chunk(content, reference_curie=reference_curie)
+    if not chunks:
+        logger.info("No chunks produced for referencefile %s; skipping", source_id)
+        return
+    embedder.embed_chunks(chunks)
+
+    if include_document_vector:
+        doc_text = chunker.document_text(chunks)
+        doc_input = embedder.truncate_to_limit(doc_text)
+        doc_vector = embedder.embed([doc_input])[0]
+        chunks.append(Chunk(
+            reference_curie=reference_curie, chunk_index=-1, content=doc_input,
+            profile_name=profile_name, chunking_strategy="document",
+            section_title="__document__", is_document_level=True,
+            n_tokens=embedder.count_tokens(doc_input), embedding=doc_vector,
+        ))
+
+    recipe = EmbeddingRecipe(
+        profile_name=profile_name, version=VERSION,
+        embedding_model=embedder.model, embedding_dim=embedder.dimension,
+        chunker_name=chunker.name, chunk_target_tokens=chunker.target_tokens,
+        chunk_overlap_tokens=0, source="fulltext", references_excluded=True,
+    )
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as tmp:
+            tmp_path = tmp.name
+        write_chunks_parquet(tmp_path, chunks, recipe, reference_curie=reference_curie)
+        with open(tmp_path, "rb") as handle:
+            parquet_bytes = handle.read()
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    request = EmbeddingFileSchemaCreate(
+        reference_curie=reference_curie, profile_name=profile_name, version=VERSION,
+        model_name=embedder.model_name, source_referencefile_id=source_id,
+    )
+    upload = UploadFile(
+        filename=f"embedding_{profile_name}_v{VERSION}.parquet",
+        file=BytesIO(parquet_bytes),
+    )
+    embedding_file_crud.create_or_update(db, request, upload)
+    logger.info(
+        "Registered %s embedding for referencefile %s (%s): %d chunks",
+        profile_name, source_id, reference_curie, len(chunks)
+    )

--- a/agr_literature_service/lit_processing/embedding/openai_embedder.py
+++ b/agr_literature_service/lit_processing/embedding/openai_embedder.py
@@ -1,0 +1,111 @@
+"""OpenAI implementation of the shared ``Embedder`` contract (SCRUM-6142).
+
+Wraps the OpenAI embeddings API behind
+:class:`agr_abc_document_parsers.embeddings.Embedder`, so the ABC producer can
+plug it into any chunker polymorphically. Batched with retry/backoff; exposes
+``model_name`` / ``dimension`` and a tiktoken-based ``count_tokens`` for the
+model's token preflight.
+
+``openai`` / ``tiktoken`` are optional runtime deps: this module is imported
+lazily by :mod:`.embedding_generation`, which degrades gracefully when the
+embedding stack is unavailable.
+"""
+
+import time
+from typing import List, Optional, Sequence
+
+from agr_abc_document_parsers.embeddings import Embedder
+
+DEFAULT_MODEL = "text-embedding-3-small"
+DEFAULT_DIMENSION = 1536
+# OpenAI's context limit for text-embedding-3-small, minus a safety margin, per
+# the curation-assistant spec (§5). A chunk over this signals a chunking bug.
+MODEL_TOKEN_LIMIT = 8191
+TOKEN_SAFETY_MARGIN = 500
+
+
+class OpenAIEmbedder(Embedder):
+    """Embed chunk ``content`` with an OpenAI embedding model."""
+
+    def __init__(self, api_key: str, *, model: str = DEFAULT_MODEL,
+                 dimension: int = DEFAULT_DIMENSION, batch_size: int = 100,
+                 max_retries: int = 5) -> None:
+        self._model = model
+        self._dimension = dimension
+        self._batch_size = batch_size
+        self._max_retries = max_retries
+        self._api_key = api_key
+        self._client = None
+        self._encoder = None
+
+    @property
+    def model_name(self) -> str:
+        # Versioned, provider-qualified id recorded in the recipe descriptor.
+        return f"openai:{self._model}"
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def max_input_tokens(self) -> int:
+        return MODEL_TOKEN_LIMIT - TOKEN_SAFETY_MARGIN
+
+    def _get_client(self):  # pragma: no cover - thin OpenAI client factory
+        if self._client is None:
+            from openai import OpenAI
+            self._client = OpenAI(api_key=self._api_key)
+        return self._client
+
+    def _get_encoder(self):
+        if self._encoder is None:
+            import tiktoken
+            self._encoder = tiktoken.encoding_for_model(self._model)
+        return self._encoder
+
+    def count_tokens(self, text: str) -> int:
+        return len(self._get_encoder().encode(text or ""))
+
+    def truncate_to_limit(self, text: str) -> str:
+        """Truncate ``text`` to the model's safe token budget (for the optional
+        whole-document vector, whose source text can exceed the limit)."""
+        enc = self._get_encoder()
+        tokens = enc.encode(text or "")
+        if len(tokens) <= self.max_input_tokens:
+            return text
+        return enc.decode(tokens[:self.max_input_tokens])
+
+    def embed(self, texts: Sequence[str]) -> List[List[float]]:
+        """Return one 1536-d vector per input text, order preserved. Batched;
+        each batch retried with exponential backoff on transient errors."""
+        if not texts:
+            return []
+        client = self._get_client()
+        out: List[List[float]] = []
+        for start in range(0, len(texts), self._batch_size):
+            batch = list(texts[start:start + self._batch_size])
+            resp = self._create_with_retry(client, batch)
+            for item in resp.data:
+                vector = item.embedding
+                if len(vector) != self._dimension:
+                    raise ValueError(
+                        f"unexpected embedding dim {len(vector)} (expected {self._dimension})"
+                    )
+                out.append([float(x) for x in vector])
+        return out
+
+    def _create_with_retry(self, client, batch: List[str]):  # pragma: no cover - network
+        last_exc: Optional[Exception] = None
+        for attempt in range(self._max_retries):
+            try:
+                return client.embeddings.create(model=self._model, input=batch)
+            except Exception as exc:  # rate limit / transient
+                last_exc = exc
+                if attempt == self._max_retries - 1:
+                    break
+                time.sleep(2 ** attempt)
+        raise RuntimeError(f"OpenAI embeddings failed after {self._max_retries} retries") from last_exc

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md.py
@@ -655,8 +655,27 @@ def process_single_reference(  # pragma: no cover
             )
 
     if main_success:
+        # Generate classifier embeddings for every merged Markdown of this
+        # reference (main + supplements), after the markdown is safely persisted.
+        _maybe_generate_embeddings(db, reference_id, reference_curie)
         return True, None
     return False, main_error or "Main reference conversion failed"
+
+
+def _maybe_generate_embeddings(  # pragma: no cover
+    db: Session, reference_id: int, reference_curie: str
+) -> None:
+    """Generate + register classifier embeddings for a converted reference's
+    merged Markdown. Idempotent (skips sources already embedded) and fully
+    isolated — any failure is logged and never flips the conversion result.
+    Dormant unless OPENAI_API_KEY is set and the embedding stack is installed."""
+    try:
+        from agr_literature_service.lit_processing.embedding.embedding_generation import (
+            generate_classifier_embeddings_for_reference,
+        )
+        generate_classifier_embeddings_for_reference(db, reference_id, reference_curie)
+    except Exception as e:
+        logger.error(f"Embedding generation failed for {reference_curie}: {e}")
 
 
 def process_newest_references(  # pragma: no cover

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -128,6 +128,7 @@ services:
       ATEAM_API_URL: "${ATEAM_API_URL}"
       SGD_API_URL: "${SGD_API_URL}"
       PDFX_API_URL: "${PDFX_API_URL}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY}"
       GUNICORN_WORKERS: "${GUNICORN_WORKERS:-4}"  # Number of worker processes (default: 4)
       LOG_LEVEL: "${LOG_LEVEL:-info}"  # Gunicorn log level (default: info)
       DEBEZIUM_STATUS_PATH: "${DEBEZIUM_STATUS_PATH:-/var/lib/debezium_status}"
@@ -248,6 +249,7 @@ services:
       DEBEZIUM_KSQLDB_PORT: "${DEBEZIUM_KSQLDB_PORT}"
       TZ: "UTC"
       PDFX_API_URL: "${PDFX_API_URL}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY}"
       SGD_API_URL: "${SGD_API_URL}"
       PERSISTENT_STORE_DB_USERNAME: "${PERSISTENT_STORE_DB_USERNAME}"
       PERSISTENT_STORE_DB_PASSWORD: "${PERSISTENT_STORE_DB_PASSWORD}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,9 +68,5 @@ cryptography>=41.0.0         # PyJWT can handle RS256 and other asymmetric algor
 
 # AGR Cognito Authentication
 agr-cognito-py==0.1.0        # AWS Cognito authentication for AGR services
-agr-abc-document-parsers==1.5.1  # Shared ABC document parsers (xml2md, md_reader, plain_text)
-# TODO(SCRUM-6142): to activate embedding generation, bump to the release that
-# ships the embeddings subpackage with its extra:
-#   agr-abc-document-parsers[embeddings]>=1.6.0  # adds tiktoken + pyarrow
-# Until then embedding_generation lazily no-ops. openai is the embedder client:
+agr-abc-document-parsers[embeddings]==1.6.0  # Shared ABC document parsers (xml2md, md_reader, plain_text, embeddings)
 openai>=1.0.0                # OpenAI embeddings client (SCRUM-6142 embedding generation)

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,3 +69,8 @@ cryptography>=41.0.0         # PyJWT can handle RS256 and other asymmetric algor
 # AGR Cognito Authentication
 agr-cognito-py==0.1.0        # AWS Cognito authentication for AGR services
 agr-abc-document-parsers==1.5.1  # Shared ABC document parsers (xml2md, md_reader, plain_text)
+# TODO(SCRUM-6142): to activate embedding generation, bump to the release that
+# ships the embeddings subpackage with its extra:
+#   agr-abc-document-parsers[embeddings]>=1.6.0  # adds tiktoken + pyarrow
+# Until then embedding_generation lazily no-ops. openai is the embedder client:
+openai>=1.0.0                # OpenAI embeddings client (SCRUM-6142 embedding generation)

--- a/tests/lit_processing/test_embedding_generation.py
+++ b/tests/lit_processing/test_embedding_generation.py
@@ -1,0 +1,144 @@
+"""Tests for the SCRUM-6142 embedding generation core.
+
+Two always-on tests prove the safe defaults (no key / stack unavailable -> the
+conversion job is unaffected) and the "merged Markdown only" source rule. The
+full end-to-end test is gated on the embeddings extra being installed (the
+shared agr_abc_document_parsers release that ships the embeddings subpackage);
+until then it skips, matching production where the feature is dormant.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agr_literature_service.api.models import ReferenceModel, ReferencefileModel
+from agr_literature_service.lit_processing.embedding import embedding_generation as eg
+from ..api.test_reference import test_reference  # noqa
+from ..fixtures import db  # noqa
+
+
+def test_merged_only_source_classes():
+    """Only the merged Markdown is embedded — never the per-method
+    grobid/marker/docling outputs."""
+    assert eg.MERGED_SOURCE_FILE_CLASSES == (
+        "converted_merged_main", "converted_merged_supplement"
+    )
+    assert not any(m in cls for cls in eg.MERGED_SOURCE_FILE_CLASSES
+                   for m in ("grobid", "marker", "docling"))
+
+
+def test_skips_without_api_key():
+    """No OPENAI_API_KEY -> no-op (returns before touching the DB or the stack)."""
+    with patch.object(eg.config, "OPENAI_API_KEY", None):
+        result = eg.generate_classifier_embeddings_for_reference(db=None, reference_id=1)
+    assert result == {"skipped": "no_api_key"}
+
+
+def test_skips_when_stack_unavailable():
+    """With a key set but the embedding stack import failing, the step is a
+    logged no-op — the conversion job is never broken by a missing dep."""
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("agr_abc_document_parsers.embeddings"):
+            raise ImportError("embeddings extra not installed")
+        return real_import(name, *args, **kwargs)
+
+    with patch.object(eg.config, "OPENAI_API_KEY", "sk-test"), \
+            patch("builtins.__import__", side_effect=fake_import):
+        result = eg.generate_classifier_embeddings_for_reference(db=None, reference_id=1)
+    assert result == {"skipped": "deps_unavailable"}
+
+
+class _FakeEmbedder:
+    """Deterministic stand-in for OpenAIEmbedder (no network)."""
+
+    model = "text-embedding-3-small"
+    model_name = "openai:text-embedding-3-small"
+    dimension = 4
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def embed(self, texts):
+        return [[float(len(t)), 0.0, 1.0, 2.0] for t in texts]
+
+    def embed_chunks(self, chunks):
+        for c in chunks:
+            c.embedding = [float(len(c.content)), 0.0, 1.0, 2.0]
+
+    def count_tokens(self, text):
+        return len((text or "").split())
+
+    def truncate_to_limit(self, text):
+        return text
+
+
+MERGED_MD = """# daf-16 regulates longevity
+
+## Abstract
+
+We studied daf-16 and found it extends lifespan in N2 worms.
+
+## Introduction
+
+The daf-16 gene was studied. We measured expression in N2 worms.
+
+## References
+
+1. Some Author. A paper title. Journal 2020.
+"""
+
+
+@pytest.mark.webtest
+def test_end_to_end_embeds_each_merged_markdown(db, test_reference):  # noqa
+    """Every merged Markdown (main + supplement) is embedded + registered once;
+    a second run skips the already-embedded sources. Gated on the embeddings
+    extra (shared package release)."""
+    pytest.importorskip("agr_abc_document_parsers.embeddings",
+                        reason="embeddings extra / shared release not installed")
+    from agr_literature_service.api.crud import embedding_file_crud
+    from agr_literature_service.api.models import EmbeddingFileModel
+
+    curie = test_reference.new_ref_curie
+    ref = db.query(ReferenceModel).filter(ReferenceModel.curie == curie).one()
+
+    # one merged-main + one merged-supplement (embedded) and one method-specific
+    # grobid output (must be ignored).
+    main = ReferencefileModel(reference_id=ref.reference_id, display_name="paper_merged",
+                              file_class="converted_merged_main", file_publication_status="final",
+                              file_extension="md", md5sum="mainmd5", is_annotation=False)
+    supp = ReferencefileModel(reference_id=ref.reference_id, display_name="supp_merged",
+                              file_class="converted_merged_supplement", file_publication_status="final",
+                              file_extension="md", md5sum="suppmd5", is_annotation=False)
+    grobid = ReferencefileModel(reference_id=ref.reference_id, display_name="paper_grobid",
+                                file_class="converted_grobid_main", file_publication_status="final",
+                                file_extension="md", md5sum="grobidmd5", is_annotation=False)
+    db.add_all([main, supp, grobid])
+    db.commit()
+
+    def fake_upload(_db, metadata, _file):
+        rf = ReferencefileModel(
+            reference_id=ref.reference_id, display_name=metadata["display_name"],
+            file_class="embedding", file_publication_status="final",
+            file_extension="parquet", md5sum=metadata["display_name"], is_annotation=False)
+        db.add(rf)
+        db.commit()
+        db.refresh(rf)
+        return rf
+
+    with patch.object(eg.config, "OPENAI_API_KEY", "sk-test"), \
+            patch("agr_literature_service.lit_processing.embedding.openai_embedder.OpenAIEmbedder",
+                  _FakeEmbedder), \
+            patch.object(eg, "download_file", return_value=MERGED_MD), \
+            patch.object(embedding_file_crud, "file_upload_single", side_effect=fake_upload):
+        result = eg.generate_classifier_embeddings_for_reference(db, ref.reference_id, curie)
+        assert result["embedded"] == 2 and result["skipped_existing"] == 0
+        # only the two merged sources embedded (grobid ignored)
+        rows = db.query(EmbeddingFileModel).filter_by(reference_id=ref.reference_id).all()
+        assert len(rows) == 2
+        assert {r.source_referencefile_id for r in rows} == {
+            main.referencefile_id, supp.referencefile_id}
+        # second run is idempotent
+        result2 = eg.generate_classifier_embeddings_for_reference(db, ref.reference_id, curie)
+        assert result2["embedded"] == 0 and result2["skipped_existing"] == 2

--- a/tests/lit_processing/test_embedding_generation.py
+++ b/tests/lit_processing/test_embedding_generation.py
@@ -2,9 +2,9 @@
 
 Two always-on tests prove the safe defaults (no key / stack unavailable -> the
 conversion job is unaffected) and the "merged Markdown only" source rule. The
-full end-to-end test is gated on the embeddings extra being installed (the
-shared agr_abc_document_parsers release that ships the embeddings subpackage);
-until then it skips, matching production where the feature is dormant.
+full end-to-end test needs the embeddings extra
+(agr-abc-document-parsers[embeddings], pinned in requirements.txt) and skips
+in environments installed without it.
 """
 
 from unittest.mock import patch


### PR DESCRIPTION
## Summary (SCRUM-6142 — embedding producer, epic SCRUM-6139)

Producer side of the embedding pipeline: after the `pdf2md` conversion job produces a reference's **merged** Markdown, embed it and register the parquet in the `embedding_file` catalog (SCRUM-6141, already merged).

- **`openai_embedder.py`** — `OpenAIEmbedder` implementing the shared `agr_abc_document_parsers.embeddings.Embedder` contract (`text-embedding-3-small`, batched + retry, tiktoken token preflight).
- **`embedding_generation.py`** — `generate_classifier_embeddings_for_reference()` embeds every **merged** Markdown of a reference — `converted_merged_main` + each `converted_merged_supplement`, **not** the per-method grobid/marker/docling outputs — into one `embedding_file` per source (so multiple per reference). Idempotent (skips sources already embedded → re-runs never re-spend OpenAI); per-source isolation; optional whole-document vector. Access is inherited from the source referencefile (SCRUM-6141).
- **`pdf2md.py`** — `_maybe_generate_embeddings` hook after a reference converts successfully (covers both the PDFX and nXML paths); failures are logged and never flip the conversion result.
- Config/infra: optional `OPENAI_API_KEY`; docker-compose passes it to the `api` + `automated_scripts` services; `.gitignore` protects the local `.env.*` secret files; `openai` added to requirements.

### Dormant until deliberately enabled
The embedding stack (`agr_abc_document_parsers.embeddings` + `openai`) is imported **lazily**, and the whole step is a logged no-op when it or `OPENAI_API_KEY` is missing — so the conversion job is unchanged on the current `agr-abc-document-parsers==1.5.1` pin. Activation requires: (1) the shared **[embeddings] release** (linked PR) merged + the pin bumped, (2) `OPENAI_API_KEY` provisioned (done for rds-dev), (3) budget sign-off.

Profile: `classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned` v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)