### PR TITLE
scope confidence-level TET exclusion to the selected topic

### DIFF
--- a/agr_literature_service/api/crud/search_crud.py
+++ b/agr_literature_service/api/crud/search_crud.py
@@ -625,14 +625,16 @@ def search_references(
         date_created=date_created,
     )
 
-    # Remove empty filter if no facets/dates were added. A standalone source method / SEA
-    # exclusion adds a top-level must_not nested clause, so keep the filter in that case.
+    # Remove empty filter if no facets/dates were added. A standalone confidence level /
+    # source method / SEA exclusion adds a top-level must_not nested clause, so keep the
+    # filter in that case.
     has_tet_whole_ref_negation = bool(
         tet_nested_facets_values
         and tet_nested_facets_values.get("tet_facets_negative_values")
         and any(
             tet_nested_facets_values["tet_facets_negative_values"][0].get(k)
             for k in (
+                "topic_entity_tags.confidence_level.keyword",
                 "topic_entity_tags.source_method.keyword",
                 "topic_entity_tags.source_evidence_assertion.keyword",
             )
@@ -1004,32 +1006,57 @@ def add_tet_facets_values(es_body, tet_nested_facets_values, apply_to_single_tet
         negated = tet_nested_facets_values["tet_facets_negative_values"][0]
         if "must" not in es_body["query"]["bool"]["filter"]["bool"]:
             es_body["query"]["bool"]["filter"]["bool"]["must"] = []
-        # Confidence level exclusion: applied as must_not within each positive nested tag query
-        for level in negated.get("topic_entity_tags.confidence_level.keyword", []):
-            levels.append({"term": {"topic_entity_tags.confidence_level.keyword": level}})
+
+        must_not_clauses = []
+
+        # Confidence level exclusion: topic-scoped whole-reference semantics. Drop a reference
+        # if it has a tag that matches the selected topic/entity AND carries an excluded
+        # confidence level (e.g. NEG). The negated level is combined with the positive facet's
+        # identity terms in ONE nested clause, so a NEG tag on a *different* topic does not
+        # remove the reference. When no positive TET facet is selected the exclusion falls back
+        # to any tag with the excluded level. (Previously this was a must_not *inside* the
+        # positive nested query, which kept a reference as long as one matching tag was not NEG
+        # -- letting through references that had a NEG tag for the selected topic.)
+        negated_levels = negated.get("topic_entity_tags.confidence_level.keyword", [])
+        if negated_levels:
+            level_term = {"terms": {"topic_entity_tags.confidence_level.keyword": negated_levels}}
+            scopes = [
+                terms for terms in (
+                    _positive_scope_terms(f)
+                    for f in tet_nested_facets_values.get("tet_facets_values", [])
+                ) if terms
+            ] or [[]]
+            for scope in scopes:
+                must_not_clauses.append({
+                    "nested": {
+                        "path": "topic_entity_tags",
+                        "query": {"bool": {"must": scope + [level_term]}},
+                    }
+                })
 
         # Source method / source evidence assertion exclusion: whole-reference semantics --
         # drop a reference if ANY of its topic_entity_tags matches an excluded value.
-        whole_ref_negations = []
+        source_negations = []
         for value in negated.get("topic_entity_tags.source_method.keyword", []):
-            whole_ref_negations.append(("topic_entity_tags.source_method.keyword", value))
+            source_negations.append(("topic_entity_tags.source_method.keyword", value))
         for value in negated.get("topic_entity_tags.source_evidence_assertion.keyword", []):
             field = "topic_entity_tags.source_evidence_assertion.keyword"
             # Remap SEA group if needed (mirror the positive remap in add_nested_query)
             if value.upper() in ("ECO:0007669", "ECO:0006155"):
                 field = "topic_entity_tags.source_evidence_assertion_group.keyword"
-            whole_ref_negations.append((field, value))
+            source_negations.append((field, value))
+        for field, value in source_negations:
+            must_not_clauses.append({
+                "nested": {
+                    "path": "topic_entity_tags",
+                    "query": {"bool": {"must": [{"term": {field: value}}]}},
+                }
+            })
 
-        if whole_ref_negations:
+        if must_not_clauses:
             if "must_not" not in es_body["query"]["bool"]["filter"]["bool"]:
                 es_body["query"]["bool"]["filter"]["bool"]["must_not"] = []
-            for field, value in whole_ref_negations:
-                es_body["query"]["bool"]["filter"]["bool"]["must_not"].append({
-                    "nested": {
-                        "path": "topic_entity_tags",
-                        "query": {"bool": {"must": [{"term": {field: value}}]}},
-                    }
-                })
+            es_body["query"]["bool"]["filter"]["bool"]["must_not"].extend(must_not_clauses)
 
     for facet_name_value_dict in tet_nested_facets_values.get("tet_facets_values", []):
         add_nested_query(es_body, facet_name_value_dict, levels)
@@ -1039,6 +1066,25 @@ def add_tet_facets_values(es_body, tet_nested_facets_values, apply_to_single_tet
                 tet_facet_values[key] = facet_value
 
     return tet_facet_values
+
+
+def _positive_scope_terms(facet_name_values_dict):  # pragma: no cover
+    """The tag-identity terms of a positive TET facet selection (topic / entity /
+    source), used to scope a confidence-level exclusion to the same tag. The
+    confidence_score range is skipped: it constrains which tags match positively,
+    but a paper's negative tag should still remove it regardless of that slider."""
+    terms = []
+    for facet_name, facet_values in facet_name_values_dict.items():
+        if facet_name == "topic_entity_tags.confidence_score":
+            continue
+        name = facet_name
+        # Remap SEA group if needed (mirror the positive remap in add_nested_query)
+        if name == "topic_entity_tags.source_evidence_assertion.keyword":
+            vals = facet_values if isinstance(facet_values, (list, tuple)) else [facet_values]
+            if any(str(v).upper() in ("ECO:0007669", "ECO:0006155") for v in vals):
+                name = "topic_entity_tags.source_evidence_assertion_group.keyword"
+        terms.append({"term": {name: facet_values}})
+    return terms
 
 
 def add_nested_query(es_body, facet_name_values_dict, levels):  # pragma: no cover

--- a/tests/api/test_tet_facets_negation.py
+++ b/tests/api/test_tet_facets_negation.py
@@ -3,8 +3,12 @@
 These exercise ``add_tet_facets_values`` directly against an in-memory ``es_body``
 dict, so they need neither Elasticsearch nor a database. They cover the
 source-method / source-evidence-assertion *whole-reference* exclusion (top-level
-``must_not`` nested clauses) added for SCRUM-5899, alongside the unchanged
-confidence-level exclusion (``must_not`` within the positive nested query).
+``must_not`` nested clauses) added for SCRUM-5899, alongside the confidence-level
+exclusion which is *topic-scoped*: the excluded level is combined with the selected
+topic/entity terms in one nested ``must_not`` clause, so a reference is dropped only
+when it has a tag that is both the selected topic AND the excluded level (e.g. NEG).
+A NEG tag on a different topic does not remove the reference. With no positive TET
+facet selected the exclusion falls back to any tag carrying the excluded level.
 """
 from agr_literature_service.api.crud.search_crud import (
     add_tet_facets_values,
@@ -98,9 +102,11 @@ class TestTetFacetsNegation:
         )
         assert _filter_bool(es_body).get("must_not", []) == []
 
-    def test_confidence_level_negation_stays_within_positive_nested_query(self):
-        """Confidence-level exclusion is per-matching-tag: a ``must_not`` *inside* the
-        positive nested query, never a top-level whole-reference clause."""
+    def test_confidence_level_negation_is_topic_scoped(self):
+        """With a topic selected, confidence-level exclusion is topic-scoped: a
+        single top-level ``must_not`` nested clause that requires BOTH the selected
+        topic and the excluded level on one tag. It does not constrain the positive
+        nested query per-tag, and a NEG tag on another topic won't drop the paper."""
         es_body = _new_es_body()
         add_tet_facets_values(
             es_body,
@@ -115,12 +121,58 @@ class TestTetFacetsNegation:
             apply_to_single_tet=True,
         )
         filter_bool = _filter_bool(es_body)
-        # No top-level must_not for confidence level
-        assert filter_bool.get("must_not", []) == []
-        # The positive nested query carries the confidence-level must_not
+        # Topic-scoped confidence-level exclusion at the top level
+        assert filter_bool.get("must_not", []) == [
+            {
+                "nested": {
+                    "path": "topic_entity_tags",
+                    "query": {
+                        "bool": {
+                            "must": [
+                                {"term": {"topic_entity_tags.topic.keyword": "ATP:0000005"}},
+                                {"terms": {"topic_entity_tags.confidence_level.keyword": ["NEG"]}},
+                            ]
+                        }
+                    },
+                }
+            }
+        ]
+        # The positive nested query no longer carries a confidence-level must_not
         nested = filter_bool["must"][-1]["nested"]["query"]["bool"]
         assert nested["must"] == [{"term": {"topic_entity_tags.topic.keyword": "ATP:0000005"}}]
-        assert nested["must_not"] == [{"term": {"topic_entity_tags.confidence_level.keyword": "NEG"}}]
+        assert nested["must_not"] == []
+
+    def test_confidence_level_negation_without_positive_facet(self):
+        """A standalone confidence-level exclusion (no positive TET facet selected)
+        falls back to dropping any reference with a tag at the excluded level -- this
+        was the reported bug where excluding NEG left every negative-tagged paper in
+        the results and emitted no filter at all."""
+        es_body = _new_es_body()
+        add_tet_facets_values(
+            es_body,
+            {
+                "tet_facets_values": [],
+                "tet_facets_negative_values": [
+                    {"topic_entity_tags.confidence_level.keyword": ["NEG"]}
+                ],
+            },
+            apply_to_single_tet=False,
+        )
+        must_not = _filter_bool(es_body).get("must_not", [])
+        assert must_not == [
+            {
+                "nested": {
+                    "path": "topic_entity_tags",
+                    "query": {
+                        "bool": {
+                            "must": [
+                                {"terms": {"topic_entity_tags.confidence_level.keyword": ["NEG"]}}
+                            ]
+                        }
+                    },
+                }
+            }
+        ]
 
     def test_multiple_source_facets_produce_independent_must_not_clauses(self):
         """A single negated object with several source/SEA keys must yield one
@@ -172,12 +224,31 @@ class TestTetFacetsNegation:
             apply_to_single_tet=True,
         )
         filter_bool = _filter_bool(es_body)
-        # Whole-reference source-method exclusion at the top level
-        sm_terms = [
-            clause["nested"]["query"]["bool"]["must"][0]["term"]
-            for clause in filter_bool.get("must_not", [])
-        ]
-        assert {"topic_entity_tags.source_method.keyword": "ACKnowledge"} in sm_terms
-        # Confidence level still nested within the positive query
+        must_not = filter_bool.get("must_not", [])
+        # Confidence-level exclusion is topic-scoped: one clause requiring BOTH the
+        # selected topic and the excluded level on a single tag.
+        conf_clause = {
+            "nested": {
+                "path": "topic_entity_tags",
+                "query": {
+                    "bool": {
+                        "must": [
+                            {"term": {"topic_entity_tags.topic.keyword": "ATP:0000005"}},
+                            {"terms": {"topic_entity_tags.confidence_level.keyword": ["NEG"]}},
+                        ]
+                    }
+                },
+            }
+        }
+        assert conf_clause in must_not
+        # Source-method exclusion stays whole-reference (single-field clause).
+        sm_clause = {
+            "nested": {
+                "path": "topic_entity_tags",
+                "query": {"bool": {"must": [{"term": {"topic_entity_tags.source_method.keyword": "ACKnowledge"}}]}},
+            }
+        }
+        assert sm_clause in must_not
+        # The positive nested query no longer carries a confidence-level must_not
         nested = filter_bool["must"][-1]["nested"]["query"]["bool"]
-        assert nested["must_not"] == [{"term": {"topic_entity_tags.confidence_level.keyword": "NEG"}}]
+        assert nested["must_not"] == []


### PR DESCRIPTION
Excluding a confidence level (e.g. NEG) previously attached a must_not only inside positive nested TET queries, so it did nothing when no positive TET facet was selected (the filter block was also dropped because the whole-ref guard ignored confidence_level), and it kept references that had a NEG tag for the selected topic as long as one matching tag was not NEG.

Emit the exclusion as a top-level nested must_not that combines the excluded level with the selected topic/entity terms, so a reference is dropped only when it has a tag that is both the selected topic AND the excluded level. A NEG tag on a different topic no longer removes the reference (a plain whole-reference negation dropped almost everything, since NEG tags are ubiquitous across topics). The confidence_score range is excluded from the scope, and with no positive TET facet the exclusion falls back to any tag at that level. Source method / SEA exclusions stay global whole-reference. Include confidence_level in the has_tet_whole_ref_negation guard so a standalone exclusion keeps its filter. Tests updated to the topic-scoped semantics.