### PR TITLE
add first pass curation workflow tags to Workflow facet…

### DIFF
--- a/agr_literature_service/api/crud/search_crud.py
+++ b/agr_literature_service/api/crud/search_crud.py
@@ -44,6 +44,7 @@ entity_extraction_root_ids = ["ATP:0000172"]
 manual_indexing_root_ids = ["ATP:0000273"]
 curation_classification_root_ids = ["ATP:0000311", "ATP:0000210"]
 community_curation_classification_root_ids = ["ATP:0000235"]
+first_pass_curation_root_ids = ["ATP:0000329"]
 email_extraction_root_ids = ["ATP:0000354"]
 
 WORKFLOW_FACETS = [
@@ -53,6 +54,7 @@ WORKFLOW_FACETS = [
     "reference_classification",
     "curation_classification",
     "community_curation",
+    "first_pass_curation",
     "email_extraction"
 ]
 
@@ -848,6 +850,7 @@ def process_workflow_tags_aggregations(res, wft_mod_abbreviations):  # pragma: n
         "manual_indexing": get_atp_ids(manual_indexing_root_ids),
         "curation_classification": get_atp_ids(curation_classification_root_ids),
         "community_curation": get_atp_ids(community_curation_classification_root_ids),
+        "first_pass_curation": get_atp_ids(first_pass_curation_root_ids),
         "email_extraction": get_atp_ids(email_extraction_root_ids)
     }
 


### PR DESCRIPTION
… (SCRUM-6287)

Add the "first pass curation" (ATP:0000329) process as a new Workflow facet parent so FB curators can find papers by their first-pass and community curation manual workflow tags. Descendant status tags (needed, in progress, blocked, finished, TBD) are expanded via get_atp_ids.