### PR TITLE
fix(pg17): correct terminal handling in containerized client wrappers (SCRUM-6374)

### DIFF
--- a/install_pg17_wrappers.sh
+++ b/install_pg17_wrappers.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Installs PG17 client wrappers backed by the postgres:17 docker image.
+#
+# Why: this box is Amazon Linux 2 (EL7). There is no native PG17 client for it
+# (no amazon-linux-extras postgres topic; PGDG has no rhel-7 build for 17), and
+# the RDS servers are now PG17 -- the host's PG13 pg_dump can no longer dump a
+# v17 server. These wrappers put pg_dump/pg_restore/psql/... in /usr/local/bin
+# (which precedes /usr/bin in PATH), each dispatching to postgres:17-alpine.
+# This fixes sync_data.sh and every other caller with no script edits.
+#
+# Run:      sudo bash ~/install_pg17_wrappers.sh
+# Undo:     sudo rm /usr/local/bin/pg-docker-wrapper \
+#              /usr/local/bin/{pg_dump,pg_restore,psql,pg_dumpall,pg_isready,\
+#              vacuumdb,reindexdb,createdb,dropdb,createuser,dropuser,clusterdb}
+set -eo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "ERROR: run this with sudo:  sudo bash $0" >&2
+    exit 1
+fi
+
+IMAGE="postgres:17-alpine"
+WRAPPER=/usr/local/bin/pg-docker-wrapper
+TOOLS="pg_dump pg_restore psql pg_dumpall pg_isready vacuumdb reindexdb createdb dropdb createuser dropuser clusterdb"
+
+echo "==> writing wrapper: $WRAPPER"
+cat > "$WRAPPER" <<'WRAP'
+#!/bin/bash
+# PG17 client tools backed by the postgres:17 docker image (see installer).
+# Symlinks pg_dump/pg_restore/psql/... point here; basename picks the tool.
+set -eo pipefail
+IMAGE="${PG_DOCKER_IMAGE:-postgres:17-alpine}"
+TOOL="$(basename "$0")"
+
+# forward the PG* env vars that are set (pass-through keeps secrets out of argv)
+env_args=()
+for v in PGPASSWORD PGHOST PGPORT PGUSER PGDATABASE PGSSLMODE PGSSLROOTCERT \
+         PGPASSFILE PGOPTIONS PGCONNECT_TIMEOUT PGCLIENTENCODING; do
+    if [ -n "${!v}" ]; then env_args+=( -e "$v" ); fi
+done
+
+# bind-mount, at identical paths, the dirs a client reads/writes (deduped)
+mount_args=(); declare -A seen
+for d in /tmp "$HOME" "$PWD"; do
+    if [ -n "$d" ] && [ -d "$d" ] && [ -z "${seen[$d]}" ]; then
+        seen[$d]=1; mount_args+=( -v "$d:$d" )
+    fi
+done
+
+# Terminal handling. libpq prompts for passwords on /dev/tty, and falls back to
+# (prompt on stderr, read from stdin) when it cannot open one. A container only has
+# a controlling terminal if docker allocates a pty. Three cases, and each needs
+# something different -- getting this wrong silently eats data or hangs:
+#
+#  1. stdin AND stdout are both terminals -> a genuine interactive session (psql).
+#     Allocate a pty; everything behaves natively.
+#
+#     Do NOT key this on stdin alone. With `pg_dump ... > file` stdin is still the
+#     terminal, so a pty gets allocated, and a pty collapses stdout, stderr and
+#     /dev/tty into one stream: the password prompt lands in the output file (so
+#     the command looks hung) and pty newline translation (LF -> CRLF) silently
+#     corrupts binary -Fc dumps.
+#
+#  2. stdin is NOT a terminal -> it carries data (`pg_restore ... < dump`). libpq's
+#     stdin fallback would read the first line of that data and send it as the
+#     password. Bind-mount the real terminal onto /dev/tty so it prompts there
+#     instead and leaves stdin alone, exactly like the native client.
+#
+#  3. stdin IS a terminal but stdout is redirected (`pg_dump ... > file`) -> do
+#     nothing. libpq's stdin fallback works here: the prompt goes to stderr (still
+#     the terminal) and `docker -i` forwards the typed password to the container's
+#     stdin. Mounting /dev/tty in this case actively BREAKS it, because the docker
+#     client is itself reading that same terminal to forward it and consumes the
+#     keystrokes before the container can read them -- you get a prompt that never
+#     accepts input, then "fe_sendauth: no password supplied".
+#     (Caveat: echo cannot be disabled on a forwarded stdin, so the password is
+#     visible as you type. Use PGPASSWORD or ~/.pgpass to avoid that.)
+tty_args=( -i )
+tty_mount=()
+if [ -t 0 ] && [ -t 1 ]; then
+    tty_args+=( -t )
+elif [ ! -t 0 ]; then
+    #     Resolve the terminal's device path with `tty` reading a dup of the fd.
+    #     Do NOT use `readlink /proc/self/fd/N` here: a `2>/dev/null` guard rewires
+    #     fd 2, and command substitution rewires fd 1, so both resolve to the wrong
+    #     thing (that mistake yields `-v /dev/null:/dev/tty`, which silently makes
+    #     every password prompt read EOF). `tty` only inspects fd 0, which we set.
+    host_tty=""
+    for fd in 2 1 0; do
+        if [ -t "$fd" ]; then
+            host_tty=$(tty <&"$fd" 2>/dev/null || true)
+            break
+        fi
+    done
+    if [ -n "$host_tty" ] && [ -c "$host_tty" ]; then
+        tty_mount=( -v "$host_tty:/dev/tty" )
+    fi
+fi
+
+exec docker run --rm "${tty_args[@]}" "${tty_mount[@]}" \
+    --network host \
+    --user "$(id -u):$(id -g)" \
+    "${env_args[@]}" "${mount_args[@]}" -w "$PWD" \
+    "$IMAGE" "$TOOL" "$@"
+WRAP
+chmod 755 "$WRAPPER"
+
+echo "==> linking tools in /usr/local/bin -> pg-docker-wrapper"
+for t in $TOOLS; do
+    ln -sf pg-docker-wrapper "/usr/local/bin/$t"
+    echo "    $t"
+done
+
+echo "==> ensuring image is present ($IMAGE)"
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "    pulling $IMAGE ..."
+    docker pull "$IMAGE"
+fi
+
+echo "==> verifying as ${SUDO_USER:-root}"
+RUN_AS=(); [ -n "$SUDO_USER" ] && RUN_AS=(sudo -u "$SUDO_USER")
+if "${RUN_AS[@]}" bash -lc 'hash -r; printf "which pg_dump -> "; which pg_dump; pg_dump --version; psql --version'; then
+    echo
+    echo "DONE. pg_dump/psql now run PG17 from docker."
+else
+    echo "WARN: verification command failed -- check docker access for ${SUDO_USER:-root}." >&2
+fi
+echo
+echo "If a shell already used pg_dump, run 'hash -r' in it (or open a new shell),"
+echo "then test:  make sync-data ARGS=\"--list\"   followed by a --db-only run."

