### PR TITLE
fix(bulk_download): stream external_ids endpoints and return 401 on i…

### DIFF
--- a/agr_literature_service/api/auth.py
+++ b/agr_literature_service/api/auth.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jwt.exceptions import PyJWTError
 
 from agr_cognito_py import get_cognito_auth, get_cognito_user_swagger
 
@@ -273,7 +274,17 @@ class IPAwareCognitoAuth:
         # Priority 1: If Bearer token is provided, authenticate with it
         # This takes precedence over IP bypass so authenticated users get their real identity
         if credentials is not None:
-            return get_cognito_user_swagger(credentials, get_cognito_auth())
+            try:
+                return get_cognito_user_swagger(credentials, get_cognito_auth())
+            except HTTPException:
+                # Already a clean auth error (e.g. 401 for an expired/invalid-claims token)
+                raise
+            except PyJWTError as e:
+                # A token that can't be validated - e.g. its kid is not in the Cognito
+                # JWKS, as happens with a wrong-issuer token (a stale Okta token) - makes
+                # PyJWKClient raise a PyJWTError that is not caught downstream. Surface it
+                # as a clean 401 instead of letting it bubble up as a 500 Internal Server Error.
+                raise HTTPException(status_code=401, detail=f"Invalid authentication token: {e}")
 
         # Priority 2: Check for session cookie (for direct browser access)
         session_user = self._get_user_from_session_cookie(request)

--- a/agr_literature_service/api/crud/reference_crud.py
+++ b/agr_literature_service/api/crud/reference_crud.py
@@ -2,6 +2,7 @@
 reference_crud.py
 =================
 """
+import json
 import logging
 import re
 from collections import defaultdict
@@ -12,10 +13,10 @@ from typing import Any, Dict, List, Optional
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import FileResponse
-from sqlalchemy import ARRAY, Boolean, String, func, and_, text, TextClause
+from sqlalchemy import func, and_, text, TextClause
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
-from sqlalchemy.sql.expression import cast, or_
+from sqlalchemy.sql.expression import or_
 from starlette.background import BackgroundTask
 
 from agr_literature_service.api.crud import (cross_reference_crud,
@@ -682,31 +683,50 @@ def delete_reference_email(db: Session, curie_or_reference_id: str, reference_em
     db.commit()
 
 
-def show_all_references_external_ids(db: Session):
+def stream_all_references_external_ids(db: Session):
     """
