### PR TITLE
fix(crud): harden ml_model download + fix TET NULL-PK & MCA savepoint warnings

### DIFF
--- a/agr_literature_service/api/crud/ml_model_crud.py
+++ b/agr_literature_service/api/crud/ml_model_crud.py
@@ -1,9 +1,12 @@
 import gzip
+import logging
 import os
 import shutil
+import tempfile
 from typing import Optional
 
 import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 from fastapi import UploadFile, HTTPException
 from sqlalchemy.orm import Session, joinedload
 from starlette.background import BackgroundTask
@@ -21,6 +24,7 @@ from agr_literature_service.api.schemas.ml_model_schemas import (
 from agr_literature_service.lit_processing.utils.s3_utils import download_file_from_s3
 
 s3_client = boto3.client('s3')
+logger = logging.getLogger(__name__)
 
 
 def get_ml_model_s3_folder(task_type: str, mod_abbreviation: str, topic: str):
@@ -124,6 +128,11 @@ def cleanup(file_path):
     os.remove(file_path)
 
 
+def cleanup_dir(dir_path):
+    """Remove a temporary working directory and its contents; never raises."""
+    shutil.rmtree(dir_path, ignore_errors=True)
+
+
 def get_mod(db: Session, mod_abbreviation: str):
     mod = db.query(ModModel).filter(ModModel.abbreviation == mod_abbreviation).first()
     if not mod:
@@ -222,19 +231,56 @@ def download_model_file(db: Session, task_type: str, mod_abbreviation: str, topi
 
     folder = get_ml_model_s3_folder(task_type, mod_abbreviation, topic)
     object_key = f"{folder}/{str(model.version_num)}.gz"
-    file_name_gzipped = f"{str(model.version_num)}.gz"
-    file_name = f"{str(model.version_num)}.{model.file_extension}"
-    downloaded = download_file_from_s3(file_name_gzipped, bucketname="agr-literature", s3_file_location=object_key)
-    if not downloaded or not os.path.exists(file_name_gzipped):
-        # The DB record exists but the S3 object is missing (e.g. it was removed
-        # via destroy(), which keeps the row). Return a 404 instead of letting
-        # gzip.open raise an unhandled FileNotFoundError (HTTP 500).
-        raise HTTPException(
-            status_code=404,
-            detail=f"Model file not found in storage for task_type='{task_type}', "
-                   f"mod='{mod_abbreviation}', topic='{topic}', version={model.version_num}")
-    with gzip.open(file_name_gzipped, 'rb') as f_in, open(file_name, 'wb') as f_out:
-        shutil.copyfileobj(f_in, f_out)
-    os.remove(file_name_gzipped)
-    return FileResponse(path=file_name, filename=file_name, media_type="application/octet-stream",
-                        background=BackgroundTask(cleanup, file_name))
+
+    # Use a unique per-request working directory. Previously the gzipped download
+    # and its decompressed output used bare relative filenames derived only from
+    # the version number ("<version>.gz" / "<version>.<ext>"), so concurrent
+    # downloads of the same model (e.g. the parallel entity-extraction pipeline)
+    # collided: one request's os.remove / cleanup deleted the file another was
+    # still reading, surfacing as an unhandled 500. A per-request tmp dir isolates them.
+    work_dir = tempfile.mkdtemp(prefix="ml_model_dl_")
+    file_name_gzipped = os.path.join(work_dir, f"{model.version_num}.gz")
+    file_name = os.path.join(work_dir, f"{model.version_num}.{model.file_extension}")
+    try:
+        try:
+            downloaded = download_file_from_s3(
+                file_name_gzipped, bucketname="agr-literature", s3_file_location=object_key)
+        except (BotoCoreError, ClientError) as exc:
+            # Storage errors that download_file_from_s3 does not swallow
+            # (missing credentials, connectivity/timeout, etc.).
+            logger.error("S3 download error for %s: %s", object_key, exc)
+            raise HTTPException(
+                status_code=502,
+                detail=f"Error retrieving model file from storage for task_type='{task_type}', "
+                       f"mod='{mod_abbreviation}', topic='{topic}', version={model.version_num}")
+
+        if not downloaded or not os.path.exists(file_name_gzipped):
+            # The DB record exists but the S3 object is missing (e.g. it was removed
+            # via destroy(), which keeps the row). Return a 404 instead of letting
+            # gzip.open raise an unhandled FileNotFoundError (HTTP 500).
+            raise HTTPException(
+                status_code=404,
+                detail=f"Model file not found in storage for task_type='{task_type}', "
+                       f"mod='{mod_abbreviation}', topic='{topic}', version={model.version_num}")
+
+        try:
+            with gzip.open(file_name_gzipped, 'rb') as f_in, open(file_name, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        except (OSError, EOFError) as exc:
+            # Object exists but is truncated / not valid gzip (gzip.BadGzipFile is an
+            # OSError subclass). Surface a clear error instead of a raw 500.
+            logger.error("Failed to decompress model file %s: %s", object_key, exc)
+            raise HTTPException(
+                status_code=502,
+                detail=f"Stored model file is corrupt or not gzip for task_type='{task_type}', "
+                       f"mod='{mod_abbreviation}', topic='{topic}', version={model.version_num}")
+    except Exception:
+        # Any failure before the FileResponse is handed off: clean up now. On success
+        # the tmp dir must survive until the response is streamed, so it is removed by
+        # the background task below instead.
+        shutil.rmtree(work_dir, ignore_errors=True)
+        raise
+
+    return FileResponse(path=file_name, filename=os.path.basename(file_name),
+                        media_type="application/octet-stream",
+                        background=BackgroundTask(cleanup_dir, work_dir))

--- a/agr_literature_service/api/crud/mod_corpus_association_crud.py
+++ b/agr_literature_service/api/crud/mod_corpus_association_crud.py
@@ -316,16 +316,18 @@ def batch_update_corpus(db: Session, mod_corpus_association_ids: List[int],
         reference_curie = mca.reference.curie if mca.reference else None
         mod_abbreviation = mca.mod.abbreviation if mca.mod else None
 
-        # Use savepoint for each item to enable individual rollback on failure
-        nested = None
+        # NOTE: the workflow/TET/xref helpers called below each issue their own
+        # db.commit() on the session, which ends the outer transaction. A per-item
+        # SAVEPOINT therefore cannot isolate an item (the first inner commit detaches
+        # it, and nested.commit()/rollback() then warn "nested transaction already
+        # deassociated from connection"). We instead commit per item and roll back
+        # only the uncommitted tail on failure.
         try:
-            nested = db.begin_nested()  # SAVEPOINT
-
             # Setting corpus to False (moving OUT)
             if corpus is False and mca.corpus is True:
                 has_manual_tags = has_manual_tet(db, str(mca.reference_id), mod_abbreviation)
                 if has_manual_tags and not force_out:
-                    nested.rollback()
+                    db.rollback()
                     results.append(ModCorpusAssociationBatchResultItem(
                         mod_corpus_association_id=mca_id,
                         success=False,
@@ -363,7 +365,7 @@ def batch_update_corpus(db: Session, mod_corpus_association_ids: List[int],
                 mca.mod_corpus_sort_source = ModCorpusSortSourceType.Manual_creation
             db.add(mca)
 
-            nested.commit()  # Commit savepoint
+            db.commit()  # Persist this item
             results.append(ModCorpusAssociationBatchResultItem(
                 mod_corpus_association_id=mca_id,
                 success=True,
@@ -372,8 +374,7 @@ def batch_update_corpus(db: Session, mod_corpus_association_ids: List[int],
             ))
 
         except Exception as e:
-            if nested is not None:
-                nested.rollback()  # Rollback savepoint on failure
+            db.rollback()  # Drop this item's uncommitted changes
             results.append(ModCorpusAssociationBatchResultItem(
                 mod_corpus_association_id=mca_id,
                 success=False,
@@ -381,7 +382,7 @@ def batch_update_corpus(db: Session, mod_corpus_association_ids: List[int],
                 reference_curie=reference_curie
             ))
 
-    # Commit all successful changes
+    # Safety net: commit any residual pending state (items are already committed above)
     db.commit()
 
     return results

--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -454,8 +454,13 @@ def show_tag(db: Session, topic_entity_tag_id: int):      # noqa: C901
     if topic_entity_tag.validated_by:
         add_list_of_users_who_validated_tag(topic_entity_tag, topic_entity_tag_data)
         add_list_of_validating_tag_ids(topic_entity_tag, topic_entity_tag_data)
-    if 'ml_model_id' in topic_entity_tag_data:
-        ml = db.query(MLModel).get(topic_entity_tag_data["ml_model_id"])
+    # Only look up the model when an ml_model_id is actually set: the key is
+    # often present with a None value (TETs without a model), and .get(None)
+    # emits SQLAlchemy's "fully NULL primary key identity" warning (and may
+    # raise in a future release). Use the 2.0-style Session.get().
+    ml_model_id = topic_entity_tag_data.get("ml_model_id")
+    if ml_model_id is not None:
+        ml = db.get(MLModel, ml_model_id)
         if ml:
             topic_entity_tag_data["ml_model_version"] = ml.version_num
 

--- a/tests/api/test_ml_model.py
+++ b/tests/api/test_ml_model.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 
 import pytest
+from botocore.exceptions import ClientError
 from fastapi import status, HTTPException
 from starlette.testclient import TestClient
 
@@ -269,3 +270,63 @@ def test_download_model_missing_s3_file_returns_404(db, monkeypatch):  # noqa
         ml_model_crud.download_model_file(
             db, "biocuration_entity_extraction", "MLT", "ATP:0000110", "99")
     assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_download_model_corrupt_gzip_returns_502(db, monkeypatch):  # noqa
+    # The S3 object exists but is not valid gzip (truncated / wrong content).
+    # download_model_file must surface a 502 rather than let gzip.open raise an
+    # unhandled BadGzipFile (HTTP 500).
+    mod = ModModel(abbreviation="MLT2", short_name="MLT2", full_name="ML test mod 2")
+    db.add(mod)
+    db.commit()
+    model = MLModel(mod_id=mod.mod_id,
+                    version_num=42,
+                    topic="ATP:0000110",
+                    production=False,
+                    task_type="biocuration_entity_extraction",
+                    file_extension="joblib",
+                    model_type="no_file")
+    db.add(model)
+    db.commit()
+
+    def fake_download(filepath, *args, **kwargs):
+        # Simulate a successful download of a non-gzip payload.
+        with open(filepath, "wb") as fh:
+            fh.write(b"this is not gzip content")
+        return True
+
+    monkeypatch.setattr(
+        "agr_literature_service.api.crud.ml_model_crud.download_file_from_s3", fake_download)
+
+    with pytest.raises(HTTPException) as exc_info:
+        ml_model_crud.download_model_file(
+            db, "biocuration_entity_extraction", "MLT2", "ATP:0000110", "42")
+    assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY
+
+
+def test_download_model_s3_error_returns_502(db, monkeypatch):  # noqa
+    # download_file_from_s3 only swallows ClientError; if the storage call raises
+    # (credentials/connectivity/other), download_model_file must return 502, not 500.
+    mod = ModModel(abbreviation="MLT3", short_name="MLT3", full_name="ML test mod 3")
+    db.add(mod)
+    db.commit()
+    model = MLModel(mod_id=mod.mod_id,
+                    version_num=7,
+                    topic="ATP:0000110",
+                    production=False,
+                    task_type="biocuration_entity_extraction",
+                    file_extension="joblib",
+                    model_type="no_file")
+    db.add(model)
+    db.commit()
+
+    def raise_client_error(*args, **kwargs):
+        raise ClientError({"Error": {"Code": "500", "Message": "boom"}}, "GetObject")
+
+    monkeypatch.setattr(
+        "agr_literature_service.api.crud.ml_model_crud.download_file_from_s3", raise_client_error)
+
+    with pytest.raises(HTTPException) as exc_info:
+        ml_model_crud.download_model_file(
+            db, "biocuration_entity_extraction", "MLT3", "ATP:0000110", "7")
+    assert exc_info.value.status_code == status.HTTP_502_BAD_GATEWAY


### PR DESCRIPTION
## Summary

Fixes three sources of production `ERR` log noise (and the real bugs behind them) in the
CRUD layer, surfaced by the entity-extraction pipeline and prod logs.

## 1. `ml_model/download` returned unhandled 500s (`ml_model_crud.py`)

`download_model_file` could return a raw 500 in several cases. Hardened:

- **Concurrency race (likely cause of the pipeline 500s):** it wrote the gzipped download
  and its decompressed output to **bare relative filenames** derived only from the version
  number (`<version>.gz` / `<version>.<ext>`). Parallel downloads of the same model collided —
  one request's `os.remove`/cleanup deleted the file another was still reading. Now uses a
  unique per-request `tempfile.mkdtemp()` directory.
- **S3 errors → 502:** exceptions `download_file_from_s3` doesn't swallow (`BotoCoreError`/
  `ClientError` — credentials, connectivity) now return 502 instead of 500.
- **Corrupt / non-gzip object → 502:** `gzip.BadGzipFile`/`OSError`/`EOFError` during
  decompression now return 502 instead of 500.
- Temp dir is cleaned up on every error path; on success it's removed by the response
  background task. Missing S3 object still returns **404** (unchanged).
- Added tests for the corrupt-gzip and S3-error 502 paths (local, via monkeypatch — no AWS needed).

## 2. `topic_entity_tag_crud.show_tag` NULL primary-key warning

`if 'ml_model_id' in topic_entity_tag_data:` guarded on **key presence**, but the value is
often `None` (TETs without a model), so `db.query(MLModel).get(None)` emitted SQLAlchemy's
*"fully NULL primary key identity cannot load any object"* warning. Now guards on the value
being non-None and uses the 2.0-style `db.get(MLModel, id)`.

## 3. `mod_corpus_association.batch_update_corpus` broken savepoint

The batch loop opened a per-item `db.begin_nested()` SAVEPOINT and closed it with
`nested.commit()`, but the workflow/TET/xref helpers it calls each issue their own
`db.commit()`, which ends the outer transaction and detaches the savepoint — producing
*"nested transaction already deassociated from connection"* and making the savepoint a no-op
(no real per-item isolation). Replaced with a per-item `db.commit()` / `db.rollback()`,
matching what the helpers already do, and documented why.

## Testing

- `flake8` + `mypy` clean on all changed files.
- 3 `ml_model` download tests pass on PostgreSQL 17 (existing 404 + two new 502 tests).
- **Not runtime-verified:** the `show_tag` and `batch_update_corpus` paths are Cognito/network-gated,
  so those changes (behavior-preserving) are covered by lint/type + reasoning, and will be
  exercised by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
