### PR TITLE
SCRUM-5781: add ABC-embedding recipe columns to ml_model

### DIFF
--- a/agr_literature_service/api/crud/ml_model_crud.py
+++ b/agr_literature_service/api/crud/ml_model_crud.py
@@ -79,7 +79,13 @@ def upload(db: Session, request: MLModelSchemaPost, file: UploadFile):
         data_novelty=request.data_novelty,
         negated=request.negated,
         file_classes=request.file_classes,
-        description=request.description
+        description=request.description,
+        embedding_profile=request.embedding_profile,
+        embedding_version=request.embedding_version,
+        embedding_model=request.embedding_model,
+        embedding_dim=request.embedding_dim,
+        embedding_pooling=request.embedding_pooling,
+        use_bow_features=request.use_bow_features
     )
     try:
         db.add(new_model)
@@ -175,6 +181,12 @@ def get_model_schema_from_orm(model: MLModel):
         "negated": model.negated,
         "file_classes": model.file_classes,
         "description": model.description,
+        "embedding_profile": model.embedding_profile,
+        "embedding_version": model.embedding_version,
+        "embedding_model": model.embedding_model,
+        "embedding_dim": model.embedding_dim,
+        "embedding_pooling": model.embedding_pooling,
+        "use_bow_features": model.use_bow_features,
         "date_created": model.date_created,
         "date_updated": model.date_updated,
         "created_by": model.created_by,

--- a/agr_literature_service/api/crud/ml_model_crud.py
+++ b/agr_literature_service/api/crud/ml_model_crud.py
@@ -81,11 +81,7 @@ def upload(db: Session, request: MLModelSchemaPost, file: UploadFile):
         file_classes=request.file_classes,
         description=request.description,
         embedding_profile=request.embedding_profile,
-        embedding_version=request.embedding_version,
-        embedding_model=request.embedding_model,
-        embedding_dim=request.embedding_dim,
-        embedding_pooling=request.embedding_pooling,
-        use_bow_features=request.use_bow_features
+        embedding_version=request.embedding_version
     )
     try:
         db.add(new_model)
@@ -183,10 +179,6 @@ def get_model_schema_from_orm(model: MLModel):
         "description": model.description,
         "embedding_profile": model.embedding_profile,
         "embedding_version": model.embedding_version,
-        "embedding_model": model.embedding_model,
-        "embedding_dim": model.embedding_dim,
-        "embedding_pooling": model.embedding_pooling,
-        "use_bow_features": model.use_bow_features,
         "date_created": model.date_created,
         "date_updated": model.date_updated,
         "created_by": model.created_by,

--- a/agr_literature_service/api/models/ml_model_model.py
+++ b/agr_literature_service/api/models/ml_model_model.py
@@ -101,6 +101,23 @@ class MLModel(AuditedModel, Base):
         nullable=True
     )
 
+    # ABC-embedding recipe (SCRUM-5781). NULL for legacy BioWordVec models. When
+    # embedding_profile is set, the model was trained on the ABC's precomputed
+    # embeddings; the classifier reads these to rebuild the matching feature vector
+    # (which profile/version to fetch, how it was pooled, and whether the hashed
+    # bag-of-words block was concatenated).
+    embedding_profile = Column(String, index=True, nullable=True)
+
+    embedding_version = Column(Integer, nullable=True)
+
+    embedding_model = Column(String, nullable=True)
+
+    embedding_dim = Column(Integer, nullable=True)
+
+    embedding_pooling = Column(String, nullable=True)
+
+    use_bow_features = Column(Boolean, nullable=True)
+
     __table_args__ = (
         UniqueConstraint('task_type', 'mod_id', 'topic', 'version_num', name='uq_ml_model_task_mod_topic_version'),
     )

--- a/agr_literature_service/api/models/ml_model_model.py
+++ b/agr_literature_service/api/models/ml_model_model.py
@@ -103,20 +103,12 @@ class MLModel(AuditedModel, Base):
 
     # ABC-embedding recipe (SCRUM-5781). NULL for legacy BioWordVec models. When
     # embedding_profile is set, the model was trained on the ABC's precomputed
