### PR TITLE
refactor(laboratory): split by_name_or_strain_designation into two en…

### DIFF
--- a/agr_literature_service/api/crud/laboratory_crud.py
+++ b/agr_literature_service/api/crud/laboratory_crud.py
@@ -261,22 +261,10 @@ def show(db: Session, curie_or_laboratory_id: str) -> LaboratoryModel:
     return obj
 
 
-def find_by_name_or_strain_designation(db: Session, query: str) -> List[LaboratoryModel]:
-    """Resolve a free-text laboratory lookup with a fixed precedence:
-
-    1. exact, case-insensitive match on strain_designation (a short code) — return
-       all such labs (normally one; more only if a code is shared);
-    2. otherwise a case-insensitive substring match on name, ordered by name;
-    3. otherwise an empty list.
-
-    Matching strain exactly (never as a substring) keeps a short code from
-    polluting name results. Each result eager-loads the same joins as show().
-    """
-    query = (query or "").strip()
-    if not query:
-        return []
-
-    options = (
+def _show_load_options():
+    """Eager-load options matching show(): cross_references, allele_designations
+    (+ their mod), and lab_persons (+ their person)."""
+    return (
         selectinload(LaboratoryModel.cross_references),
         selectinload(LaboratoryModel.allele_designations).selectinload(
             LaboratoryAlleleDesignationModel.mod
@@ -284,20 +272,34 @@ def find_by_name_or_strain_designation(db: Session, query: str) -> List[Laborato
         selectinload(LaboratoryModel.lab_persons).selectinload(LaboratoryPersonModel.person),
     )
 
-    strain_matches = (
+
+def find_by_name(db: Session, query: str) -> List[LaboratoryModel]:
+    """Case-insensitive substring match on laboratory name, ordered by name."""
+    query = (query or "").strip()
+    if not query:
+        return []
+    return (
         db.query(LaboratoryModel)
-        .options(*options)
-        .filter(func.lower(LaboratoryModel.strain_designation) == query.lower())
+        .options(*_show_load_options())
+        .filter(LaboratoryModel.name.ilike(f"%{query}%"))
         .order_by(LaboratoryModel.name.asc())
         .all()
     )
-    if strain_matches:
-        return strain_matches
 
+
+def find_by_strain_designation(db: Session, query: str) -> List[LaboratoryModel]:
+    """Exact, case-insensitive match on strain_designation, ordered by name.
+
+    A strain designation is a short code, so it is matched exactly (never as a
+    substring). Normally one lab; more only when a code is shared.
+    """
+    query = (query or "").strip()
+    if not query:
+        return []
     return (
         db.query(LaboratoryModel)
-        .options(*options)
-        .filter(LaboratoryModel.name.ilike(f"%{query}%"))
+        .options(*_show_load_options())
+        .filter(func.lower(LaboratoryModel.strain_designation) == query.lower())
         .order_by(LaboratoryModel.name.asc())
         .all()
     )

--- a/agr_literature_service/api/routers/laboratory_router.py
+++ b/agr_literature_service/api/routers/laboratory_router.py
@@ -61,23 +61,33 @@ def get_by_laboratory_cross_reference(
     return laboratory_crud.show(db, str(lcr.laboratory_id))
 
 
-# Free-text lookup — declared BEFORE the catch-all /{curie_or_laboratory_id}.
+# Free-text lookups — declared BEFORE the catch-all /{curie_or_laboratory_id}.
 @router.get(
-    "/by_name_or_strain_designation",
+    "/by_name",
     response_model=List[LaboratorySchemaShow],
     status_code=status.HTTP_200_OK,
 )
-def get_by_name_or_strain_designation(
+def get_by_name(
     query: str,
     user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
     db: Session = db_session,
 ):
-    """Find laboratories by an exact strain_designation code or a name substring.
+    """Find laboratories by a case-insensitive substring match on name."""
+    return laboratory_crud.find_by_name(db, query)
 
-    Precedence: an exact (case-insensitive) strain_designation match wins; otherwise
-    a case-insensitive substring match on name. Returns a (possibly empty) list.
-    """
-    return laboratory_crud.find_by_name_or_strain_designation(db, query)
+
+@router.get(
+    "/by_strain_designation",
+    response_model=List[LaboratorySchemaShow],
+    status_code=status.HTTP_200_OK,
+)
+def get_by_strain_designation(
+    query: str,
+    user: Optional[Dict[str, Any]] = Security(get_authenticated_user),
+    db: Session = db_session,
+):
+    """Find laboratories by an exact (case-insensitive) strain_designation code."""
+    return laboratory_crud.find_by_strain_designation(db, query)
 
 
 @router.delete("/{curie_or_laboratory_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/tests/api/test_laboratory.py
+++ b/tests/api/test_laboratory.py
@@ -237,7 +237,7 @@ class TestLaboratory:
                 headers=auth_headers,
             )
             res = client.get(
-                "/laboratory/by_name_or_strain_designation", params={"query": "QX"}, headers=auth_headers
+                "/laboratory/by_strain_designation", params={"query": "QX"}, headers=auth_headers
             )
             assert res.status_code == status.HTTP_200_OK
             rows = res.json()
@@ -245,7 +245,7 @@ class TestLaboratory:
             assert rows[0]["strain_designation"] == "QX"
             # case-insensitive
             res2 = client.get(
-                "/laboratory/by_name_or_strain_designation", params={"query": "qx"}, headers=auth_headers
+                "/laboratory/by_strain_designation", params={"query": "qx"}, headers=auth_headers
             )
             assert len(res2.json()) == 1
 
@@ -259,7 +259,7 @@ class TestLaboratory:
                     headers=auth_headers,
                 )
             res = client.get(
-                "/laboratory/by_name_or_strain_designation", params={"query": "SHX"}, headers=auth_headers
+                "/laboratory/by_strain_designation", params={"query": "SHX"}, headers=auth_headers
             )
             assert res.status_code == status.HTTP_200_OK
             assert len(res.json()) == 2
@@ -268,43 +268,54 @@ class TestLaboratory:
         with TestClient(app) as client:
             client.post("/laboratory/", json={"name": "Unique Kappa Lab UNIQK"}, headers=auth_headers)
             res = client.get(
-                "/laboratory/by_name_or_strain_designation", params={"query": "UNIQK"}, headers=auth_headers
+                "/laboratory/by_name", params={"query": "UNIQK"}, headers=auth_headers
             )
             assert len(res.json()) == 1
 
             client.post("/laboratory/", json={"name": "Multi MMTOKEN One"}, headers=auth_headers)
             client.post("/laboratory/", json={"name": "Multi MMTOKEN Two"}, headers=auth_headers)
             res2 = client.get(
-                "/laboratory/by_name_or_strain_designation", params={"query": "MMTOKEN"}, headers=auth_headers
+                "/laboratory/by_name", params={"query": "MMTOKEN"}, headers=auth_headers
             )
             assert len(res2.json()) == 2
 
-    def test_strain_exact_short_circuits_name(self, auth_headers):  # noqa
-        # One lab has the query as its strain code; another merely contains it in
-        # its name. The exact-strain match wins and the name match is not returned.
+    def test_name_and_strain_endpoints_are_separate(self, auth_headers):  # noqa
+        # One lab has the query as its strain code (name does NOT contain it);
+        # another merely contains it in its name. The two endpoints keep the
+        # lookups cleanly separated: by_strain_designation returns only the
+        # exact-strain lab, by_name returns only the name-containing lab.
         with TestClient(app) as client:
             client.post(
                 "/laboratory/",
-                json={"name": "Has strain code SCQ", "strain_designation": "SCQ"},
+                json={"name": "Has strain code only", "strain_designation": "SCQ"},
                 headers=auth_headers,
             )
             client.post("/laboratory/", json={"name": "Name contains SCQ here"}, headers=auth_headers)
-            res = client.get(
-                "/laboratory/by_name_or_strain_designation", params={"query": "SCQ"}, headers=auth_headers
+
+            strain_res = client.get(
+                "/laboratory/by_strain_designation", params={"query": "SCQ"}, headers=auth_headers
             )
-            rows = res.json()
-            assert len(rows) == 1
-            assert rows[0]["strain_designation"] == "SCQ"
+            strain_rows = strain_res.json()
+            assert len(strain_rows) == 1
+            assert strain_rows[0]["strain_designation"] == "SCQ"
+
+            name_res = client.get(
+                "/laboratory/by_name", params={"query": "SCQ"}, headers=auth_headers
+            )
+            name_rows = name_res.json()
+            assert len(name_rows) == 1
+            assert name_rows[0]["name"] == "Name contains SCQ here"
 
     def test_find_no_match_empty_list(self, auth_headers):  # noqa
         with TestClient(app) as client:
-            res = client.get(
-                "/laboratory/by_name_or_strain_designation",
-                params={"query": "NOSUCHLABTOKENXYZ"},
-                headers=auth_headers,
-            )
-            assert res.status_code == status.HTTP_200_OK
-            assert res.json() == []
+            for endpoint in ("/laboratory/by_name", "/laboratory/by_strain_designation"):
+                res = client.get(
+                    endpoint,
+                    params={"query": "NOSUCHLABTOKENXYZ"},
+                    headers=auth_headers,
+                )
+                assert res.status_code == status.HTTP_200_OK
+                assert res.json() == []
 
     def test_find_results_include_joins(self, db, auth_headers):  # noqa
         mod = db.query(ModModel).filter(ModModel.abbreviation == "WB").one_or_none()
@@ -320,7 +331,7 @@ class TestLaboratory:
             }
             client.post("/laboratory/", json=payload, headers=auth_headers)
             res = client.get(
-                "/laboratory/by_name_or_strain_designation", params={"query": "JNQ"}, headers=auth_headers
+                "/laboratory/by_strain_designation", params={"query": "JNQ"}, headers=auth_headers
             )
             rows = res.json()
             assert len(rows) == 1


### PR DESCRIPTION
…dpoints

The combined /laboratory/by_name_or_strain_designation endpoint conflated a name substring search with a strain-code lookup behind one query param. Since strain designations are short (often two-letter) codes, folding both lookups together was confusing and error-prone.

Replace it with two purpose-built endpoints:
- GET /laboratory/by_name — case-insensitive substring match on name
- GET /laboratory/by_strain_designation — exact case-insensitive strain match

Factor the shared eager-load joins into _show_load_options() and update tests to cover the two endpoints, including that the lookups stay cleanly separated.