### PR TITLE
test(debezium): add real-time deletion propagation tests (SCRUM-6337)

### DIFF
--- a/tests/test_debezium_integration.py
+++ b/tests/test_debezium_integration.py
@@ -376,6 +376,187 @@ class TestDebeziumIntegration:
 
     @pytest.mark.debezium
     @pytest.mark.webtest
+    def test_real_time_author_delete_sync(self, db, mock_data_factory, elasticsearch_config):  # noqa
+        """Deleting a joined-table row must be reflected in the reference's ES document.
+
+        Creates a reference with two authors, waits for both to appear in the private
+        index, then deletes one author and asserts it is removed from the reference's
+        ``authors`` array while the other author remains.
+
+        This exercises the joined-table delete path (``author`` -> ``GROUP BY
+        reference_id`` aggregate). If a row deletion is not propagated, the deleted
+        author lingers in the document and this test fails. See SCRUM-6337.
+        """
+        import time
+
+        test_curie = "AGRKB:101000998"
+        kept_orcid = "0000-0000-0000-9981"
+        deleted_orcid = "0000-0000-0000-9982"
+
+        # Build a reference with two distinct authors and a MOD corpus association
+        resource = mock_data_factory.create_resource(db, 998)
+        citation = mock_data_factory.create_citation(db, 998)
+        reference = mock_data_factory.create_reference(db, 998, citation, resource)
+        mock_data_factory.create_author(db, reference, 9981)
+        author_to_delete = mock_data_factory.create_author(db, reference, 9982)
+
+        # Reuse the WB MOD created by populate_test_db.py (abbreviation is unique)
+        mod = db.query(ModModel).filter(ModModel.abbreviation == "WB").first()
+        if mod is None:
+            mod = mock_data_factory.create_mod(db, 0)
+        mock_data_factory.create_mod_corpus_association(db, reference, mod, True)
+        db.commit()
+
+        es_url = f"http://{elasticsearch_config['host']}:{elasticsearch_config['port']}"
+        index = elasticsearch_config['private_index']
+
+        def fetch_authors():
+            """Return the authors array of the reference doc, or None if not indexed yet."""
+            resp = requests.post(
+                f"{es_url}/{index}/_search",
+                json={"query": {"term": {"curie.keyword": test_curie}}, "size": 1}
+            )
+            if resp.status_code != 200:
+                return None
+            hits = resp.json()['hits']['hits']
+            if not hits:
+                return None
+            return hits[0]['_source'].get('authors') or []
+
+        def orcids(authors):
+            return {a.get('orcid') for a in authors if isinstance(a, dict)}
+
+        max_wait_time = 30  # seconds
+        poll_interval = 2
+
+        # Wait until both authors have been synced to the private index
+        both_present = False
+        elapsed_time = 0
+        while elapsed_time < max_wait_time and not both_present:
+            time.sleep(poll_interval)
+            elapsed_time += poll_interval
+            authors = fetch_authors()
+            if authors is not None and {kept_orcid, deleted_orcid}.issubset(orcids(authors)):
+                both_present = True
+
+        assert both_present, (
+            f"Both authors of {test_curie} should be present in the private index "
+            f"after {max_wait_time}s before testing deletion"
+        )
+
+        # Delete one author -> Debezium should emit a tombstone for that author row
+        db.delete(author_to_delete)
+        db.commit()
+
+        # Wait for the deleted author to disappear from the reference document
+        deleted_gone = False
+        current_authors = None
+        elapsed_time = 0
+        while elapsed_time < max_wait_time and not deleted_gone:
+            time.sleep(poll_interval)
+            elapsed_time += poll_interval
+            current_authors = fetch_authors()
+            if current_authors is not None and deleted_orcid not in orcids(current_authors):
+                deleted_gone = True
+
+        assert deleted_gone, (
+            f"Deleted author {deleted_orcid} still present in {test_curie} document "
+            f"after {max_wait_time}s -- row deletion was not propagated to the index"
+        )
+        assert kept_orcid in orcids(current_authors), (
+            f"Author {kept_orcid} should remain in {test_curie} document after "
+            f"deleting the other author"
+        )
+
+    @pytest.mark.debezium
+    @pytest.mark.webtest
+    def test_real_time_reference_delete_sync(self, db, mock_data_factory, elasticsearch_config):  # noqa
+        """Deleting an entire reference must remove its document from both indexes.
+
+        Creates a reference (with an author, a cross-reference and a MOD corpus
+        association), waits for it to appear in the private and public indexes, then
+        deletes the reference and asserts the document is removed from both indexes.
+
+        If the deletion is not propagated, the stale document lingers and this test
+        fails. See SCRUM-6337.
+        """
+        import time
+
+        test_curie = "AGRKB:101000997"
+
+        resource = mock_data_factory.create_resource(db, 997)
+        citation = mock_data_factory.create_citation(db, 997)
+        reference = mock_data_factory.create_reference(db, 997, citation, resource)
+        mock_data_factory.create_author(db, reference, 997)
+        mock_data_factory.create_cross_reference(db, reference, 997, False)
+
+        # Reuse the WB MOD created by populate_test_db.py (abbreviation is unique)
+        mod = db.query(ModModel).filter(ModModel.abbreviation == "WB").first()
+        if mod is None:
+            mod = mock_data_factory.create_mod(db, 0)
+        mock_data_factory.create_mod_corpus_association(db, reference, mod, True)
+        db.commit()
+
+        es_url = f"http://{elasticsearch_config['host']}:{elasticsearch_config['port']}"
+        private_index = elasticsearch_config['private_index']
+        public_index = elasticsearch_config['public_index']
+
+        def count_in(index):
+            """Return the number of docs matching the curie, or None on a failed request."""
+            resp = requests.post(
+                f"{es_url}/{index}/_search",
+                json={"query": {"term": {"curie.keyword": test_curie}}, "size": 1}
+            )
+            if resp.status_code != 200:
+                return None
+            return resp.json()['hits']['total']['value']
+
+        max_wait_time = 30  # seconds
+        poll_interval = 2
+
+        # Wait until the reference is indexed in both the private and public indexes
+        present = False
+        elapsed_time = 0
+        while elapsed_time < max_wait_time and not present:
+            time.sleep(poll_interval)
+            elapsed_time += poll_interval
+            if count_in(private_index) and count_in(public_index):
+                present = True
+
+        assert present, (
+            f"{test_curie} should be indexed in both the private and public indexes "
+            f"after {max_wait_time}s before testing deletion"
+        )
+
+        # Delete the reference (ondelete=CASCADE removes author/xref/mod_corpus rows).
+        # Re-fetch to operate on a managed instance, mirroring reference_crud.destroy.
+        ref = db.query(ReferenceModel).filter(ReferenceModel.curie == test_curie).one()
+        db.delete(ref)
+        db.commit()
+
+        # Wait for the reference document to be removed from both indexes
+        private_gone = False
+        public_gone = False
+        elapsed_time = 0
+        while elapsed_time < max_wait_time and not (private_gone and public_gone):
+            time.sleep(poll_interval)
+            elapsed_time += poll_interval
+            if not private_gone and count_in(private_index) == 0:
+                private_gone = True
+            if not public_gone and count_in(public_index) == 0:
+                public_gone = True
+
+        assert private_gone, (
+            f"{test_curie} still present in the private index after {max_wait_time}s "
+            f"-- reference deletion was not propagated to the index"
+        )
+        assert public_gone, (
+            f"{test_curie} still present in the public index after {max_wait_time}s "
+            f"-- reference deletion was not propagated to the index"
+        )
+
+    @pytest.mark.debezium
+    @pytest.mark.webtest
     def test_elasticsearch_indexes_exist(self, elasticsearch_config):
         """Test that both public and private Elasticsearch indexes exist."""
         es_url = f"http://{elasticsearch_config['host']}:{elasticsearch_config['port']}"