--- a/sync_data.sh
+++ b/sync_data.sh
@@ -21,8 +21,19 @@ DEST_PREFIX="develop/"
 # Config file location
 CONFIG_FILE="${HOME}/.agr_sync_config.json"
 
-# Temporary file for database dump
-DUMP_FILE="/tmp/agr_literature_dump_$(date +%Y%m%d_%H%M%S).dump"
+# Temporary target for the database dump. Parallel dumps require directory format
+# (pg_dump -j only works with -Fd), so the target is a directory when JOBS > 1 and a
+# single custom-format file otherwise. Both live under /tmp.
+DUMP_STAMP="$(date +%Y%m%d_%H%M%S)"
+DUMP_FILE="/tmp/agr_literature_dump_${DUMP_STAMP}.dump"
+DUMP_DIR="/tmp/agr_literature_dump_${DUMP_STAMP}.dir"
+
+# Parallel jobs for pg_dump/pg_restore, used by default (a plain `make sync-data`
+# is parallel). Scales with the host but capped at 8: each job opens its own
+# connection, and the source is often a shared or production server. Lower it with
+# `--jobs 2`, or `--jobs 1` for the original serial single-file behaviour.
+DEFAULT_JOBS=$( { nproc 2>/dev/null || echo 2; } | awk '{ j=$1+0; if (j>8) j=8; if (j<1) j=1; print j }' )
+JOBS="$DEFAULT_JOBS"
 
 # Colors for output
 RED='\033[0;31m'
