### PR TITLE
propagate resolved evidence-assertion name to grid entries

### DIFF
--- a/agr_literature_service/api/crud/topic_entity_tag_crud.py
+++ b/agr_literature_service/api/crud/topic_entity_tag_crud.py
@@ -1463,6 +1463,7 @@ def _entry_base(label: str, source_data: Dict[str, Any]) -> Dict[str, Any]:
         "source_label": label,
         "source_description": source_data.get("description"),
         "source_evidence_assertion": source_data.get("source_evidence_assertion"),
+        "source_evidence_assertion_name": source_data.get("source_evidence_assertion_name"),
     }
 
 


### PR DESCRIPTION
Include source_evidence_assertion_name (resolved from the ateam ontology store) on each aggregated grid mini-row so the UI can render the real label instead of relying on a hardcoded curie->label list.