### PR DESCRIPTION
## Summary

Adds two hard-failing integration tests to the Debezium pipeline suite that verify **row deletions propagate** from PostgreSQL through Kafka/ksqlDB to Elasticsearch:

- `test_real_time_author_delete_sync` — deletes one of a reference's two authors and asserts it is removed from the reference document's `authors` array while the other remains (the joined-table `GROUP BY reference_id` aggregate delete path).
- `test_real_time_reference_delete_sync` — deletes an entire reference and asserts its document is removed from both the private and public indexes.

Each test asserts the data is present in the index first, then deletes and asserts removal, so a pass reflects genuine tombstone propagation (not data that was never indexed). Both are hard assertions (no `xfail`) and reuse the pre-populated WB MOD to avoid the `abbreviation` unique-constraint collision.

## Why

Deletion propagation was suspected to be broken during the PostgreSQL 17 / Debezium 2.7 upgrade work (SCRUM-6318). These tests exercise deletion behavior **independently of that upgrade**, on the current pipeline, so any regression the upgrade introduces is caught. See [SCRUM-6337](https://agr-jira.atlassian.net/browse/SCRUM-6337).

## Result

Both delete paths propagate correctly on the current (pre-upgrade) pipeline — which also updates SCRUM-6337: the original "deletions never propagate" conclusion does **not** reproduce here. Full `debezium-integration-test` CI run: **11 passed** ([run 30063557381](https://github.com/alliance-genome/agr_literature_service/actions/runs/30063557381)).

The tests are marked `@pytest.mark.debezium @pytest.mark.webtest`, so they run only in the Debezium integration CI job and are excluded from the default unit-test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SCRUM-6337]: https://agr-jira.atlassian.net/browse/SCRUM-6337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