-    # embeddings; the classifier reads these to rebuild the matching feature vector
-    # (which profile/version to fetch, how it was pooled, and whether the hashed
-    # bag-of-words block was concatenated).
+    # embeddings: (profile, version) is what the classifier needs to select which
+    # stored embedding to fetch for a reference. Everything else (model, dim,
+    # pooling, BoW) is a fixed convention read from the parquet or hard-coded.
     embedding_profile = Column(String, index=True, nullable=True)
 
     embedding_version = Column(Integer, nullable=True)
-
-    embedding_model = Column(String, nullable=True)
-
-    embedding_dim = Column(Integer, nullable=True)
-
-    embedding_pooling = Column(String, nullable=True)
-
-    use_bow_features = Column(Boolean, nullable=True)
 
     __table_args__ = (
         UniqueConstraint('task_type', 'mod_id', 'topic', 'version_num', name='uq_ml_model_task_mod_topic_version'),

--- a/agr_literature_service/api/routers/ml_model_router.py
+++ b/agr_literature_service/api/routers/ml_model_router.py
@@ -51,7 +51,13 @@ def upload_model(
         data_novelty: str = None,
         species: str = None,
         file_classes: str = None,
-        description: str = None):
+        description: str = None,
+        embedding_profile: str = None,
+        embedding_version: int = None,
+        embedding_model: str = None,
+        embedding_dim: int = None,
+        embedding_pooling: str = None,
+        use_bow_features: bool = None):
     model_data = None
     if task_type and mod_abbreviation:
         file_classes_list = [c.strip() for c in file_classes.split(",") if c.strip()] if file_classes else None
@@ -72,7 +78,13 @@ def upload_model(
             "data_novelty": data_novelty,
             "species": species,
             "file_classes": file_classes_list,
-            "description": description
+            "description": description,
+            "embedding_profile": embedding_profile,
+            "embedding_version": embedding_version,
+            "embedding_model": embedding_model,
+            "embedding_dim": embedding_dim,
+            "embedding_pooling": embedding_pooling,
+            "use_bow_features": use_bow_features
         }
     elif model_data_file:
         try:
@@ -100,7 +112,13 @@ def upload_model(
         data_novelty=model_data["data_novelty"],
         species=model_data["species"],
         file_classes=model_data.get("file_classes"),
-        description=model_data.get("description")
+        description=model_data.get("description"),
+        embedding_profile=model_data.get("embedding_profile"),
+        embedding_version=model_data.get("embedding_version"),
+        embedding_model=model_data.get("embedding_model"),
+        embedding_dim=model_data.get("embedding_dim"),
+        embedding_pooling=model_data.get("embedding_pooling"),
+        use_bow_features=model_data.get("use_bow_features")
     )
     set_global_user_from_cognito(db, user)
     return ml_model_crud.upload(db, request, file)

--- a/agr_literature_service/api/routers/ml_model_router.py
+++ b/agr_literature_service/api/routers/ml_model_router.py
@@ -53,11 +53,7 @@ def upload_model(
         file_classes: str = None,
         description: str = None,
         embedding_profile: str = None,
-        embedding_version: int = None,
-        embedding_model: str = None,
-        embedding_dim: int = None,
-        embedding_pooling: str = None,
-        use_bow_features: bool = None):
+        embedding_version: int = None):
     model_data = None
     if task_type and mod_abbreviation:
         file_classes_list = [c.strip() for c in file_classes.split(",") if c.strip()] if file_classes else None
@@ -80,11 +76,7 @@ def upload_model(
             "file_classes": file_classes_list,
             "description": description,
             "embedding_profile": embedding_profile,
-            "embedding_version": embedding_version,
-            "embedding_model": embedding_model,
-            "embedding_dim": embedding_dim,
-            "embedding_pooling": embedding_pooling,
-            "use_bow_features": use_bow_features
+            "embedding_version": embedding_version
         }
     elif model_data_file:
         try:
@@ -114,11 +106,7 @@ def upload_model(
         file_classes=model_data.get("file_classes"),
         description=model_data.get("description"),
         embedding_profile=model_data.get("embedding_profile"),
-        embedding_version=model_data.get("embedding_version"),
-        embedding_model=model_data.get("embedding_model"),
-        embedding_dim=model_data.get("embedding_dim"),
-        embedding_pooling=model_data.get("embedding_pooling"),
-        use_bow_features=model_data.get("use_bow_features")
+        embedding_version=model_data.get("embedding_version")
     )
     set_global_user_from_cognito(db, user)
     return ml_model_crud.upload(db, request, file)

