### PR TITLE
classify PMC thumbnails by file size (SCRUM-6281)

### DIFF
--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/load_pmc_metadata.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/load_pmc_metadata.py
@@ -49,9 +49,10 @@ def build_file_root_mappings(input_file):
     return pmcid_to_xml_root, pmcid_to_pdf_roots
 
 
-def determine_file_class(file_name, file_extension, pmcid, pmcid_to_xml_root, pmcid_to_pdf_roots):
+def determine_file_class(file_name, file_extension, pmcid, pmcid_to_xml_root, pmcid_to_pdf_roots,
+                         file_size=None):
     """Determine the file_class for a PMC file based on extension and root name matching."""
-    file_class = classify_pmc_file(file_name, file_extension)
+    file_class = classify_pmc_file(file_name, file_extension, file_size)
     file_root = file_name.lower()
 
     # Check if this PDF is the main PDF (matches XML root name)
@@ -126,12 +127,17 @@ def load_ref_file_metadata_into_db():  # pragma: no cover
                 if referencefile_id in ref_files_id_pmc_set:
                     continue
 
+            # Optional 5th column: raw file size in bytes (added by the PMC
+            # download step) used for size-based thumbnail classification.
+            file_size = int(pieces[4]) if len(pieces) > 4 and pieces[4].strip().isdigit() else None
+
             file_class = None
             if not referencefile_id:
                 file_extension = file_name_with_suffix.split(".")[-1].lower()
                 file_name = file_name_with_suffix.replace("." + file_extension, "")
                 file_class = determine_file_class(file_name, file_extension, pmcid,
-                                                  pmcid_to_xml_root, pmcid_to_pdf_roots)
+                                                  pmcid_to_xml_root, pmcid_to_pdf_roots,
+                                                  file_size)
                 referencefile_id = insert_referencefile(db_session, pmid, file_class,
                                                         file_publication_status,
                                                         file_name_with_suffix,

--- a/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_download_pmc_files.py
+++ b/agr_literature_service/lit_processing/data_ingest/pubmed_ingest/pubmed_download_pmc_files.py
@@ -316,9 +316,11 @@ def upload_suppl_files_to_s3():  # pragma: no cover
                     if gzip_file_with_path is None:
                         skip_count += 1
                         continue
+                    file_size = path.getsize(file_with_path)
                     status = upload_suppl_file_to_s3(gzip_file_with_path, md5sum)
                     if status is True:
-                        fw.write(pmid + "\t" + pmcid + "\t" + file_name + "\t" + md5sum + "\n")
+                        fw.write(pmid + "\t" + pmcid + "\t" + file_name + "\t"
+                                 + md5sum + "\t" + str(file_size) + "\n")
                         upload_count += 1
         except Exception as e:
             error_count += 1

--- a/agr_literature_service/lit_processing/data_ingest/utils/file_processing_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/file_processing_utils.py
@@ -200,9 +200,14 @@ def remove_old_files(dir_path, days_old):
 # thumbnail rather than a full figure. Derived from the observed size
 # distribution of PMC figure images (SCRUM-6281): genuine thumbnails cluster
 # below ~25 KB for gif and ~15 KB for jpg, while full figures are much larger.
-# The stored object is gzipped, but for already compressed image formats that
-# is within a few percent of the raw size, so the same thresholds apply to
-# both the raw size seen at ingest and the gzipped size seen in S3.
+# These thresholds are applied to two slightly different measurements: the raw
+# file size at ingest, and the gzipped S3 object size in the backfill. For jpeg
+# that difference is negligible (already-compressed, raw/gz ~= 1.0), but for gif
+# gzip shrinks the LZW stream a bit further (measured raw/gz ~= 1.09 on average,
+# up to ~1.15 near the boundary). The gif thumbnail population sits well below
+# 20 KB with very few files in 20-30 KB, so this only affects a handful of
+# boundary cases; a per-file exact split would require the raw bytes on both
+# paths, which is not worth the extra S3 downloads.
 THUMBNAIL_MAX_SIZE_BYTES = {
     'gif': 25000,
     'jpg': 15000,

--- a/agr_literature_service/lit_processing/data_ingest/utils/file_processing_utils.py
+++ b/agr_literature_service/lit_processing/data_ingest/utils/file_processing_utils.py
@@ -196,7 +196,29 @@ def remove_old_files(dir_path, days_old):
                 remove(file_path)
 
 
-def classify_pmc_file(file_name, file_extension):
+# Maximum file size (in bytes) below which a PMC image is treated as a
+# thumbnail rather than a full figure. Derived from the observed size
+# distribution of PMC figure images (SCRUM-6281): genuine thumbnails cluster
+# below ~25 KB for gif and ~15 KB for jpg, while full figures are much larger.
+# The stored object is gzipped, but for already compressed image formats that
+# is within a few percent of the raw size, so the same thresholds apply to
+# both the raw size seen at ingest and the gzipped size seen in S3.
+THUMBNAIL_MAX_SIZE_BYTES = {
+    'gif': 25000,
+    'jpg': 15000,
+    'jpeg': 15000,
+}
+
+
+def is_thumbnail_by_size(file_extension, file_size):
+    """Return True if an image of this extension and size is a thumbnail."""
+    if file_size is None:
+        return False
+    max_size = THUMBNAIL_MAX_SIZE_BYTES.get(file_extension.lower())
+    return max_size is not None and file_size < max_size
+
+
+def classify_pmc_file(file_name, file_extension, file_size=None):
 
     """
     image_related_file_extensions = [
@@ -205,12 +227,18 @@ def classify_pmc_file(file_name, file_extension):
     ]
     """
     image_related_file_extensions = ['jpg', 'jpeg', 'gif', 'tif', 'tiff', 'png']
-    if file_extension.lower() == "nxml":
+    ext = file_extension.lower()
+    if ext == "nxml":
         return "nXML"
-    if "thumb" in file_name.lower() and file_extension.lower() in image_related_file_extensions:
-        return "thumbnail"
-    # if "fig" in file_name.lower() and file_extension.lower() in image_related_file_extensions:
-    if file_extension.lower() in image_related_file_extensions:
+    if ext in image_related_file_extensions:
+        # Some publishers (e.g. JoVE, Royal Society) label thumbnails in the
+        # file name; honor that regardless of size.
+        if "thumb" in file_name.lower():
+            return "thumbnail"
+        # Otherwise rely on size: PMC packages ship most figures as a large
+        # image plus a small same-named thumbnail that is NOT named "thumb".
+        if is_thumbnail_by_size(ext, file_size):
+            return "thumbnail"
         return "figure"
     return "supplement"
 

--- a/agr_literature_service/lit_processing/end_of_year_update/annual_pmc_package_update.py
+++ b/agr_literature_service/lit_processing/end_of_year_update/annual_pmc_package_update.py
@@ -591,7 +591,8 @@ def add_file(db, pmid, file_name, md5sum, old_file_class, pmcid, reference_id, r
             _, file_extension = file_name.rsplit(".", 1)
         else:
             file_extension = ""
-        file_class = classify_pmc_file(file_name, file_extension.lower())
+        file_size = path.getsize(file_with_path)
+        file_class = classify_pmc_file(file_name, file_extension.lower(), file_size)
 
     logger.info(f"{pmid}: file_class for {file_name} is {file_class}")
 

--- a/agr_literature_service/lit_processing/oneoff_scripts/reclassify_pmc_thumbnails.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/reclassify_pmc_thumbnails.py
@@ -1,0 +1,187 @@
+"""
+One-off cleanup for SCRUM-6281: re-classify mislabeled PMC thumbnails.
+
+Historically every PMC image was stored with ``file_class = 'figure'`` because
+the classifier only recognized a thumbnail when the file name contained
+"thumb". In reality PMC ships each figure as a large image plus a small,
+same-named thumbnail that carries no "thumb" token, so ~half of the ``figure``
+rows are actually thumbnails. The only reliable discriminator is file size.
+
+This script scans ``figure``-class ``gif``/``jpg``/``jpeg`` rows, reads each
+object's size from S3, and re-classifies it as ``thumbnail`` when it falls
+below the size threshold for its type (gif < 25 KB, jpg/jpeg < 15 KB). The
+thresholds live in file_processing_utils.THUMBNAIL_MAX_SIZE_BYTES, the same
+values the ingest-time classifier now uses, so past and future data agree.
+
+By default the script is a dry run: it reports what it would change (with a
+size histogram) but commits nothing. Pass --apply to perform the updates.
+
+Usage:
+    python reclassify_pmc_thumbnails.py                 # dry run
+    python reclassify_pmc_thumbnails.py --apply         # perform updates
+    python reclassify_pmc_thumbnails.py --limit 5000    # cap rows (testing)
+"""
+import argparse
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from os import environ, path
+
+import boto3
+from botocore.exceptions import ClientError
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+
+from agr_literature_service.lit_processing.utils.sqlalchemy_utils import create_postgres_session
+from agr_literature_service.api.crud.referencefile_utils import get_s3_folder_from_md5sum
+from agr_literature_service.lit_processing.data_ingest.utils.file_processing_utils import (
+    is_thumbnail_by_size,
+)
+from agr_literature_service.api.user import set_global_user_id
+
+logging.basicConfig(format='%(message)s')
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+BUCKET = environ.get("REFFILE_S3_BUCKET", "agr-literature")
+BATCH_SIZE = 500
+S3_WORKERS = 24
+
+SELECT_CANDIDATES = text(
+    "SELECT referencefile_id, display_name, file_extension, md5sum "
+    "FROM referencefile "
+    "WHERE file_class = 'figure' "
+    "AND lower(file_extension) IN ('gif', 'jpg', 'jpeg') "
+    "AND referencefile_id > :last_id "
+    "ORDER BY referencefile_id "
+    "LIMIT :limit"
+)
+
+UPDATE_CLASS = text(
+    "UPDATE referencefile "
+    "SET file_class = 'thumbnail' "
+    "WHERE referencefile_id = :referencefile_id"
+)
+
+
+def get_s3_size(s3_client, md5sum):
+    """Return the size in bytes of the stored (gzipped) object, or None."""
+    folder = get_s3_folder_from_md5sum(md5sum)
+    key = f"{folder}/{md5sum}.gz"
+    try:
+        return s3_client.head_object(Bucket=BUCKET, Key=key)["ContentLength"]
+    except ClientError:
+        return None
+
+
+def _bucket_label(size):
+    if size < 10000:
+        return "<10KB"
+    if size < 15000:
+        return "10-15KB"
+    if size < 20000:
+        return "15-20KB"
+    if size < 25000:
+        return "20-25KB"
+    return ">=25KB"
+
+
+def reclassify_thumbnails(apply_changes: bool, row_limit: int) -> None:
+
+    db_session = create_postgres_session(False)
+    script_name = path.basename(__file__).replace(".py", "")
+    set_global_user_id(db_session, script_name)
+
+    s3_client = boto3.client("s3")
+
+    mode = "APPLY" if apply_changes else "DRY-RUN"
+    logger.info(f"Running in {mode} mode (bucket={BUCKET})")
+
+    last_id = 0
+    scanned = 0
+    updated = 0
+    missing = 0
+    histogram: dict = {}
+
+    while True:
+        if row_limit and scanned >= row_limit:
+            break
+
+        batch = min(BATCH_SIZE, row_limit - scanned) if row_limit else BATCH_SIZE
+        try:
+            rows = db_session.execute(
+                SELECT_CANDIDATES, {"last_id": last_id, "limit": batch}
+            ).fetchall()
+        except SQLAlchemyError as e:
+            logger.error(f"Error executing SELECT query: {e}")
+            break
+
+        if not rows:
+            break
+
+        # Fetch S3 sizes for the batch concurrently.
+        md5s = [row[3] for row in rows]
+        with ThreadPoolExecutor(max_workers=S3_WORKERS) as pool:
+            sizes = list(pool.map(lambda m: get_s3_size(s3_client, m), md5s))
+
+        to_update = []
+        for row, size in zip(rows, sizes):
+            referencefile_id, display_name, file_extension, _ = row
+            last_id = referencefile_id
+            scanned += 1
+
+            if size is None:
+                missing += 1
+                logger.info(f"MISSING in S3: referencefile_id={referencefile_id} "
+                            f"display_name='{display_name}'")
+                continue
+
+            if not is_thumbnail_by_size(file_extension, size):
+                continue
+
+            histogram[_bucket_label(size)] = histogram.get(_bucket_label(size), 0) + 1
+            to_update.append(referencefile_id)
+            logger.info(f"figure -> thumbnail: referencefile_id={referencefile_id} "
+                        f"display_name='{display_name}.{file_extension}' size={size}")
+
+        if to_update:
+            updated += len(to_update)
+            if apply_changes:
+                try:
+                    for referencefile_id in to_update:
+                        db_session.execute(
+                            UPDATE_CLASS, {"referencefile_id": referencefile_id}
+                        )
+                    db_session.commit()
+                except SQLAlchemyError as e:
+                    logger.error(f"Error committing batch: {e}")
+                    db_session.rollback()
+                    updated -= len(to_update)
+
+    logger.info("---- size histogram of reclassified rows ----")
+    for label in ["<10KB", "10-15KB", "15-20KB", "20-25KB", ">=25KB"]:
+        if label in histogram:
+            logger.info(f"  {label}: {histogram[label]}")
+
+    logger.info(
+        f"DONE! mode={mode} scanned={scanned} missing_in_s3={missing} "
+        f"{'updated' if apply_changes else 'to_update'}={updated}"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Reclassify size-qualifying PMC 'figure' rows as 'thumbnail'."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit the updates. Without this flag the script only reports.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Cap the number of rows scanned (0 = no cap). Useful for testing.",
+    )
+    args = parser.parse_args()
+    reclassify_thumbnails(args.apply, args.limit)

--- a/tests/lit_processing/data_ingest/utils/test_file_processing_utils.py
+++ b/tests/lit_processing/data_ingest/utils/test_file_processing_utils.py
@@ -1,0 +1,72 @@
+from agr_literature_service.lit_processing.data_ingest.utils.file_processing_utils import (
+    classify_pmc_file,
+    is_thumbnail_by_size,
+    THUMBNAIL_MAX_SIZE_BYTES,
+)
+
+
+class TestIsThumbnailBySize:
+
+    def test_thresholds_are_the_expected_values(self):
+        # Lock the agreed SCRUM-6281 thresholds so they can't drift silently.
+        assert THUMBNAIL_MAX_SIZE_BYTES == {'gif': 25000, 'jpg': 15000, 'jpeg': 15000}
+
+    def test_none_size_is_not_a_thumbnail(self):
+        assert is_thumbnail_by_size('gif', None) is False
+
+    def test_gif_below_threshold_is_thumbnail(self):
+        assert is_thumbnail_by_size('gif', 24999) is True
+
+    def test_gif_at_or_above_threshold_is_not_thumbnail(self):
+        assert is_thumbnail_by_size('gif', 25000) is False
+        assert is_thumbnail_by_size('gif', 40000) is False
+
+    def test_jpg_and_jpeg_share_the_lower_threshold(self):
+        assert is_thumbnail_by_size('jpg', 14999) is True
+        assert is_thumbnail_by_size('jpeg', 14999) is True
+        assert is_thumbnail_by_size('jpg', 15000) is False
+        assert is_thumbnail_by_size('jpeg', 20000) is False
+
+    def test_extension_is_case_insensitive(self):
+        assert is_thumbnail_by_size('GIF', 10000) is True
+
+    def test_extensions_without_a_threshold_are_never_thumbnails(self):
+        # tif/tiff/png are only ever name-classified, never size-classified.
+        assert is_thumbnail_by_size('tif', 1000) is False
+        assert is_thumbnail_by_size('png', 1000) is False
+
+
+class TestClassifyPmcFile:
+
+    def test_nxml_is_nxml(self):
+        assert classify_pmc_file('main', 'nxml') == 'nXML'
+
+    def test_non_image_is_supplement(self):
+        assert classify_pmc_file('table1', 'xlsx') == 'supplement'
+        assert classify_pmc_file('data', 'pdf') == 'supplement'
+
+    def test_thumb_in_name_wins_regardless_of_size(self):
+        # Publisher-labeled thumbnails (JoVE, Royal Society) stay thumbnails
+        # even when large or when no size is supplied.
+        assert classify_pmc_file('jove-76-50447-thumb', 'gif') == 'thumbnail'
+        assert classify_pmc_file('rsob220308.thumb', 'jpg', 999999) == 'thumbnail'
+
+    def test_image_without_size_and_without_thumb_is_figure(self):
+        # Backward-compatible 2-arg call path (e.g. update_referencefile_class).
+        assert classify_pmc_file('fig1', 'gif') == 'figure'
+        assert classify_pmc_file('fig1', 'jpg') == 'figure'
+
+    def test_small_gif_is_thumbnail_large_gif_is_figure(self):
+        assert classify_pmc_file('5fig1', 'gif', 13224) == 'thumbnail'
+        # A large gif (real full figure, e.g. BMC "*_HTML") stays a figure.
+        assert classify_pmc_file('13072_2017_159_Fig5_HTML', 'gif', 555922) == 'figure'
+
+    def test_small_jpg_is_thumbnail_large_jpg_is_figure(self):
+        assert classify_pmc_file('somefig', 'jpg', 14000) == 'thumbnail'
+        assert classify_pmc_file('5fig1', 'jpg', 107388) == 'figure'
+        # 16 KB jpg is above the 15 KB jpg threshold -> figure.
+        assert classify_pmc_file('somefig', 'jpg', 16000) == 'figure'
+
+    def test_tif_is_not_size_classified(self):
+        # tif has no size threshold, so even a tiny one is a figure.
+        assert classify_pmc_file('imgtif', 'tif', 5000) == 'figure'


### PR DESCRIPTION
Real PMC thumbnails are not named "thumb" (only a few JoVE/Royal Society files are); PMC ships each figure as a large image plus a small same-named thumbnail, so ~half of the 'figure' rows are actually thumbnails. The only reliable discriminator is file size.

- classify_pmc_file: add size-aware thumbnail detection (gif < 25KB, jpg/jpeg < 15KB) via shared THUMBNAIL_MAX_SIZE_BYTES thresholds; keep the legacy "thumb" name check and fall back to it when size is unknown.
- Thread raw file size through the ingest pipeline: emit it in the PMC download TSV, parse it in load_pmc_metadata, and pass it in the annual PMC package update.
- Add oneoff_scripts/reclassify_pmc_thumbnails.py to back-reclassify existing 'figure' gif/jpg/jpeg rows using their S3 object sizes (dry-run by default).