### PR TITLE
feat(embedding): restrict classifier embeddings to classifier MODs + wire into manual conversion (SCRUM-6273)

### DIFF
--- a/agr_literature_service/api/crud/file_conversion_crud.py
+++ b/agr_literature_service/api/crud/file_conversion_crud.py
@@ -674,6 +674,16 @@ def _execute_sync_nxml(db: Session, reference: ReferenceModel,
         reference_curie=reference.curie,
         mod_abbreviation=assessment["mod_abbreviation"],
     )
+    if success:
+        # Generate classifier embeddings for the freshly-converted merged
+        # Markdown. Isolated + idempotent, and skipped for references not in a
+        # classifier MOD's corpus.
+        from agr_literature_service.lit_processing.embedding.embedding_generation import (
+            maybe_generate_classifier_embeddings,
+        )
+        maybe_generate_classifier_embeddings(
+            db, reference.reference_id, reference.curie
+        )
     return success, error
 
 

--- a/agr_literature_service/api/utils/conversion_processor.py
+++ b/agr_literature_service/api/utils/conversion_processor.py
@@ -274,6 +274,16 @@ def run_conversion_job(job_id: str, reference_id: int, reference_curie: str,
                 f"for reference_id={reference_id}"
             )
 
+        # Generate classifier embeddings for the merged Markdown, mirroring the
+        # cron path's main-only success semantics: embed whenever the main
+        # conversion succeeded, even if a supplement failed. Isolated + idempotent
+        # (skips references without a classifier MOD and sources already embedded).
+        if not main_failure:
+            from agr_literature_service.lit_processing.embedding.embedding_generation import (
+                maybe_generate_classifier_embeddings,
+            )
+            maybe_generate_classifier_embeddings(db, reference_id, reference_curie)
+
         conversion_manager.complete_job(
             job_id=job_id,
             success=overall_success,

--- a/agr_literature_service/lit_processing/embedding/embedding_generation.py
+++ b/agr_literature_service/lit_processing/embedding/embedding_generation.py
@@ -32,7 +32,11 @@ from agr_cognito_py import ModAccess
 from agr_literature_service.api.config import config
 from agr_literature_service.api.crud import embedding_file_crud
 from agr_literature_service.api.crud.referencefile_crud import download_file
-from agr_literature_service.api.models import ReferencefileModel
+from agr_literature_service.api.models import (
+    ModCorpusAssociationModel,
+    ModModel,
+    ReferencefileModel,
+)
 from agr_literature_service.api.schemas.embedding_file_schemas import EmbeddingFileSchemaCreate
 
 logger = logging.getLogger(__name__)
@@ -42,6 +46,31 @@ logger = logging.getLogger(__name__)
 MERGED_SOURCE_FILE_CLASSES = ("converted_merged_main", "converted_merged_supplement")
 
 VERSION = 1
+
+# MODs whose ML topic classifiers consume these classifier embeddings. Only
+# references in the corpus of one of these MODs are embedded, so we don't spend
+# OpenAI generating classifier embeddings that no classifier will use. This is
+# intentionally a hardcoded list for now — extend it as more MODs get
+# classifiers, or replace it with an ml_model-table lookup. NOTE: this filter is
+# specific to *classifier* embeddings; future embeddings for other tools produce
+# separate embedding files and must not reuse it.
+ML_CLASSIFIER_MODS = ("WB", "FB")
+
+
+def _reference_has_classifier_mod(db, reference_id: int) -> bool:
+    """True iff the reference is in corpus for at least one MOD that has an ML
+    classifier (see :data:`ML_CLASSIFIER_MODS`)."""
+    return (
+        db.query(ModCorpusAssociationModel)
+        .join(ModModel, ModModel.mod_id == ModCorpusAssociationModel.mod_id)
+        .filter(
+            ModCorpusAssociationModel.reference_id == reference_id,
+            ModCorpusAssociationModel.corpus.is_(True),
+            ModModel.abbreviation.in_(ML_CLASSIFIER_MODS),
+        )
+        .first()
+        is not None
+    )
 
 
 def generate_classifier_embeddings_for_reference(
@@ -75,6 +104,15 @@ def generate_classifier_embeddings_for_reference(
             "'agr-abc-document-parsers[embeddings]' and 'openai' to enable.", exc
         )
         return {"skipped": "deps_unavailable"}
+
+    # Only embed references belonging to a MOD that actually has an ML classifier
+    # — otherwise the embeddings would never be consumed.
+    if not _reference_has_classifier_mod(db, reference_id):
+        logger.debug(
+            "Reference %s is not in a classifier MOD corpus (%s); skipping "
+            "classifier embedding generation", reference_id, ML_CLASSIFIER_MODS
+        )
+        return {"skipped": "no_classifier_mod"}
 
     sources = (
         db.query(ReferencefileModel)
@@ -191,3 +229,28 @@ def _embed_and_register(db, reference_curie, source, chunker, embedder, profile_
         "Registered %s embedding for referencefile %s (%s): %d chunks",
         profile_name, source_id, reference_curie, len(chunks)
     )
+
+
+def maybe_generate_classifier_embeddings(
+    db, reference_id: int, reference_curie: Optional[str] = None
+) -> None:
+    """Fire-and-forget wrapper around
+    :func:`generate_classifier_embeddings_for_reference` for conversion callers.
+
+    Fully isolated: any failure is logged and swallowed so classifier embedding
+    generation can never flip the outcome of a conversion. The underlying
+    function already no-ops (returns a skip reason) when the feature is disabled,
+    the embedding stack is missing, or the reference is not in a classifier MOD's
+    corpus."""
+    try:
+        result = generate_classifier_embeddings_for_reference(
+            db, reference_id, reference_curie
+        )
+        logger.debug(
+            "Classifier embedding result for reference %s: %s", reference_id, result
+        )
+    except Exception as exc:
+        logger.error(
+            "Classifier embedding generation failed for reference %s (%s): %s",
+            reference_id, reference_curie, exc
+        )

--- a/agr_literature_service/lit_processing/embedding/embedding_generation.py
+++ b/agr_literature_service/lit_processing/embedding/embedding_generation.py
@@ -185,18 +185,22 @@ def _embed_and_register(db, reference_curie, source, chunker, embedder, profile_
     if not chunks:
         logger.info("No chunks produced for referencefile %s; skipping", source_id)
         return
-    embedder.embed_chunks(chunks)
 
+    # Append the optional whole-document vector as one more chunk BEFORE embedding,
+    # so the document text is embedded in the same batched request as the
+    # paragraph chunks — one OpenAI round trip per source instead of two. This
+    # matters for bulk runs where OpenAI round-trip latency dominates per-source
+    # cost. document_text() must be computed on the paragraph chunks only.
     if include_document_vector:
-        doc_text = chunker.document_text(chunks)
-        doc_input = embedder.truncate_to_limit(doc_text)
-        doc_vector = embedder.embed([doc_input])[0]
+        doc_input = embedder.truncate_to_limit(chunker.document_text(chunks))
         chunks.append(Chunk(
             reference_curie=reference_curie, chunk_index=-1, content=doc_input,
             profile_name=profile_name, chunking_strategy="document",
             section_title="__document__", is_document_level=True,
-            n_tokens=embedder.count_tokens(doc_input), embedding=doc_vector,
+            n_tokens=embedder.count_tokens(doc_input),
         ))
+
+    embedder.embed_chunks(chunks)
 
     recipe = EmbeddingRecipe(
         profile_name=profile_name, version=VERSION,

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md.py
@@ -816,7 +816,8 @@ def _build_workflow_error_record(  # pragma: no cover
 
 def main(  # pragma: no cover
     prefer_nxml: bool = True,
-    process_supplements: bool = True
+    process_supplements: bool = True,
+    max_references: Optional[int] = None
 ):
     """
     Main entry point for workflow-based reference-to-Markdown conversion.
@@ -831,6 +832,8 @@ def main(  # pragma: no cover
     Args:
         prefer_nxml: Prefer nXML over PDFX for main-file conversion.
         process_supplements: Also convert supplemental PDFs.
+        max_references: When set, stop after this many references (jobs) have
+            been processed. Useful for smoke-testing on a few references.
     """
     start_time = time.time()
 
@@ -860,6 +863,12 @@ def main(  # pragma: no cover
                     seen_wf_tag_ids.add(job["reference_workflow_tag_id"])
             offset += limit
             logger.info(f"Loaded batch of {len(jobs)} jobs. Total jobs loaded: {len(all_jobs)}")
+            # Stop paging once we have enough jobs to satisfy max_references.
+            if max_references is not None and len(all_jobs) >= max_references:
+                break
+        if max_references is not None and len(all_jobs) > max_references:
+            all_jobs = all_jobs[:max_references]
+            logger.info(f"Limiting this run to {max_references} reference(s).")
         logger.info("Finished loading all text conversion jobs.")
 
         # Per-MOD per-job iteration: each text_convert_job processes only
@@ -1000,11 +1009,17 @@ Examples:
   # Process references via workflow jobs (default)
   python -m agr_literature_service.lit_processing.pdf2md.pdf2md
 
+  # Process only the first 2 workflow-job references, then exit (smoke test)
+  python -m agr_literature_service.lit_processing.pdf2md.pdf2md --limit 2
+
   # Process N newest references (enumerated by newest main PDFs)
   python -m agr_literature_service.lit_processing.pdf2md.pdf2md --newest 50
 
   # Process all unconverted references for papers published since 2025
   python -m agr_literature_service.lit_processing.pdf2md.pdf2md --since 2025
+
+  # Process at most 10 unconverted references published since 2025
+  python -m agr_literature_service.lit_processing.pdf2md.pdf2md --since 2025 --limit 10
 
   # Process newest references, skipping those with XML files
   python -m agr_literature_service.lit_processing.pdf2md.pdf2md --newest 50 --skip-xml
@@ -1031,7 +1046,10 @@ Examples:
         "--limit",
         type=int,
         metavar="N",
-        help="Limit number of references to process (only applies to --since mode)"
+        help=(
+            "Stop after processing N references. Applies to --since mode and to "
+            "the default workflow mode. For --newest, use --newest N instead."
+        )
     )
     parser.add_argument(
         "--no-xml",
@@ -1059,8 +1077,8 @@ Examples:
         print("Error: --skip-xml requires --newest or --since mode.")
         exit(1)
 
-    if args.limit and not args.since:
-        print("Error: --limit only applies to --since mode. Use --newest N instead.")
+    if args.limit and args.newest:
+        print("Error: --limit cannot be combined with --newest. Use --newest N instead.")
         exit(1)
 
     if args.newest:
@@ -1098,7 +1116,14 @@ Examples:
         print(f"\nResults: {result}")
     else:
         # Workflow mode (default)
+        if args.limit:
+            print(f"Limiting to {args.limit} references.")
+        if not args.prefer_nxml:
+            print("Forcing PDFX for main file (--no-xml).")
+        if not args.process_supplements:
+            print("Skipping supplemental PDFs (--no-supplements).")
         main(
             prefer_nxml=args.prefer_nxml,
-            process_supplements=args.process_supplements
+            process_supplements=args.process_supplements,
+            max_references=args.limit
         )

--- a/agr_literature_service/lit_processing/pdf2md/pdf2md.py
+++ b/agr_literature_service/lit_processing/pdf2md/pdf2md.py
@@ -668,14 +668,12 @@ def _maybe_generate_embeddings(  # pragma: no cover
     """Generate + register classifier embeddings for a converted reference's
     merged Markdown. Idempotent (skips sources already embedded) and fully
     isolated — any failure is logged and never flips the conversion result.
-    Dormant unless OPENAI_API_KEY is set and the embedding stack is installed."""
-    try:
-        from agr_literature_service.lit_processing.embedding.embedding_generation import (
-            generate_classifier_embeddings_for_reference,
-        )
-        generate_classifier_embeddings_for_reference(db, reference_id, reference_curie)
-    except Exception as e:
-        logger.error(f"Embedding generation failed for {reference_curie}: {e}")
+    Dormant unless OPENAI_API_KEY is set and the embedding stack is installed,
+    and skipped for references not in a classifier MOD's corpus."""
+    from agr_literature_service.lit_processing.embedding.embedding_generation import (
+        maybe_generate_classifier_embeddings,
+    )
+    maybe_generate_classifier_embeddings(db, reference_id, reference_curie)
 
 
 def process_newest_references(  # pragma: no cover

--- a/tests/lit_processing/test_embedding_generation.py
+++ b/tests/lit_processing/test_embedding_generation.py
@@ -1,20 +1,42 @@
 """Tests for the SCRUM-6142 embedding generation core.
 
-Two always-on tests prove the safe defaults (no key / stack unavailable -> the
-conversion job is unaffected) and the "merged Markdown only" source rule. The
-full end-to-end test needs the embeddings extra
-(agr-abc-document-parsers[embeddings], pinned in requirements.txt) and skips
-in environments installed without it.
+Always-on tests prove the safe defaults (no key / stack unavailable -> the
+conversion job is unaffected), the "merged Markdown only" source rule, and the
+SCRUM-6273 classifier-MOD filter skip. The full end-to-end tests need the
+embeddings extra (agr-abc-document-parsers[embeddings], pinned in
+requirements.txt) and skip in environments installed without it.
 """
 
 from unittest.mock import patch
 
 import pytest
 
-from agr_literature_service.api.models import ReferenceModel, ReferencefileModel
+from agr_literature_service.api.models import (
+    ModCorpusAssociationModel,
+    ModModel,
+    ReferenceModel,
+    ReferencefileModel,
+)
+from agr_literature_service.api.schemas.mod_corpus_sort_source_type import ModCorpusSortSourceType
 from agr_literature_service.lit_processing.embedding import embedding_generation as eg
 from ..api.test_reference import test_reference  # noqa
 from ..fixtures import db  # noqa
+
+
+def _add_classifier_mod_corpus(db, reference_id):  # noqa
+    """Put a reference in a classifier MOD's (WB) corpus so it passes the
+    SCRUM-6273 filter. Reuses an existing WB row if the test DB already has one."""
+    mod = db.query(ModModel).filter(ModModel.abbreviation == "WB").first()
+    if mod is None:
+        mod = ModModel(abbreviation="WB", short_name="WB", full_name="WormBase")
+        db.add(mod)
+        db.commit()
+        db.refresh(mod)
+    db.add(ModCorpusAssociationModel(
+        reference_id=reference_id, mod_id=mod.mod_id, corpus=True,
+        mod_corpus_sort_source=ModCorpusSortSourceType.Dqm_files,
+    ))
+    db.commit()
 
 
 def test_merged_only_source_classes():
@@ -48,6 +70,17 @@ def test_skips_when_stack_unavailable():
             patch("builtins.__import__", side_effect=fake_import):
         result = eg.generate_classifier_embeddings_for_reference(db=None, reference_id=1)
     assert result == {"skipped": "deps_unavailable"}
+
+
+def test_skips_when_no_classifier_mod():
+    """A reference not in a classifier MOD's corpus is skipped before any
+    embedding work — so we never spend OpenAI on embeddings no classifier uses."""
+    pytest.importorskip("agr_abc_document_parsers.embeddings",
+                        reason="embeddings extra / shared release not installed")
+    with patch.object(eg.config, "OPENAI_API_KEY", "sk-test"), \
+            patch.object(eg, "_reference_has_classifier_mod", return_value=False):
+        result = eg.generate_classifier_embeddings_for_reference(db=object(), reference_id=1)
+    assert result == {"skipped": "no_classifier_mod"}
 
 
 class _FakeEmbedder:
@@ -102,6 +135,8 @@ def test_end_to_end_embeds_each_merged_markdown(db, test_reference):  # noqa
 
     curie = test_reference.new_ref_curie
     ref = db.query(ReferenceModel).filter(ReferenceModel.curie == curie).one()
+    # Reference must be in a classifier MOD's corpus to pass the SCRUM-6273 filter.
+    _add_classifier_mod_corpus(db, ref.reference_id)
 
     # one merged-main + one merged-supplement (embedded) and one method-specific
     # grobid output (must be ignored).
@@ -142,3 +177,30 @@ def test_end_to_end_embeds_each_merged_markdown(db, test_reference):  # noqa
         # second run is idempotent
         result2 = eg.generate_classifier_embeddings_for_reference(db, ref.reference_id, curie)
         assert result2["embedded"] == 0 and result2["skipped_existing"] == 2
+
+
+@pytest.mark.webtest
+def test_end_to_end_skips_reference_without_classifier_mod(db, test_reference):  # noqa
+    """A reference with merged Markdown but NOT in a classifier MOD's corpus is
+    skipped end-to-end (SCRUM-6273): no embeddings are generated or registered."""
+    pytest.importorskip("agr_abc_document_parsers.embeddings",
+                        reason="embeddings extra / shared release not installed")
+    from agr_literature_service.api.models import EmbeddingFileModel
+
+    curie = test_reference.new_ref_curie
+    ref = db.query(ReferenceModel).filter(ReferenceModel.curie == curie).one()
+    # Intentionally NO classifier-MOD corpus association for this reference.
+    main = ReferencefileModel(reference_id=ref.reference_id, display_name="paper_merged",
+                              file_class="converted_merged_main", file_publication_status="final",
+                              file_extension="md", md5sum="mainmd5nomod", is_annotation=False)
+    db.add(main)
+    db.commit()
+
+    with patch.object(eg.config, "OPENAI_API_KEY", "sk-test"), \
+            patch("agr_literature_service.lit_processing.embedding.openai_embedder.OpenAIEmbedder",
+                  _FakeEmbedder), \
+            patch.object(eg, "download_file", return_value=MERGED_MD):
+        result = eg.generate_classifier_embeddings_for_reference(db, ref.reference_id, curie)
+    assert result == {"skipped": "no_classifier_mod"}
+    rows = db.query(EmbeddingFileModel).filter_by(reference_id=ref.reference_id).all()
+    assert rows == []


### PR DESCRIPTION
## Summary

Follow-on to SCRUM-6142 (part of the ABC embedding pipeline, SCRUM-6139).

Classifier embeddings are only useful to MODs that have an ML topic classifier, so embedding every converted reference wasted OpenAI spend on embeddings no classifier would consume. This PR restricts classifier embedding generation to references in the corpus of a classifier MOD, wires embedding generation into the manual conversion path (which previously generated none), and adds a `--limit` flag to the pdf2md script for smoke-testing.

## Changes

- **Classifier-MOD filter** (`embedding_generation.py`): new `ML_CLASSIFIER_MODS = ("WB", "FB")` constant (hardcoded for now, easy to extend or swap for an `ml_model`-table lookup) and a `_reference_has_classifier_mod` check. `generate_classifier_embeddings_for_reference` now returns `{"skipped": "no_classifier_mod"}` for references outside those MODs. The batch pdf2md cron path is covered automatically. The filter lives in the classifier-specific function, so future non-classifier embeddings (separate files) are unaffected.
- **Manual conversion API now generates embeddings**: a new isolated wrapper `maybe_generate_classifier_embeddings` is invoked from `run_conversion_job` (main-success semantics) and the sync nXML branch (`_execute_sync_nxml`). Idempotency prevents double-embedding when the batch and manual paths overlap. `pdf2md._maybe_generate_embeddings` was refactored to delegate to the same wrapper.
- **`--limit N` for pdf2md**: adds `max_references` to `main()` and lets `--limit` cap the default workflow mode (it already applied to `--since`); rejected when combined with `--newest`.

## Testing

- flake8 + mypy clean.
- Unit tests: new `test_skips_when_no_classifier_mod`; e2e webtests updated (positive path adds a WB corpus association; new negative-path test asserts a non-classifier-MOD reference is skipped with no embeddings).
- **Validated end-to-end on dev/stage**: ran `pdf2md --limit 2` against the dev DB. Two FB references converted via PDFX and each registered one `embedding_file` row sourced from its `converted_merged_main` Markdown (profile `classifier_fulltext_paragraph_chunk_refs_excluded_md_cleaned`, v1, `openai:text-embedding-3-small`; 53 and 40 chunks). `Failed: 0`.

## Deploy note

With these changes, once containers are rebuilt with `agr-abc-document-parsers[embeddings]` and `OPENAI_API_KEY` set, embeddings also fire on manual conversions for WB/FB references (previously the manual path generated none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
