### PR TITLE
feat(SCRUM-6272): require curie and name-or-strain on laboratory

### DIFF
--- a/agr_literature_service/api/crud/laboratory_crud.py
+++ b/agr_literature_service/api/crud/laboratory_crud.py
@@ -136,33 +136,36 @@ def create(db: Session, payload: LaboratorySchemaCreate) -> LaboratoryModel:
 
     obj = LaboratoryModel(**data)
     db.add(obj)
-    db.flush()  # get laboratory_id for the inline children
-    new_laboratory_id = obj.laboratory_id
+    # Wrap flush and commit: DB constraints (e.g. ck_laboratory_name_or_strain,
+    # curie NOT NULL/unique) can fire at the flush that assigns laboratory_id, not
+    # just at commit. Convert any such violation into a 422 instead of a raw 500.
+    try:
+        db.flush()  # get laboratory_id for the inline children
+        new_laboratory_id = obj.laboratory_id
 
-    if xrefs_data:
-        for xr in xrefs_data:
-            curie = xr["curie"].strip()
-            curie_prefix = _curie_prefix_from(curie)
+        if xrefs_data:
+            for xr in xrefs_data:
+                curie = xr["curie"].strip()
+                curie_prefix = _curie_prefix_from(curie)
+                db.add(
+                    LaboratoryCrossReferenceModel(
+                        laboratory_id=obj.laboratory_id,
+                        curie=curie,
+                        curie_prefix=curie_prefix,
+                        pages=xr.get("pages"),
+                        is_obsolete=bool(xr.get("is_obsolete", False)),
+                    )
+                )
+
+        for mod_id, allele_designation in resolved_alleles:
             db.add(
-                LaboratoryCrossReferenceModel(
+                LaboratoryAlleleDesignationModel(
                     laboratory_id=obj.laboratory_id,
-                    curie=curie,
-                    curie_prefix=curie_prefix,
-                    pages=xr.get("pages"),
-                    is_obsolete=bool(xr.get("is_obsolete", False)),
+                    mod_id=mod_id,
+                    allele_designation=allele_designation,
                 )
             )
 
-    for mod_id, allele_designation in resolved_alleles:
-        db.add(
-            LaboratoryAlleleDesignationModel(
-                laboratory_id=obj.laboratory_id,
-                mod_id=mod_id,
-                allele_designation=allele_designation,
-            )
-        )
-
-    try:
         db.commit()
     except IntegrityError:
         db.rollback()
@@ -223,7 +226,16 @@ def patch(db: Session, curie_or_laboratory_id: str, patch_dict: Dict[str, Any]) 
             continue
         setattr(obj, field, value)
 
-    db.commit()
+    # e.g. clearing both name and strain_designation violates
+    # ck_laboratory_name_or_strain; surface as 422, not a raw 500.
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Database constraint violation; please verify input and retry.",
+        )
     return {"message": "updated"}
 
 

--- a/agr_literature_service/api/models/laboratory_model.py
+++ b/agr_literature_service/api/models/laboratory_model.py
@@ -1,6 +1,6 @@
 from typing import Dict
 from sqlalchemy import (
-    Column, Integer, String, ARRAY, Boolean,
+    Column, Integer, String, ARRAY, Boolean, CheckConstraint,
 )
 from sqlalchemy.orm import relationship
 from agr_literature_service.api.database.base import Base
@@ -14,12 +14,21 @@ class LaboratoryModel(Base, AuditedModel):
     __tablename__ = "laboratory"
     __versioned__: Dict = {}
 
+    __table_args__ = (
+        # A laboratory must be identifiable by at least a strain_designation or a
+        # name (curie alone is not enough). DB-level backstop for the API validator.
+        CheckConstraint(
+            "strain_designation IS NOT NULL OR name IS NOT NULL",
+            name="ck_laboratory_name_or_strain",
+        ),
+    )
+
     laboratory_id = Column(Integer, primary_key=True, autoincrement=True)
 
     # Allocated from MATI on create (laboratory subdomain -> AGRKB:104), like
-    # reference/resource/person. Indexed for lookup but intentionally not unique
-    # (no DB constraints on Laboratory fields).
-    curie = Column(String(), nullable=True, index=True)
+    # reference/resource/person. Required and unique like those siblings, and
+    # indexed for lookup.
+    curie = Column(String(), nullable=False, unique=True, index=True)
 
     name = Column(String(), nullable=True)
     strain_designation = Column(String(), nullable=True)

--- a/agr_literature_service/api/models/laboratory_model.py
+++ b/agr_literature_service/api/models/laboratory_model.py
@@ -26,9 +26,9 @@ class LaboratoryModel(Base, AuditedModel):
     laboratory_id = Column(Integer, primary_key=True, autoincrement=True)
 
     # Allocated from MATI on create (laboratory subdomain -> AGRKB:104), like
