### PR TITLE
fix(oneoff): classify workflow_tag duplicates and missing xrefs in JSON loader

### DIFF
--- a/agr_literature_service/lit_processing/oneoff_scripts/load_curation_status_from_json.py
+++ b/agr_literature_service/lit_processing/oneoff_scripts/load_curation_status_from_json.py
@@ -62,6 +62,13 @@ def is_already_present(response):
     reason="duplicate". These are not real failures: the data is present. Other
     409 reasons (opposite_negation, different_creator) are genuine conflicts and
     are treated as failures.
+
+    The workflow_tag endpoint signals an already-present record differently: it
+    proactively detects a duplicate (same reference/mod/tag) and returns 422 with
+    a plain-string detail ending "can not create duplicate record." That is also a
+    record that is already present, not a real failure. The match is on the
+    specific message so the endpoint's other genuine 422s (e.g. "Reference ...
+    does not exist", "Mod ... does not exist") stay classified as errors.
     """
     if response.status_code == 200:
         return True
@@ -72,14 +79,42 @@ def is_already_present(response):
             return False
         if isinstance(detail, dict) and detail.get("reason") == "duplicate":
             return True
+    if response.status_code == 422:
+        try:
+            detail = response.json().get("detail")
+        except (ValueError, AttributeError):
+            return False
+        if isinstance(detail, str) and "can not create duplicate record" in detail:
+            return True
     return False
 
 
-def write_output_files(datafile, metadata, success_records, already_present_records, failed_records):
+def is_missing_xref(response):
+    """Return True if the record's reference_curie has no cross_reference row.
+
+    The workflow_tag endpoint resolves reference_curie via normalize_reference_curie,
+    which returns 404 "The XREF <curie> is not in the cross_reference table" when the
+    reference is not in the database at all. This is a genuine data gap rather than a
+    transient failure or a duplicate, so these records are segregated into their own
+    output file instead of the general error bucket.
+    """
+    if response.status_code == 404:
+        try:
+            detail = response.json().get("detail")
+        except (ValueError, AttributeError):
+            return False
+        if isinstance(detail, str) and "is not in the cross_reference table" in detail:
+            return True
+    return False
+
+
+def write_output_files(datafile, metadata, success_records, already_present_records,
+                       failed_records, missing_xref_records):
     base, _ = os.path.splitext(datafile)
     for suffix, records in [("_success.json", success_records),
                             ("_already_present.json", already_present_records),
-                            ("_failed.json", failed_records)]:
+                            ("_failed.json", failed_records),
+                            ("_missing_xref.json", missing_xref_records)]:
         output_path = base + suffix
         output_data = {"metaData": metadata, "data": records}
         with open(output_path, 'w') as f:
@@ -107,9 +142,11 @@ def load_data(datafile):
 
     success_count = 0
     already_present_count = 0
+    missing_xref_count = 0
     error_count = 0
     success_records = []
     already_present_records = []
+    missing_xref_records = []
     failed_records = []
     count = 0
     for i, record in enumerate(records, start=1):
@@ -122,6 +159,9 @@ def load_data(datafile):
             elif is_already_present(response):
                 already_present_count += 1
                 already_present_records.append(record)
+            elif is_missing_xref(response):
+                missing_xref_count += 1
+                missing_xref_records.append(record)
             else:
                 error_count += 1
                 failed_records.append(record)
@@ -135,15 +175,19 @@ def load_data(datafile):
         if count > 20 and success_count * 3 < error_count:
             rate = (success_count / (error_count + success_count)) * 100
             logger.error(f"STOPPING TOO MANY ERRORS: SUCCESS RATE {rate}% last and {i}th record{record['reference_curie']} ")
-            write_output_files(datafile, metadata, success_records, already_present_records, failed_records)
+            write_output_files(datafile, metadata, success_records, already_present_records,
+                               failed_records, missing_xref_records)
             exit(-1)
         if i % 500 == 0:
             logger.info(f"Progress: {i}/{total} (success={success_count}, "
-                        f"already_present={already_present_count}, errors={error_count})")
+                        f"already_present={already_present_count}, "
+                        f"missing_xref={missing_xref_count}, errors={error_count})")
 
-    write_output_files(datafile, metadata, success_records, already_present_records, failed_records)
+    write_output_files(datafile, metadata, success_records, already_present_records,
+                       failed_records, missing_xref_records)
     logger.info(f"DONE! Total={total}, Success={success_count}, "
-                f"AlreadyPresent={already_present_count}, Errors={error_count}")
+                f"AlreadyPresent={already_present_count}, "
+                f"MissingXref={missing_xref_count}, Errors={error_count}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

When re-running `load_curation_status_from_json.py` against a `workflow_tag` file, records that already exist were counted as **errors** rather than *already-present*, inflating `error_count` and risking a false-positive **"STOPPING TOO MANY ERRORS"** abort. Investigation showed the "errors" were two distinct kinds:

1. **Genuine duplicates** — the workflow_tag create endpoint proactively detects an existing `reference_id + mod_id + workflow_tag_id` and returns **`422`** with detail `"... already exist ... can not create duplicate record."` (`workflow_tag_crud.py:639-649`). The loader's `is_already_present()` only recognised the *topic_entity_tag* signals (`200`, or `409 reason=duplicate`), so this 422 was mis-bucketed as an error.
2. **Missing cross-reference** — `normalize_reference_curie()` returns **`404`** `"The XREF <curie> is not in the cross_reference table"` when a `reference_curie` (e.g. `FB:FBrf0102842`) has no active `cross_reference` row (`reference_utils.py:144-166`). This is a real data gap, not a duplicate.

## Changes

Single file — `agr_literature_service/lit_processing/oneoff_scripts/load_curation_status_from_json.py`:

- **`is_already_present()`**: also treat `422` with `"can not create duplicate record"` as already-present, matched on the specific message so genuine 422s ("Reference … does not exist", "Mod … does not exist") stay errors.
- **New `is_missing_xref()`**: matches `404` + `"is not in the cross_reference table"`.
- **New `missing_xref` bucket** written to a dedicated `*_missing_xref.json` file; the abort guard stays driven by genuine `error_count` only; `missing_xref` is reported in the progress and `DONE!` summary lines.

The `topic_entity_tag` path is unaffected (its 200/409 handling is untouched; the new 422/404 message matches are workflow_tag-specific).

## Verification

- ✅ `flake8` (max-line 120): clean
- ✅ `mypy --config-file mypy.config`: `Success: no issues found`
- ✅ 11 classification assertions against the real functions: 422-duplicate → already_present; 422 ref/mod-missing → still error; 404-xref → missing_xref (not already_present); 200 → success; 500 → neither; non-JSON bodies handled defensively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)