@@ -91,6 +102,14 @@ parse_args() {
                 DELETE_CONNECTION="$2"
                 shift 2
                 ;;
+            --jobs|-j)
+                if [[ ! "$2" =~ ^[0-9]+$ ]] || [[ "$2" -lt 1 ]]; then
+                    print_error "--jobs requires a positive integer (got '${2:-}')"
+                    exit 1
+                fi
+                JOBS="$2"
+                shift 2
+                ;;
             --help|-h)
                 show_help
                 exit 0
@@ -116,12 +135,18 @@ show_help() {
     echo "  --dest <name>          Use saved connection as destination database"
     echo "  --list                 List all saved connections"
     echo "  --delete <name>        Delete a saved connection"
+    echo "  --jobs, -j <n>         Parallel dump/restore jobs (default: ${DEFAULT_JOBS})"
+    echo "                         n > 1 uses directory-format dumps (required by"
+    echo "                         pg_dump -j); n = 1 uses a single custom-format file."
+    echo "                         Each job opens its own connection to the server."
     echo "  --help, -h             Show this help message"
     echo ""
     echo "Examples:"
     echo "  sync_data.sh                                    # Interactive mode"
     echo "  sync_data.sh --db-only                          # Database sync only"
     echo "  sync_data.sh --db-only --source prod --dest dev # Use saved connections"
+    echo "  sync_data.sh --db-only --jobs 8                 # Faster sync, 8 jobs"
+    echo "  sync_data.sh --db-only --jobs 1                 # Serial (old behaviour)"
     echo "  sync_data.sh --list                             # List saved connections"
     echo ""
 }