-    # reference/resource/person. Required and unique like those siblings, and
-    # indexed for lookup.
-    curie = Column(String(), nullable=False, unique=True, index=True)
+    # reference/resource/person. Required and unique like those siblings; the
+    # unique constraint's own index serves lookups, so no separate index=True.
+    curie = Column(String(), nullable=False, unique=True)
 
     name = Column(String(), nullable=True)
     strain_designation = Column(String(), nullable=True)

--- a/alembic/versions/20260710_c8d1f2a3b4e5_laboratory_curie_name_constraints.py
+++ b/alembic/versions/20260710_c8d1f2a3b4e5_laboratory_curie_name_constraints.py
@@ -1,0 +1,37 @@
+"""laboratory: require unique curie and a name or strain_designation
+
+Revision ID: c8d1f2a3b4e5
+Revises: b7c3e9f1a2d4
+Create Date: 2026-07-10
+
+The laboratory table was created without DB-level constraints on its identifying
+fields. Bring it in line with reference/resource/person: curie becomes NOT NULL
+and UNIQUE (curie is server-allocated from MATI, so this only makes the existing
+guarantee explicit). Also add a check constraint requiring at least one of
+strain_designation or name, mirroring ck_at_least_one_priority on indexing_priority
+and the API-level validator.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'c8d1f2a3b4e5'
+down_revision = 'b7c3e9f1a2d4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('laboratory', 'curie', existing_type=sa.String(), nullable=False)
+    op.create_unique_constraint('laboratory_curie_key', 'laboratory', ['curie'])
+    op.create_check_constraint(
+        'ck_laboratory_name_or_strain',
+        'laboratory',
+        'strain_designation IS NOT NULL OR name IS NOT NULL',
+    )
+
+
+def downgrade():
+    op.drop_constraint('ck_laboratory_name_or_strain', 'laboratory', type_='check')
+    op.drop_constraint('laboratory_curie_key', 'laboratory', type_='unique')
+    op.alter_column('laboratory', 'curie', existing_type=sa.String(), nullable=True)

--- a/alembic/versions/20260710_c8d1f2a3b4e5_laboratory_curie_name_constraints.py
+++ b/alembic/versions/20260710_c8d1f2a3b4e5_laboratory_curie_name_constraints.py
@@ -29,9 +29,13 @@ def upgrade():
         'laboratory',
         'strain_designation IS NOT NULL OR name IS NOT NULL',
     )
+    # The unique constraint's index serves all curie lookups; drop the now-redundant
+    # non-unique index created with the table.
+    op.drop_index('ix_laboratory_curie', table_name='laboratory')
 
 
 def downgrade():
+    op.create_index('ix_laboratory_curie', 'laboratory', ['curie'])
     op.drop_constraint('ck_laboratory_name_or_strain', 'laboratory', type_='check')
     op.drop_constraint('laboratory_curie_key', 'laboratory', type_='unique')
     op.alter_column('laboratory', 'curie', existing_type=sa.String(), nullable=True)

--- a/alembic/versions/20260710_c8d1f2a3b4e5_laboratory_curie_name_constraints.py
+++ b/alembic/versions/20260710_c8d1f2a3b4e5_laboratory_curie_name_constraints.py
@@ -1,7 +1,7 @@
 """laboratory: require unique curie and a name or strain_designation
 
 Revision ID: c8d1f2a3b4e5
-Revises: b7c3e9f1a2d4
+Revises: 3e8b1a2c9f47
 Create Date: 2026-07-10
 
 The laboratory table was created without DB-level constraints on its identifying
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 
 
 revision = 'c8d1f2a3b4e5'
-down_revision = 'b7c3e9f1a2d4'
+down_revision = '3e8b1a2c9f47'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/20260710_c8d1f2a3b4e5_laboratory_curie_name_constraints.py
+++ b/alembic/versions/20260710_c8d1f2a3b4e5_laboratory_curie_name_constraints.py
@@ -21,7 +21,48 @@ branch_labels = None
 depends_on = None
 
 
+def _guard_existing_data(bind):
+    """Fail fast with an actionable message if any existing laboratory row would
+    violate the constraints added below, instead of aborting mid-DDL on a raw
+    Postgres error. Non-mutating: this only reads."""
+    null_curie = bind.execute(
+        sa.text("SELECT count(*) FROM laboratory WHERE curie IS NULL")
+    ).scalar()
+    dup_curie = bind.execute(
+        sa.text(
+            "SELECT count(*) FROM ("
+            "SELECT curie FROM laboratory GROUP BY curie HAVING count(*) > 1"
+            ") d"
+        )
+    ).scalar()
+    no_name_or_strain = bind.execute(
+        sa.text(
+            "SELECT count(*) FROM laboratory "
+            "WHERE name IS NULL AND strain_designation IS NULL"
+        )
+    ).scalar()
+
+    problems = []
+    if null_curie:
+        problems.append(f"{null_curie} row(s) with NULL curie (blocks NOT NULL)")
+    if dup_curie:
+        problems.append(f"{dup_curie} duplicate curie value(s) (blocks UNIQUE)")
+    if no_name_or_strain:
+        problems.append(
+            f"{no_name_or_strain} row(s) with both name and strain_designation NULL "
+            "(blocks ck_laboratory_name_or_strain)"
+        )
+    if problems:
+        raise RuntimeError(
+            "laboratory table has rows that violate the new constraints: "
+            + "; ".join(problems)
+            + ". Backfill/fix these rows (assign a curie, set a name or "
+            "strain_designation, dedupe curie) before running this migration."
+        )
+
+
 def upgrade():
