### PR TITLE
fix(ml_model): return 404 when model S3 file is missing on download

### DIFF
--- a/agr_literature_service/api/crud/ml_model_crud.py
+++ b/agr_literature_service/api/crud/ml_model_crud.py
@@ -220,7 +220,15 @@ def download_model_file(db: Session, task_type: str, mod_abbreviation: str, topi
     object_key = f"{folder}/{str(model.version_num)}.gz"
     file_name_gzipped = f"{str(model.version_num)}.gz"
     file_name = f"{str(model.version_num)}.{model.file_extension}"
-    download_file_from_s3(file_name_gzipped, bucketname="agr-literature", s3_file_location=object_key)
+    downloaded = download_file_from_s3(file_name_gzipped, bucketname="agr-literature", s3_file_location=object_key)
+    if not downloaded or not os.path.exists(file_name_gzipped):
+        # The DB record exists but the S3 object is missing (e.g. it was removed
+        # via destroy(), which keeps the row). Return a 404 instead of letting
+        # gzip.open raise an unhandled FileNotFoundError (HTTP 500).
+        raise HTTPException(
+            status_code=404,
+            detail=f"Model file not found in storage for task_type='{task_type}', "
+                   f"mod='{mod_abbreviation}', topic='{topic}', version={model.version_num}")
     with gzip.open(file_name_gzipped, 'rb') as f_in, open(file_name, 'wb') as f_out:
         shutil.copyfileobj(f_in, f_out)
     os.remove(file_name_gzipped)

--- a/tests/api/test_ml_model.py
+++ b/tests/api/test_ml_model.py
@@ -4,9 +4,10 @@ import os
 import tempfile
 
 import pytest
-from fastapi import status
+from fastapi import status, HTTPException
 from starlette.testclient import TestClient
 
+from agr_literature_service.api.crud import ml_model_crud
 from agr_literature_service.api.main import app
 from agr_literature_service.api.models import MLModel, ModModel
 from .fixtures import auth_headers  # noqa
@@ -239,3 +240,32 @@ class TestMLModel:
             assert response.json()["task_type"] == "document_classification"
             assert response.json()["version_num"] == prod.version_num
             assert response.json()["model_type"] == prod.model_type
+
+
+def test_download_model_missing_s3_file_returns_404(db, monkeypatch):  # noqa
+    # A DB record can exist without its S3 .gz object (e.g. after destroy(),
+    # which deletes the S3 file but keeps the row). download_file_from_s3
+    # swallows the ClientError and returns False without writing the local
+    # file. download_model_file must then raise a 404, not let gzip.open blow
+    # up with an unhandled FileNotFoundError (which surfaces as an HTTP 500).
+    mod = ModModel(abbreviation="MLT", short_name="MLT", full_name="ML test mod")
+    db.add(mod)
+    db.commit()
+    model = MLModel(mod_id=mod.mod_id,
+                    version_num=99,
+                    topic="ATP:0000110",
+                    production=False,
+                    task_type="biocuration_entity_extraction",
+                    file_extension="joblib",
+                    model_type="no_file")
+    db.add(model)
+    db.commit()
+
+    monkeypatch.setattr(
+        "agr_literature_service.api.crud.ml_model_crud.download_file_from_s3",
+        lambda *args, **kwargs: False)
+
+    with pytest.raises(HTTPException) as exc_info:
+        ml_model_crud.download_model_file(
+            db, "biocuration_entity_extraction", "MLT", "ATP:0000110", "99")
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Problem

Downloading an ML model returned an unhandled **HTTP 500** when the DB record existed but its S3 `.gz` object was missing, e.g.:

```
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url:
https://literature-rest.alliancegenome.org/ml_model/download/biocuration_entity_extraction/WB/ATP:0000110
```

## Root cause

`download_model_file` in `agr_literature_service/api/crud/ml_model_crud.py` ignored the return value of `download_file_from_s3`:

```python
download_file_from_s3(file_name_gzipped, ...)   # returns False on failure — ignored
with gzip.open(file_name_gzipped, 'rb') as f_in, ...:   # local file was never written → FileNotFoundError
```

`download_file_from_s3` swallows `ClientError` (missing object, access denied, etc.) and returns `False` **without writing the local file**. Execution then hit `gzip.open()` on a nonexistent file → unhandled `FileNotFoundError` → HTTP 500.

This is guaranteed to happen whenever a DB record exists without its S3 object — notably after `destroy()`, which deletes the S3 file but intentionally keeps the DB row. `get_model` still returns that row (metadata/listings show it), the client requests the download, and the file is gone.

## Fix

Check the download result and raise a clean **404** with a descriptive message instead of letting `gzip.open` crash:

```python
downloaded = download_file_from_s3(file_name_gzipped, bucketname="agr-literature", s3_file_location=object_key)
if not downloaded or not os.path.exists(file_name_gzipped):
    raise HTTPException(status_code=404, detail="Model file not found in storage for ...")
```

## Testing

- Added `test_download_model_missing_s3_file_returns_404`, a CRUD-level regression test that reproduces the exact condition (S3 download returns `False`, no local file) and asserts a 404 is raised. Confirmed it fails before the fix (`FileNotFoundError` from `gzip.open`) and passes after.
- `flake8` clean; `mypy --config-file mypy.config` clean on the changed file.

> Note: the CRUD-level test is used because the HTTP-layer tests in this file require live Cognito admin secrets, which run in CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)