--- a/agr_literature_service/api/schemas/ml_model_schemas.py
+++ b/agr_literature_service/api/schemas/ml_model_schemas.py
@@ -28,6 +28,13 @@ class MLModelSchemaBase(BaseModel):
     species: Optional[str] = None
     file_classes: Optional[List[str]] = None
     description: Optional[str] = None
+    # ABC-embedding recipe (SCRUM-5781); NULL for legacy BioWordVec models.
+    embedding_profile: Optional[str] = None
+    embedding_version: Optional[int] = None
+    embedding_model: Optional[str] = None
+    embedding_dim: Optional[int] = None
+    embedding_pooling: Optional[str] = None
+    use_bow_features: Optional[bool] = None
 
 
 class MLModelSchemaPost(MLModelSchemaBase):

--- a/agr_literature_service/api/schemas/ml_model_schemas.py
+++ b/agr_literature_service/api/schemas/ml_model_schemas.py
@@ -31,10 +31,6 @@ class MLModelSchemaBase(BaseModel):
     # ABC-embedding recipe (SCRUM-5781); NULL for legacy BioWordVec models.
     embedding_profile: Optional[str] = None
     embedding_version: Optional[int] = None
-    embedding_model: Optional[str] = None
-    embedding_dim: Optional[int] = None
-    embedding_pooling: Optional[str] = None
-    use_bow_features: Optional[bool] = None
 
 
 class MLModelSchemaPost(MLModelSchemaBase):

--- a/alembic/versions/20260717_32089edb2830_embedding_profile.py
+++ b/alembic/versions/20260717_32089edb2830_embedding_profile.py
@@ -1,0 +1,29 @@
+"""embedding_profile
+
+Revision ID: 32089edb2830
+Revises: c8d1f2a3b4e5
+Create Date: 2026-07-17 17:01:46.892112
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '32089edb2830'
+down_revision = 'c8d1f2a3b4e5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # SCRUM-5781: ABC-embedding recipe columns on ml_model (NULL for legacy models).
+    op.add_column('ml_model', sa.Column('embedding_profile', sa.String(), nullable=True))
+    op.add_column('ml_model', sa.Column('embedding_version', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_ml_model_embedding_profile'), 'ml_model', ['embedding_profile'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_ml_model_embedding_profile'), table_name='ml_model')
+    op.drop_column('ml_model', 'embedding_version')
+    op.drop_column('ml_model', 'embedding_profile')


### PR DESCRIPTION
## Summary
Supports SCRUM-5781 (retrain FB classifiers on the ABC's precomputed embeddings). Adds two nullable columns to `ml_model` so a model self-describes whether it was trained on ABC embeddings and which stored embedding to fetch:

- `embedding_profile` (String, indexed) — the ABC embedding profile; **NULL for legacy BioWordVec models**.
- `embedding_version` (Integer).

That `(profile, version)` pair is all the classifier needs *before* fetching, to select which stored embedding parquet to pull for a reference. Pooling (L2 chunk-mean) and the BoW block are fixed conventions for every ABC-embedding model (hard-coded in the consumer, not stored), and `embedding_model`/`embedding_dim` are read from the parquet's own recipe metadata — so they are intentionally not columns.

## Changes
- `ml_model` model: the two nullable columns.
- Wired through the create schema (`MLModelSchemaBase`), the `/ml_model/upload` endpoint (Form params), and the crud (persist + return in `get_model_schema_from_orm`).
- Alembic migration (hand-trimmed to only these three ops — the autogenerate had picked up unrelated drift on other tables, which was removed).

## Consumer
The consuming side lives in `agr_automated_information_extraction` (branch `SCRUM-5781`): the trainer stamps `(profile, version)` at upload; the classifier routes per model on `embedding_profile` being set, and falls back to the unchanged BioWordVec path when NULL. Backward-compatible — legacy models leave the columns NULL.

## Deploy note
Deploy this (migration + endpoint) to stage before any ABC-embedding model is promoted to `production=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)