+    _guard_existing_data(op.get_bind())
     op.alter_column('laboratory', 'curie', existing_type=sa.String(), nullable=False)
     op.create_unique_constraint('laboratory_curie_key', 'laboratory', ['curie'])
     op.create_check_constraint(

--- a/tests/api/test_laboratory.py
+++ b/tests/api/test_laboratory.py
@@ -99,6 +99,17 @@ class TestLaboratory:
             )
             assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+    def test_patch_clearing_name_and_strain_rejected(self, auth_headers, test_laboratory):  # noqa
+        """Clearing both name and strain_designation violates
+        ck_laboratory_name_or_strain; surfaced as 422, not a 500."""
+        with TestClient(app) as client:
+            res = client.patch(
+                f"/laboratory/{test_laboratory.new_laboratory_id}",
+                json={"name": None, "strain_designation": None},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
     def test_bad_status_rejected(self, auth_headers):  # noqa
         with TestClient(app) as client:
             res = client.post(

--- a/tests/api/test_laboratory.py
+++ b/tests/api/test_laboratory.py
@@ -87,6 +87,18 @@ class TestLaboratory:
             res = client.post("/laboratory/", json={}, headers=auth_headers)
             assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+    def test_name_or_strain_required(self, db, auth_headers):  # noqa
+        """A laboratory with a substantive field but no name/strain_designation is
+        rejected by the ck_laboratory_name_or_strain check constraint (surfaced as
+        422 by the CRUD layer)."""
+        with TestClient(app) as client:
+            res = client.post(
+                "/laboratory/",
+                json={"institution": ["Caltech"]},
+                headers=auth_headers,
+            )
+            assert res.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
     def test_bad_status_rejected(self, auth_headers):  # noqa
         with TestClient(app) as client:
             res = client.post(

--- a/tests/api/test_laboratory_allele_designation.py
+++ b/tests/api/test_laboratory_allele_designation.py
@@ -23,7 +23,7 @@ AlleleTestData = namedtuple(
 
 @pytest.fixture
 def seeded_lab_and_mod(db):  # noqa
-    lab = LaboratoryModel(name="Allele Lab", status="active", lab_is_open=False)
+    lab = LaboratoryModel(curie="AGRKB:104test-allele", name="Allele Lab", status="active", lab_is_open=False)
     db.add(lab)
     mod = db.query(ModModel).filter(ModModel.abbreviation == "WB").one_or_none()
     if mod is None:

--- a/tests/api/test_laboratory_cross_reference.py
+++ b/tests/api/test_laboratory_cross_reference.py
@@ -19,7 +19,7 @@ XrefTestData = namedtuple(
 
 @pytest.fixture
 def seeded_laboratory(db):  # noqa
-    lab = LaboratoryModel(name="Xref Lab", status="active", lab_is_open=False)
+    lab = LaboratoryModel(curie="AGRKB:104test-xref", name="Xref Lab", status="active", lab_is_open=False)
     db.add(lab)
     db.commit()
     db.refresh(lab)

--- a/tests/api/test_laboratory_person.py
+++ b/tests/api/test_laboratory_person.py
@@ -24,7 +24,8 @@ LabPersonTestData = namedtuple(
 @pytest.fixture
 def seeded_lab_and_person(db):  # noqa
     lab = LaboratoryModel(
-        name="People Lab", strain_designation="PL", status="active", lab_is_open=False
+        curie="AGRKB:104test-people", name="People Lab", strain_designation="PL",
+        status="active", lab_is_open=False
     )
     person = PersonModel(display_name="Lab Member", curie="AGRKB:test-lab-person")
     db.add(lab)


### PR DESCRIPTION
Bring the laboratory table in line with reference/resource/person: curie becomes NOT NULL and UNIQUE (it is already server-allocated from MATI). Add a check constraint ck_laboratory_name_or_strain requiring at least one of strain_designation or name, mirroring ck_at_least_one_priority on indexing_priority and the API-level validator.

- model: curie nullable=False, unique=True; add __table_args__ CheckConstraint
- alembic: new revision c8d1f2a3b4e5 (alter curie NOT NULL, unique, check)
- tests: add test_name_or_strain_required (institution-only POST -> 422)