### PR TITLE
fix(person-xref): enforce uniqueness only among non-obsolete rows (SC…

### DIFF
--- a/agr_literature_service/api/crud/person_cross_reference_crud.py
+++ b/agr_literature_service/api/crud/person_cross_reference_crud.py
@@ -48,10 +48,13 @@ def create_for_person(db: Session, person_id: int, payload: Dict[str, Any]) -> P
 
     curie_prefix = _curie_prefix(curie)
 
-    # curie is globally unique on person_cross_reference (uq_person_xref_curie).
+    # curie is unique among non-obsolete person_cross_reference rows (uq_person_xref_curie).
     dup = (
         db.query(PersonCrossReferenceModel.person_cross_reference_id)
-        .filter(PersonCrossReferenceModel.curie == curie)
+        .filter(
+            PersonCrossReferenceModel.curie == curie,
+            PersonCrossReferenceModel.is_obsolete.is_(False),
+        )
         .first()
     )
     if dup:
@@ -60,12 +63,14 @@ def create_for_person(db: Session, person_id: int, payload: Dict[str, Any]) -> P
             detail=f"Cross-reference '{curie}' already exists",
         )
 
-    # (person_id, curie_prefix) is unique per-person (uq_person_xref_person_prefix).
+    # (person_id, curie_prefix) is unique per-person among non-obsolete rows
+    # (uq_person_xref_person_prefix).
     prefix_dup = (
         db.query(PersonCrossReferenceModel.person_cross_reference_id)
         .filter(
             PersonCrossReferenceModel.person_id == person_id,
             PersonCrossReferenceModel.curie_prefix == curie_prefix,
+            PersonCrossReferenceModel.is_obsolete.is_(False),
         )
         .first()
     )