+    Stream every reference with its cross-reference external ids as a JSON array.
+
+    Rather than aggregating the whole reference x cross_reference join into memory
+    (array_agg + .all() + a list of dicts, which grows unbounded and previously timed
+    out / OOM'd the worker into a 502), this reads flat rows through a server-side
+    cursor ordered by reference curie and yields the JSON array one reference at a
+    time. Memory stays bounded and bytes start flowing immediately. The emitted
+    structure is identical to the previous implementation.
 
     :param db:
-    :return:
+    :return: a generator of JSON string chunks forming a JSON array
     """
+    rows = (
+        db.query(ReferenceModel.curie,
+                 CrossReferenceModel.curie,
+                 CrossReferenceModel.is_obsolete)
+        .outerjoin(ReferenceModel.cross_reference)
+        .order_by(ReferenceModel.curie)
+        .yield_per(1000)
+    )
 
-    references_query = db.query(ReferenceModel.curie,
-                                cast(func.array_agg(CrossReferenceModel.curie),
-                                     ARRAY(String)),
-                                cast(func.array_agg(CrossReferenceModel.is_obsolete),
-                                     ARRAY(Boolean))).outerjoin(ReferenceModel.cross_reference).group_by(
-        ReferenceModel.curie)
+    yield "["
+    first = True
+    current_curie = None
+    current_xrefs: List[Dict[str, Any]] = []
 
-    return [
-        {
-            "curie": reference[0],
-            "cross_references": [
-                {
-                    "curie": reference[1][idx],
-                    "is_obsolete": reference[2][idx]
-                } for idx in range(len(reference[1]))
-            ]
-        } for reference in references_query.all()
-    ]
+    for ref_curie, xref_curie, is_obsolete in rows:
+        if ref_curie != current_curie:
+            if current_curie is not None:
+                yield ("" if first else ",") + json.dumps(
+                    {"curie": current_curie, "cross_references": current_xrefs})
+                first = False
+            current_curie = ref_curie
+            current_xrefs = []
+        if xref_curie is not None:
+            current_xrefs.append({"curie": xref_curie, "is_obsolete": is_obsolete})
+
+    if current_curie is not None:
+        yield ("" if first else ",") + json.dumps(
+            {"curie": current_curie, "cross_references": current_xrefs})
+
+    yield "]"
 
 
 def show(db: Session, curie_or_reference_id: str):  # noqa

--- a/agr_literature_service/api/crud/resource_crud.py
+++ b/agr_literature_service/api/crud/resource_crud.py
@@ -3,14 +3,13 @@ resource_crud.py
 ================
 """
 
+import json
 from datetime import datetime
-from typing import Dict, Union
+from typing import Any, Dict, List, Union
 
 from fastapi import HTTPException, status
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import ARRAY, Boolean, String, func
 from sqlalchemy.orm import Session, selectinload
-from sqlalchemy.sql.expression import cast
 
 from agr_literature_service.api.crud import cross_reference_crud
 from agr_literature_service.api.crud.cross_reference_crud import (
@@ -81,26 +80,48 @@ def create(db: Session, resource: ResourceSchemaPost):
     return curie
 
 
-def show_all_resources_external_ids(db: Session):
+def stream_all_resources_external_ids(db: Session):
     """
-    Returns all resources with external ids.
+    Stream every resource with its cross-reference external ids as a JSON array.
+
+    Mirrors stream_all_references_external_ids: reads flat rows through a server-side
+    cursor ordered by resource curie and yields the JSON array one resource at a time,
+    so memory stays bounded and the response starts flowing immediately. The emitted
+    structure is identical to the previous implementation.
+
     :param db:
-    :return:
+    :return: a generator of JSON string chunks forming a JSON array
     """
+    rows = (
+        db.query(ResourceModel.curie,
+                 CrossReferenceModel.curie,
+                 CrossReferenceModel.is_obsolete)
+        .outerjoin(ResourceModel.cross_reference)
+        .order_by(ResourceModel.curie)
+        .yield_per(1000)
+    )
 
-    resources_query = db.query(ResourceModel.curie,
-                               cast(func.array_agg(CrossReferenceModel.curie),
-                                    ARRAY(String)),
-                               cast(func.array_agg(CrossReferenceModel.is_obsolete),
-                                    ARRAY(Boolean))) \
-        .outerjoin(ResourceModel.cross_reference) \
-        .group_by(ResourceModel.curie)
+    yield "["
+    first = True
+    current_curie = None
+    current_xrefs: List[Dict[str, Any]] = []
 
-    return [{'curie': resource[0],
-             'cross_references': [{'curie': resource[1][idx],
-                                   'is_obsolete': resource[2][idx]}
-                                  for idx in range(len(resource[1]))]}
-            for resource in resources_query.all()]
+    for res_curie, xref_curie, is_obsolete in rows:
+        if res_curie != current_curie:
+            if current_curie is not None:
+                yield ("" if first else ",") + json.dumps(
+                    {"curie": current_curie, "cross_references": current_xrefs})
+                first = False
+            current_curie = res_curie
+            current_xrefs = []
+        if xref_curie is not None:
+            current_xrefs.append({"curie": xref_curie, "is_obsolete": is_obsolete})
+
+    if current_curie is not None:
+        yield ("" if first else ",") + json.dumps(
+            {"curie": current_curie, "cross_references": current_xrefs})
+
+    yield "]"
 
 
 def destroy(db: Session, curie: str):

--- a/agr_literature_service/api/routers/bulk_downloads_router.py
+++ b/agr_literature_service/api/routers/bulk_downloads_router.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, Security
+from fastapi.responses import StreamingResponse
 from typing import Dict, Any, Optional
 
 from sqlalchemy.orm import Session
@@ -18,13 +19,15 @@ db_session: Session = Depends(get_db)
 
 @router.get('/references/external_ids/',
             status_code=200)
-async def show(db: Session = db_session,
-               user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    return reference_crud.show_all_references_external_ids(db)
+def show(db: Session = db_session,
+         user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
+    return StreamingResponse(reference_crud.stream_all_references_external_ids(db),
+                             media_type="application/json")
 
 
 @router.get('/resources/external_ids/',
             status_code=200)
-async def show_ex_ids(db: Session = db_session,
-                      user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
-    return resource_crud.show_all_resources_external_ids(db)
+def show_ex_ids(db: Session = db_session,
+                user: Optional[Dict[str, Any]] = Security(get_authenticated_user)):
+    return StreamingResponse(resource_crud.stream_all_resources_external_ids(db),
+                             media_type="application/json")

--- a/tests/api/test_bulk_download.py
+++ b/tests/api/test_bulk_download.py
@@ -1,0 +1,96 @@
+import json
+
+from fastapi import status
+from sqlalchemy import text
+from starlette.testclient import TestClient
+
+from agr_literature_service.api.main import app
+from ..fixtures import db  # noqa
+from .fixtures import auth_headers  # noqa
+
+
+def _insert_xref_descriptor(db, prefix):  # noqa
+    """Register a cross-reference db_prefix so /cross_reference/ POSTs are accepted."""
+    with db.begin():
+        db.execute(text("INSERT INTO resource_descriptors (db_prefix, name, default_url) "
+                        f"VALUES ('{prefix}', 'Madeup {prefix}', 'http://www.example.com/[%s]')"))
+
+
+def _by_curie(payload):
+    """Turn the streamed JSON array into a {curie: entry} dict for easy assertions."""
+    return {entry["curie"]: entry for entry in payload}
+
+
+class TestBulkDownloadReferencesExternalIds:
+
+    def test_references_external_ids(self, db, auth_headers):  # noqa
+        _insert_xref_descriptor(db, "XREF")
+        with TestClient(app) as client:
+            # Reference A: two cross references, one active + one obsolete
+            ref_a = client.post(url="/reference/",
+                                json={"title": "Ref A", "category": "research_article"},
+                                headers=auth_headers).json()["curie"]
+            client.post(url="/cross_reference/",
+                        json={"curie": "XREF:refA-active", "reference_curie": ref_a,
+                              "pages": ["reference"], "is_obsolete": False},
+                        headers=auth_headers)
+            client.post(url="/cross_reference/",
+                        json={"curie": "XREF:refA-obsolete", "reference_curie": ref_a,
+                              "pages": ["reference"], "is_obsolete": True},
+                        headers=auth_headers)
+
+            # Reference B: no cross references (exercises the outer-join / empty-list path)
+            ref_b = client.post(url="/reference/",
+                                json={"title": "Ref B", "category": "research_article"},
+                                headers=auth_headers).json()["curie"]
+
+            response = client.get(url="/bulk_download/references/external_ids/", headers=auth_headers)
+            assert response.status_code == status.HTTP_200_OK
+
+            # Body must be a single valid JSON array (streamed, but buffered by TestClient)
+            payload = json.loads(response.content)
+            assert isinstance(payload, list)
+            by_curie = _by_curie(payload)
+
+            assert ref_a in by_curie
+            assert ref_b in by_curie
+
+            xrefs_a = {x["curie"]: x["is_obsolete"] for x in by_curie[ref_a]["cross_references"]}
+            assert xrefs_a == {"XREF:refA-active": False, "XREF:refA-obsolete": True}
+
+            assert by_curie[ref_b]["cross_references"] == []
+
+    def test_invalid_token_returns_401_not_500(self):
+        """A malformed/wrong-issuer bearer token must yield a clean 401, not a 500.
+
+        Regression test for the auth fix: PyJWKClient raises a PyJWTError (not a
+        jose JWTError) that previously bubbled up as a 500 Internal Server Error.
+        """
+        with TestClient(app) as client:
+            response = client.get(url="/bulk_download/references/external_ids/",
+                                  headers={"Authorization": "Bearer not-a-valid-jwt"})
+            assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestBulkDownloadResourcesExternalIds:
+
+    def test_resources_external_ids(self, db, auth_headers):  # noqa
+        _insert_xref_descriptor(db, "XREF")
+        with TestClient(app) as client:
+            resource_curie = client.post(url="/resource/", json={"title": "Res A"},
+                                         headers=auth_headers).json()["curie"]
+            client.post(url="/cross_reference/",
+                        json={"curie": "XREF:resA-active", "resource_curie": resource_curie,
+                              "is_obsolete": False},
+                        headers=auth_headers)
+
+            response = client.get(url="/bulk_download/resources/external_ids/", headers=auth_headers)
+            assert response.status_code == status.HTTP_200_OK
+
+            payload = json.loads(response.content)
+            assert isinstance(payload, list)
+            by_curie = _by_curie(payload)
+
+            assert resource_curie in by_curie
+            xrefs = {x["curie"]: x["is_obsolete"] for x in by_curie[resource_curie]["cross_references"]}
+            assert xrefs == {"XREF:resA-active": False}


### PR DESCRIPTION
…nvalid token (SCRUM-6265)

The /bulk_download/references/external_ids/ endpoint 502'd on production: it ran an unbounded array_agg over the entire reference x cross_reference tables, materialized the whole result twice in memory, and did so from an async handler that blocked the event loop - so as the DB grew it exceeded the worker timeout/memory. Rewrite it (and the identical resources sibling) to read flat rows through a server-side cursor (yield_per), group per curie incrementally, and return a StreamingResponse. Memory stays bounded, bytes flow immediately, and the JSON-array response shape is unchanged.

Separately, an Okta (wrong-issuer) token made PyJWKClient raise a PyJWTError that was not caught (only jose JWTError was), surfacing as a 500 Internal Server Error. Catch PyJWTError in the auth dependency and return a clean 401 instead.

Add tests/api/test_bulk_download.py covering both endpoints and the 401 case.