@@ -381,11 +406,26 @@ sync_database() {
     # Get destination database credentials (using saved connection if provided)
     get_db_credentials "destination" "$DEST_CONNECTION"
 
+    # Parallel dumps need directory format; a single job keeps the original
+    # single-file custom format.
+    if [[ "$JOBS" -gt 1 ]]; then
+        DUMP_TARGET="$DUMP_DIR"
+        DUMP_FORMAT_ARGS=( -Fd -j "$JOBS" )
+        RESTORE_JOB_ARGS=( -j "$JOBS" )
+        DUMP_DESC="directory format, ${JOBS} parallel jobs"
+    else
+        DUMP_TARGET="$DUMP_FILE"
+        DUMP_FORMAT_ARGS=( -Fc )
+        RESTORE_JOB_ARGS=()
+        DUMP_DESC="custom format, single job"
+    fi
+
     echo ""
     echo "=== Database Sync Configuration ==="
     echo "Source:      ${SOURCE_DB_USER}@${SOURCE_DB_HOST}:${SOURCE_DB_PORT}/${SOURCE_DB_NAME}"
     echo "Destination: ${DEST_DB_USER}@${DEST_DB_HOST}:${DEST_DB_PORT}/${DEST_DB_NAME}"
-    echo "Dump file:   ${DUMP_FILE}"
+    echo "Dump target: ${DUMP_TARGET}"
+    echo "Parallelism: ${DUMP_DESC}"
     echo ""
 
     # Check that source and destination are not the same database
@@ -425,18 +465,19 @@ sync_database() {
         -p "$SOURCE_DB_PORT" \
         -U "$SOURCE_DB_USER" \
         -d "$SOURCE_DB_NAME" \
-        -Fc \
+        "${DUMP_FORMAT_ARGS[@]}" \
         --no-owner \
         --no-acl \
         --verbose \
-        -f "$DUMP_FILE"
+        -f "$DUMP_TARGET"
 
-    if [[ ! -f "$DUMP_FILE" ]]; then
+    # -e, not -f: a directory-format dump is a directory, not a regular file
+    if [[ ! -e "$DUMP_TARGET" ]]; then
         print_error "Failed to create database dump!"
         return 1
     fi
 
-    DUMP_SIZE=$(du -h "$DUMP_FILE" | cut -f1)
+    DUMP_SIZE=$(du -sh "$DUMP_TARGET" | cut -f1)
     print_success "Dump created successfully! Size: ${DUMP_SIZE}"
 
     echo ""
@@ -471,10 +512,11 @@ sync_database() {
         -p "$DEST_DB_PORT" \
         -U "$DEST_DB_USER" \
         -d "$DEST_DB_NAME" \
+        "${RESTORE_JOB_ARGS[@]}" \
         --no-owner \
         --no-acl \
         --verbose \
-        "$DUMP_FILE" || RESTORE_EXIT_CODE=$?
+        "$DUMP_TARGET" || RESTORE_EXIT_CODE=$?
 
     if [[ $RESTORE_EXIT_CODE -ne 0 ]]; then
         print_warning "pg_restore exited with code ${RESTORE_EXIT_CODE} (may include warnings)"
@@ -492,15 +534,15 @@ sync_database() {
 
     print_success "Database restore completed!"
 
-    # Cleanup dump file
+    # Cleanup dump (a file for -Fc, a directory for -Fd)
     echo ""
-    read -p "Delete temporary dump file? (yes/no) [yes]: " cleanup
+    read -p "Delete temporary dump? (yes/no) [yes]: " cleanup
     cleanup=${cleanup:-yes}
     if [[ "$cleanup" == "yes" ]]; then
-        rm -f "$DUMP_FILE"
-        echo "Dump file deleted."
+        rm -rf "$DUMP_TARGET"
+        echo "Dump deleted."
     else
-        echo "Dump file kept at: ${DUMP_FILE}"
+        echo "Dump kept at: ${DUMP_TARGET}"
     fi
 
     print_success "=== Database sync complete ==="


### PR DESCRIPTION
## Context

[SCRUM-6374](https://agr-jira.atlassian.net/browse/SCRUM-6374)

The dev EC2 box is Amazon Linux 2 (EL7) and ships a PG13 client, which cannot dump the now-PG17 RDS servers. The PG17 client tools were therefore wrapped to run out of the `postgres:17-alpine` image, with symlinks in `/usr/local/bin`. A container only has a controlling terminal when docker allocates a pty, and that broke interactive password prompts in two different ways.

## Problems

**`pg_dump ... > file`** wrote the password prompt *into the output file* and appeared to hang. The wrapper allocated a pty whenever **stdin** was a terminal — but `pg_dump > file` redirects only stdout, so stdin was still the terminal. A pty collapses stdout, stderr and `/dev/tty` into one stream, which the shell redirect then captured. pty newline translation (LF → CRLF) would also have silently corrupted binary `-Fc` dumps.

**`pg_restore ... < dump`** failed with `password authentication failed`. With no controlling terminal, libpq falls back to reading the password from stdin — so it consumed the archive's first line (the `PGDMP` header) and sent that as the password. It would have failed even with the right password, since the archive was then short a line.

## Fix

Terminal handling is split by which fds are actually available:

| stdin | stdout | mechanism |
|---|---|---|
| tty | tty | allocate a pty (interactive `psql`) |
| data | tty | bind-mount the real terminal onto `/dev/tty`, so libpq prompts there and leaves stdin intact |
| tty | redirected | do nothing — libpq's stdin fallback works here |

That last row matters: mounting `/dev/tty` in that case *actively breaks* it, because the docker client is itself reading the same terminal to forward stdin and consumes the keystrokes before the container can.

## Verification

Driven against a real pty (`pty.fork`) rather than an ssh harness, which confounds the very fds under test:

- `pg_dump -W > file` — prompt on terminal, password delivered, **0 bytes** leaked into the file on auth failure
- `pg_restore -W < dump` — prompt with echo suppressed, custom-format archive read from stdin, data landed (`mod rows=9`, `users rows=1527`)
- interactive `psql` — real pty, prompt and echo suppression normal
- redirected `pg_dump` output is **byte-identical** to `-f` output (435462 bytes both, differing only in the embedded timestamp)
- `pg_dump -Fd -j 4` — parallel directory dump created and read back via `pg_restore --list`

Known caveat, inherent rather than fixable: in the stdin-is-a-tty / stdout-redirected case the password is **visible as you type**, because echo cannot be disabled on a stdin that docker is forwarding. Prefer `PGPASSWORD` or `~/.pgpass` for anything scripted.

## Also: parallelized `sync_data.sh`

Dump and restore now use multiple jobs by default, scaled to the host and capped at 8. Parallel dumps use directory format because `pg_dump -j` requires `-Fd`; `--jobs N` tunes it and `--jobs 1` restores the previous serial single-file behaviour. Cleanup and size reporting handle both shapes.

Note `sync_data.sh` was never affected by the prompt bugs — it sets `PGPASSWORD` and writes with `-f` rather than a shell redirect, so it never prompts and never writes through stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SCRUM-6374]: https://agr-jira.atlassian.net/browse/SCRUM-6374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