@@ -170,12 +175,13 @@ def patch(db: Session, person_cross_reference_id: int, patch_dict: Dict[str, Any
         new_curie = data["curie"].strip()
         new_prefix = _curie_prefix(new_curie)
 
-        # curie is globally unique on person_cross_reference (uq_person_xref_curie).
+        # curie is unique among non-obsolete person_cross_reference rows (uq_person_xref_curie).
         dup = (
             db.query(PersonCrossReferenceModel.person_cross_reference_id)
             .filter(
                 PersonCrossReferenceModel.curie == new_curie,
                 PersonCrossReferenceModel.person_cross_reference_id != person_cross_reference_id,
+                PersonCrossReferenceModel.is_obsolete.is_(False),
             )
             .first()
         )
@@ -185,9 +191,10 @@ def patch(db: Session, person_cross_reference_id: int, patch_dict: Dict[str, Any
                 detail=f"Cross-reference '{new_curie}' already exists",
             )
 
-        # (person_id, curie_prefix) is unique per-person (uq_person_xref_person_prefix).
-        # NULL person_ids are exempt — Postgres treats NULLs in unique constraints
-        # as distinct, so the constraint only fires when person_id is non-null.
+        # (person_id, curie_prefix) is unique per-person among non-obsolete rows
+        # (uq_person_xref_person_prefix). NULL person_ids are exempt — Postgres treats
+        # NULLs in unique indexes as distinct, so the index only fires when person_id
+        # is non-null.
         if obj.person_id is not None:
             prefix_dup = (
                 db.query(PersonCrossReferenceModel.person_cross_reference_id)
@@ -195,6 +202,7 @@ def patch(db: Session, person_cross_reference_id: int, patch_dict: Dict[str, Any
                     PersonCrossReferenceModel.person_id == obj.person_id,
                     PersonCrossReferenceModel.curie_prefix == new_prefix,
                     PersonCrossReferenceModel.person_cross_reference_id != person_cross_reference_id,
+                    PersonCrossReferenceModel.is_obsolete.is_(False),
                 )
                 .first()
             )

--- a/agr_literature_service/api/models/person_cross_reference_model.py
+++ b/agr_literature_service/api/models/person_cross_reference_model.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from sqlalchemy import ARRAY, Boolean, Column, ForeignKey, Integer, String, Index, UniqueConstraint, text
+from sqlalchemy import ARRAY, Boolean, Column, ForeignKey, Integer, String, Index, and_, text
 from sqlalchemy.orm import relationship
 from agr_literature_service.api.database.base import Base
 from agr_literature_service.api.database.versioning import enable_versioning
@@ -23,8 +23,16 @@ class PersonCrossReferenceModel(Base, AuditedModel):
     is_obsolete = Column(Boolean, nullable=False, server_default=text("false"))
 
     __table_args__ = (
-        UniqueConstraint("curie", name="uq_person_xref_curie"),
-        UniqueConstraint("person_id", "curie_prefix", name="uq_person_xref_person_prefix"),
+        # Uniqueness is enforced only among non-obsolete rows (mirrors the Biblio
+        # cross_reference partial unique indexes), so a soft-deleted xref does not
+        # block re-adding the same curie/prefix.
+        Index("uq_person_xref_curie", "curie",
+              unique=True,
+              postgresql_where=(is_obsolete.is_(False))),
+        Index("uq_person_xref_person_prefix", "person_id", "curie_prefix",
+              unique=True,
+              postgresql_where=(and_(is_obsolete.is_(False),
+                                     person_id.isnot(None)))),
         Index("ix_person_xref_person_id", "person_id"),
         Index("ix_person_xref_prefix_curie", "curie_prefix", "curie"),
     )

--- a/agr_literature_service/api/routers/person_cross_reference_router.py
+++ b/agr_literature_service/api/routers/person_cross_reference_router.py
@@ -7,10 +7,10 @@ from sqlalchemy.orm import Session
 from agr_literature_service.api import database
 from agr_literature_service.api.crud import person_crud, person_cross_reference_crud
 from agr_literature_service.api.schemas import (
-    PersonCrossReferenceSchemaCreate,
     PersonCrossReferenceSchemaPost,
     PersonCrossReferenceSchemaShow,
     PersonCrossReferenceSchemaRelated,
+    PersonCrossReferenceSchemaUpdate,
 )
 from agr_literature_service.api.user import set_global_user_from_cognito
 from agr_literature_service.api.auth import get_authenticated_user
@@ -74,7 +74,7 @@ def show(
 )
 def patch(
     person_cross_reference_id: int,
-    request: PersonCrossReferenceSchemaCreate,
+    request: PersonCrossReferenceSchemaUpdate,
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):

--- a/alembic/versions/20260708_b7c3e9f1a2d4_person_xref_partial_unique_indexes.py
+++ b/alembic/versions/20260708_b7c3e9f1a2d4_person_xref_partial_unique_indexes.py
@@ -1,0 +1,50 @@
+"""person_cross_reference: non-obsolete-only uniqueness
+
+Revision ID: b7c3e9f1a2d4
+Revises: 1a1274ba1f52
+Create Date: 2026-07-08
+
+Mirrors the Biblio cross_reference table: uniqueness on person_cross_reference
+should apply only among non-obsolete rows. The prior plain UniqueConstraints
+counted obsolete (soft-deleted) rows, so an old obsolete xref blocked re-adding
+the same curie/prefix. Replace them with partial unique indexes gated on
+is_obsolete IS FALSE.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'b7c3e9f1a2d4'
+down_revision = '1a1274ba1f52'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('uq_person_xref_curie', 'person_cross_reference', type_='unique')
+    op.drop_constraint('uq_person_xref_person_prefix', 'person_cross_reference', type_='unique')
+    op.create_index(
+        'uq_person_xref_curie',
+        'person_cross_reference',
+        ['curie'],
+        unique=True,
+        postgresql_where=sa.text('is_obsolete IS false'),
+    )
+    op.create_index(
+        'uq_person_xref_person_prefix',
+        'person_cross_reference',
+        ['person_id', 'curie_prefix'],
+        unique=True,
+        postgresql_where=sa.text('is_obsolete IS false AND person_id IS NOT NULL'),
+    )
+
+
+def downgrade():
+    op.drop_index('uq_person_xref_person_prefix', table_name='person_cross_reference')
+    op.drop_index('uq_person_xref_curie', table_name='person_cross_reference')
+    op.create_unique_constraint('uq_person_xref_curie', 'person_cross_reference', ['curie'])
+    op.create_unique_constraint(
+        'uq_person_xref_person_prefix',
+        'person_cross_reference',
+        ['person_id', 'curie_prefix'],
+    )

--- a/tests/api/test_person_cross_reference.py
+++ b/tests/api/test_person_cross_reference.py
@@ -166,6 +166,43 @@ class TestPersonCrossReference:
             )
             assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+    def test_obsolete_xref_does_not_block_new_curie(self, auth_headers, test_person_xref):  # noqa
+        """An obsolete xref must not block re-adding the same curie/prefix (SCRUM-6257).
+
+        Uniqueness on person_cross_reference is enforced only among non-obsolete
+        rows, mirroring the Biblio cross_reference partial unique indexes.
+        """
+        with TestClient(app) as client:
+            # Soft-delete the baseline ORCID xref.
+            res = client.patch(
+                f"/person_cross_reference/{test_person_xref.new_person_cross_reference_id}",
+                json={"is_obsolete": True},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_200_OK
+
+            # Same curie (and same prefix) for the same person now succeeds.
+            res = client.post(
+                "/person_cross_reference/",
+                json={
+                    "person_curie": str(test_person_xref.person_id),
+                    "curie": "ORCID:0000-0001-2345-6789",
+                },
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_201_CREATED
+
+            # A second non-obsolete row with that curie is still rejected.
+            res = client.post(
+                "/person_cross_reference/",
+                json={
+                    "person_curie": str(test_person_xref.person_id),
+                    "curie": "ORCID:0000-0001-2345-6789",
+                },
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
     def test_list_for_person(self, auth_headers, test_person_xref):  # noqa
         with TestClient(app) as client:
             res = client.get(

--- a/tests/api/test_person_cross_reference.py
+++ b/tests/api/test_person_cross_reference.py
@@ -173,10 +173,12 @@ class TestPersonCrossReference:
         rows, mirroring the Biblio cross_reference partial unique indexes.
         """
         with TestClient(app) as client:
-            # Soft-delete the baseline ORCID xref.
+            # Soft-delete the baseline ORCID xref. The PATCH endpoint requires
+            # curie (PersonCrossReferenceSchemaCreate), so resend it alongside
+            # is_obsolete, matching test_patch_is_obsolete.
             res = client.patch(
                 f"/person_cross_reference/{test_person_xref.new_person_cross_reference_id}",
-                json={"is_obsolete": True},
+                json={"curie": "ORCID:0000-0001-2345-6789", "is_obsolete": True},
                 headers=auth_headers,
             )
             assert res.status_code == status.HTTP_200_OK

--- a/tests/api/test_person_cross_reference.py
+++ b/tests/api/test_person_cross_reference.py
@@ -173,12 +173,10 @@ class TestPersonCrossReference:
         rows, mirroring the Biblio cross_reference partial unique indexes.
         """
         with TestClient(app) as client:
-            # Soft-delete the baseline ORCID xref. The PATCH endpoint requires
-            # curie (PersonCrossReferenceSchemaCreate), so resend it alongside
-            # is_obsolete, matching test_patch_is_obsolete.
+            # Soft-delete the baseline ORCID xref (partial patch, curie omitted).
             res = client.patch(
                 f"/person_cross_reference/{test_person_xref.new_person_cross_reference_id}",
-                json={"curie": "ORCID:0000-0001-2345-6789", "is_obsolete": True},
+                json={"is_obsolete": True},
                 headers=auth_headers,
             )
             assert res.status_code == status.HTTP_200_OK


### PR DESCRIPTION
…RUM-6257)

person_cross_reference used plain, unfiltered UniqueConstraints, so an obsolete (soft-deleted) row blocked re-adding the same curie/prefix. This diverged from the Biblio cross_reference table, which enforces uniqueness via partial unique indexes gated on is_obsolete IS FALSE.

Mirror the Biblio semantics:
- model: replace the two UniqueConstraints with partial unique indexes (curie WHERE is_obsolete IS FALSE; (person_id, curie_prefix) WHERE is_obsolete IS FALSE AND person_id IS NOT NULL)
- migration b7c3e9f1a2d4: drop the constraints, create the partial indexes
- crud: add is_obsolete IS FALSE to the duplicate checks in create_for_person and patch so obsolete rows no longer block inserts/updates
- test: regression covering "obsolete row does not block a new active row"